### PR TITLE
feat(ui): add copy button on code blocks

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -110,6 +110,34 @@
     });
   }
 
+  function addCopyButtons(el) {
+    el.querySelectorAll("pre").forEach(function(pre) {
+      if (pre.querySelector(".copy-code-btn")) return;
+      var btn = document.createElement("button");
+      btn.className = "copy-code-btn";
+      btn.innerHTML = iconHtml("clipboard");
+      btn.title = "Copy code";
+      btn.addEventListener("click", function(e) {
+        e.stopPropagation();
+        var code = pre.querySelector("code");
+        var text = code ? code.textContent : pre.textContent;
+        if (!text) return;
+        navigator.clipboard.writeText(text).then(function() {
+          btn.innerHTML = iconHtml("check");
+          btn.classList.add("copied");
+          refreshIcons();
+          setTimeout(function() {
+            btn.innerHTML = iconHtml("clipboard");
+            btn.classList.remove("copied");
+            refreshIcons();
+          }, 2000);
+        });
+      });
+      pre.appendChild(btn);
+      refreshIcons();
+    });
+  }
+
   function escapeHtml(s) {
     return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
   }
@@ -453,6 +481,7 @@
     body.className = "plan-card-body";
     body.innerHTML = renderMarkdown(content);
     highlightCodeBlocks(body);
+    addCopyButtons(body);
 
     header.addEventListener("click", function() {
       el.classList.toggle("collapsed");
@@ -611,6 +640,7 @@
     if (highlightTimer) clearTimeout(highlightTimer);
     highlightTimer = setTimeout(function() {
       highlightCodeBlocks(contentEl);
+      addCopyButtons(contentEl);
     }, 150);
 
     scrollToBottom();
@@ -619,7 +649,10 @@
   function finalizeAssistantBlock() {
     if (currentMsgEl) {
       var contentEl = currentMsgEl.querySelector(".md-content");
-      if (contentEl) highlightCodeBlocks(contentEl);
+      if (contentEl) {
+        highlightCodeBlocks(contentEl);
+        addCopyButtons(contentEl);
+      }
     }
     currentMsgEl = null;
     currentFullText = "";
@@ -753,6 +786,8 @@
     pre.textContent = displayContent;
     resultBlock.appendChild(pre);
     tool.el.appendChild(resultBlock);
+
+    addCopyButtons(resultBlock);
 
     tool.el.querySelector(".tool-header").addEventListener("click", function() {
       resultBlock.classList.toggle("collapsed");

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -289,6 +289,7 @@ html, body {
 }
 
 .md-content pre {
+  position: relative;
   background: var(--code-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -514,6 +515,7 @@ html, body {
 }
 
 .tool-result-block {
+  position: relative;
   margin: 4px 0 8px 0;
   background: var(--code-bg);
   border: 1px solid var(--border);
@@ -1185,6 +1187,49 @@ html, body {
 @keyframes sparkle {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: 0.5; transform: scale(0.85); }
+}
+
+/* --- Copy code button --- */
+.copy-code-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: rgba(255,255,255,0.06);
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+  z-index: 1;
+  padding: 0;
+}
+
+pre:hover .copy-code-btn { opacity: 1; }
+.tool-result-block:hover .copy-code-btn { opacity: 1; }
+
+.copy-code-btn:hover {
+  background: rgba(255,255,255,0.1);
+  color: var(--text);
+}
+
+.copy-code-btn .lucide {
+  width: 14px;
+  height: 14px;
+}
+
+.copy-code-btn.copied {
+  color: var(--success);
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .copy-code-btn { opacity: 1; }
 }
 
 /* --- Mobile responsive --- */


### PR DESCRIPTION
Adds a clipboard icon on every \<pre\> code block (markdown content, plan cards, and tool results) that copies the code to clipboard. Button appears on hover (always visible on touch devices) and shows a checkmark for 2s after copying.