### PR TITLE
feat(ui): add session renaming via double-click

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -123,12 +123,22 @@
       el.className = "session-item" + (s.active ? " active" : "");
       el.dataset.sessionId = s.id;
 
-      var html = "";
+      var textSpan = document.createElement("span");
+      textSpan.className = "session-item-text";
+      var textHtml = "";
       if (s.isProcessing) {
-        html += '<span class="session-processing"></span>';
+        textHtml += '<span class="session-processing"></span>';
       }
-      html += escapeHtml(s.title || "New Session");
-      el.innerHTML = html;
+      textHtml += escapeHtml(s.title || "New Session");
+      textSpan.innerHTML = textHtml;
+      el.appendChild(textSpan);
+
+      textSpan.addEventListener("dblclick", (function(id, textEl) {
+        return function(e) {
+          e.stopPropagation();
+          startInlineRename(id, textEl);
+        };
+      })(s.id, textSpan));
 
       el.addEventListener("click", (function(id) {
         return function() {
@@ -141,6 +151,45 @@
 
       sessionListEl.appendChild(el);
     }
+  }
+
+  function startInlineRename(sessionId, textEl) {
+    var current = textEl.textContent;
+    var input = document.createElement("input");
+    input.type = "text";
+    input.className = "session-rename-input";
+    input.value = current;
+    textEl.innerHTML = "";
+    textEl.appendChild(input);
+    input.focus();
+    input.select();
+
+    var committed = false;
+    function commit() {
+      if (committed) return;
+      committed = true;
+      var val = input.value.trim();
+      if (val && val !== current && ws && connected) {
+        ws.send(JSON.stringify({ type: "rename_session", id: sessionId, title: val }));
+      } else {
+        textEl.textContent = current;
+      }
+    }
+
+    input.addEventListener("keydown", function(e) {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commit();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        committed = true;
+        textEl.textContent = current;
+      }
+    });
+
+    input.addEventListener("blur", function() {
+      commit();
+    });
   }
 
   function openSidebar() {

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -110,16 +110,24 @@ html, body {
 }
 
 .session-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   padding: 10px 12px;
   border-radius: 8px;
   cursor: pointer;
   font-size: 13px;
   color: var(--text-muted);
+  margin-bottom: 2px;
+  transition: background 0.15s;
+}
+
+.session-item-text {
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-bottom: 2px;
-  transition: background 0.15s;
+  min-width: 0;
 }
 
 .session-item:hover { background: rgba(255,255,255,0.05); }
@@ -137,6 +145,18 @@ html, body {
   animation: pulse 1.2s infinite;
   margin-right: 6px;
   vertical-align: middle;
+}
+
+.session-rename-input {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: inherit;
+  padding: 2px 6px;
+  outline: none;
 }
 
 /* --- Sidebar overlay (mobile) --- */

--- a/lib/server.js
+++ b/lib/server.js
@@ -201,6 +201,14 @@ function createServer(cwd) {
     }
   }
 
+  function renameSession(localId, newTitle) {
+    var session = sessions.get(localId);
+    if (!session) return;
+    session.title = newTitle.substring(0, 100);
+    saveSessionFile(session);
+    broadcastSessionList();
+  }
+
   function processLine(session, line) {
     if (!line.trim()) return;
 
@@ -490,6 +498,13 @@ function createServer(cwd) {
       if (msg.type === "switch_session") {
         if (msg.id && sessions.has(msg.id)) {
           switchSession(msg.id);
+        }
+        return;
+      }
+
+      if (msg.type === "rename_session") {
+        if (msg.id && sessions.has(msg.id) && typeof msg.title === "string") {
+          renameSession(msg.id, msg.title.trim());
         }
         return;
       }


### PR DESCRIPTION
Double-click a session title in the sidebar to inline-edit it. Press Enter to save, Escape to cancel. Server persists the new title in the JSONL session file and broadcasts the updated list.