### PR TITLE
feat(server): support multiple concurrent WebSocket clients

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -47,9 +47,8 @@ function createServer(cwd) {
   // --- Multi-session state ---
   let nextLocalId = 1;
   let sessions = new Map();     // localId -> session object
-  let activeSessionId = null;   // currently active local ID
   let slashCommands = null;     // shared across sessions
-  let activeWs = null;
+  let clients = new Set();      // Set<WebSocket> — each ws has ws.activeSessionId
 
   // --- Session persistence ---
   var sessionsDir = path.join(cwd, ".claude-relay", "sessions");
@@ -128,40 +127,57 @@ function createServer(cwd) {
   // Load persisted sessions from disk
   loadSessions();
 
-  function send(obj) {
-    if (activeWs && activeWs.readyState === 1) {
-      activeWs.send(JSON.stringify(obj));
+  function sendToClient(ws, obj) {
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify(obj));
     }
+  }
+
+  function broadcast(obj) {
+    clients.forEach(function(ws) {
+      sendToClient(ws, obj);
+    });
   }
 
   // Send a message and record it in session history for replay on reconnect
   function sendAndRecord(session, obj) {
     session.history.push(obj);
     appendToSessionFile(session, obj);
-    if (session.localId === activeSessionId) {
-      send(obj);
-    }
-  }
-
-  function getActiveSession() {
-    return sessions.get(activeSessionId) || null;
-  }
-
-  function broadcastSessionList() {
-    send({
-      type: "session_list",
-      sessions: [...sessions.values()].map(function(s) {
-        return {
-          id: s.localId,
-          title: s.title || "New Session",
-          active: s.localId === activeSessionId,
-          isProcessing: s.isProcessing,
-        };
-      }),
+    clients.forEach(function(ws) {
+      if (ws.activeSessionId === session.localId) {
+        sendToClient(ws, obj);
+      }
     });
   }
 
-  function createSession() {
+  function getClientSession(ws) {
+    return sessions.get(ws.activeSessionId) || null;
+  }
+
+  function broadcastSessionList() {
+    var sessionArray = [...sessions.values()].map(function(s) {
+      return {
+        id: s.localId,
+        title: s.title || "New Session",
+        isProcessing: s.isProcessing,
+      };
+    });
+    clients.forEach(function(ws) {
+      sendToClient(ws, {
+        type: "session_list",
+        sessions: sessionArray.map(function(s) {
+          return {
+            id: s.id,
+            title: s.title,
+            active: s.id === ws.activeSessionId,
+            isProcessing: s.isProcessing,
+          };
+        }),
+      });
+    });
+  }
+
+  function createSession(ws) {
     var localId = nextLocalId++;
     var session = {
       localId: localId,
@@ -177,27 +193,27 @@ function createServer(cwd) {
     };
     sessions.set(localId, session);
     spawnProcess(session);
-    switchSession(localId);
+    if (ws) switchSession(ws, localId);
     return session;
   }
 
-  function replayHistory(session) {
+  function replayHistory(ws, session) {
     for (var i = 0; i < session.history.length; i++) {
-      send(session.history[i]);
+      sendToClient(ws, session.history[i]);
     }
   }
 
-  function switchSession(localId) {
+  function switchSession(ws, localId) {
     var session = sessions.get(localId);
     if (!session) return;
 
-    activeSessionId = localId;
-    send({ type: "session_switched", id: localId });
+    ws.activeSessionId = localId;
+    sendToClient(ws, { type: "session_switched", id: localId });
     broadcastSessionList();
-    replayHistory(session);
+    replayHistory(ws, session);
 
     if (session.isProcessing) {
-      send({ type: "status", status: "processing" });
+      sendToClient(ws, { type: "status", status: "processing" });
     }
   }
 
@@ -221,7 +237,7 @@ function createServer(cwd) {
     // Cache slash_commands from CLI init message
     if (parsed.type === "system" && parsed.subtype === "init" && parsed.slash_commands) {
       slashCommands = parsed.slash_commands;
-      send({ type: "slash_commands", commands: slashCommands });
+      broadcast({ type: "slash_commands", commands: slashCommands });
     }
 
     if (parsed.type === "stream_event" && parsed.event) {
@@ -345,9 +361,11 @@ function createServer(cwd) {
     session.proc.stderr.on("data", function(chunk) {
       var errText = chunk.toString();
       if (errText.includes("Error") || errText.includes("error")) {
-        if (session.localId === activeSessionId) {
-          send({ type: "stderr", text: errText });
-        }
+        clients.forEach(function(ws) {
+          if (ws.activeSessionId === session.localId) {
+            sendToClient(ws, { type: "stderr", text: errText });
+          }
+        });
       }
     });
 
@@ -426,13 +444,9 @@ function createServer(cwd) {
     session.proc.stdin.write(JSON.stringify(msg) + "\n");
   }
 
-  // --- Spawn initial session only if no persisted sessions ---
+  // --- Ensure at least one session exists ---
   if (sessions.size === 0) {
-    createSession();
-  } else {
-    // Activate the most recent session
-    var lastSession = [...sessions.values()].pop();
-    activeSessionId = lastSession.localId;
+    createSession(null);
   }
 
   // --- HTTP server ---
@@ -455,22 +469,26 @@ function createServer(cwd) {
   var wss = new WebSocketServer({ server: server });
 
   wss.on("connection", function(ws) {
-    activeWs = ws;
+    clients.add(ws);
+
+    // Default to the most recent session
+    var lastSession = [...sessions.values()].pop();
+    ws.activeSessionId = lastSession ? lastSession.localId : null;
 
     // Send cached state
-    send({ type: "info", cwd: cwd, project: project });
+    sendToClient(ws, { type: "info", cwd: cwd, project: project });
     if (slashCommands) {
-      send({ type: "slash_commands", commands: slashCommands });
+      sendToClient(ws, { type: "slash_commands", commands: slashCommands });
     }
     broadcastSessionList();
 
-    // Restore active session
-    var active = getActiveSession();
+    // Restore active session for this client
+    var active = getClientSession(ws);
     if (active) {
-      send({ type: "session_switched", id: active.localId });
-      replayHistory(active);
+      sendToClient(ws, { type: "session_switched", id: active.localId });
+      replayHistory(ws, active);
       if (active.isProcessing) {
-        send({ type: "status", status: "processing" });
+        sendToClient(ws, { type: "status", status: "processing" });
       }
     }
 
@@ -483,19 +501,19 @@ function createServer(cwd) {
       }
 
       if (msg.type === "new_session") {
-        createSession();
+        createSession(ws);
         return;
       }
 
       if (msg.type === "switch_session") {
         if (msg.id && sessions.has(msg.id)) {
-          switchSession(msg.id);
+          switchSession(ws, msg.id);
         }
         return;
       }
 
       if (msg.type === "ask_user_response") {
-        var session = getActiveSession();
+        var session = getClientSession(ws);
         if (!session || !session.proc) return;
 
         var toolId = msg.toolId;
@@ -509,11 +527,11 @@ function createServer(cwd) {
       if (msg.type !== "message") return;
       if (!msg.text && (!msg.images || msg.images.length === 0)) return;
 
-      var session = getActiveSession();
+      var session = getClientSession(ws);
       if (!session) return;
 
       if (session.isProcessing) {
-        send({ type: "error", text: "Still processing previous message. Please wait." });
+        sendToClient(ws, { type: "error", text: "Still processing previous message. Please wait." });
         return;
       }
 
@@ -527,7 +545,13 @@ function createServer(cwd) {
       }
       session.history.push(userMsg);
       appendToSessionFile(session, userMsg);
-      send({ type: "status", status: "processing" });
+
+      // Notify all clients viewing this session
+      clients.forEach(function(c) {
+        if (c.activeSessionId === session.localId) {
+          sendToClient(c, { type: "status", status: "processing" });
+        }
+      });
 
       // Set title from first user message
       if (!session.title) {
@@ -546,7 +570,7 @@ function createServer(cwd) {
     });
 
     ws.on("close", function() {
-      if (activeWs === ws) activeWs = null;
+      clients.delete(ws);
       // Don't kill procs — they persist across reconnects
     });
   });


### PR DESCRIPTION
Replace the activeWs singleton with a Set of connected clients, each tracking their own activeSessionId. Multiple browser tabs can now connect simultaneously, each viewing different sessions independently. Messages are routed per-client, and session lists show the correct active flag for each client.