### PR TITLE
feat: HTTPS support, interactive setup, permission UI, and multi-device sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,43 +8,64 @@ Run `npx claude-relay` in any directory. Access Claude Code on that directory fr
 $ cd ~/my-project
 $ npx claude-relay
 
-  Claude Relay running at http://100.64.1.5:3456
-  Project: my-project
-  Directory: /Users/you/my-project
+  ◆  Claude Relay
+  │
+  ▲  READ BEFORE CONTINUING
+  │
+  │  Anyone with access to the URL gets full Claude Code access
+  │  to this machine, including reading, writing, and executing
+  │  files with your user permissions.
+  │
+  ◆  PIN protection
+  │  6-digit PIN, or Enter to skip
+  │  ●●●●●●
+  ◇  PIN protection · Enabled
+  │
+  ◆  Keep awake
+  ◇  Keep awake · Yes
+  │
+  └  Starting relay...
 
-  Open the URL on your phone to start chatting.
+  Claude Relay running at http://100.64.1.5:2633
+  my-project · /Users/you/my-project
 ```
 
 ## Why?
 
-Yes, you can use Claude Code from the Claude app — but it requires a GitHub repo, runs in a sandboxed VM, and comes with limitations. No local tools, no custom skills, no access to your actual dev environment.
+You can use Claude Code from the Claude app, but it requires a GitHub repo, runs in a sandboxed VM, and comes with limitations. No local tools, no custom skills, no access to your actual dev environment.
 
-**claude-relay** gives you the real thing. One command in any directory — even `~` — and you get full Claude Code on **your machine**, from any device. Your files, your tools, your skills, your environment. No GitHub required, no sandbox.
+**claude-relay** gives you the real thing. One command in any directory and you get full Claude Code on **your machine**, from any device. Your files, your tools, your skills, your environment. No GitHub required, no sandbox.
 
 ## How it works
 
-claude-relay spawns `claude` CLI processes and bridges them to a web UI over WebSocket. Your browser talks to the relay, the relay talks to Claude Code. Sessions persist across reconnects.
+claude-relay uses the [Claude Agent SDK](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk) and bridges it to a web UI over WebSocket. Your browser talks to the relay, the relay talks to Claude Code. Sessions persist across reconnects.
 
 ```
-Browser (any device)  <-->  claude-relay (your machine)  <-->  claude CLI
-        WebSocket                HTTP + WS                    stdin/stdout
+Browser (any device)  <-->  claude-relay (your machine)  <-->  Claude Agent SDK
+        WebSocket                HTTP/HTTPS + WS
 ```
 
 ## Features
 
 - **One command** — `npx claude-relay` and you're live
 - **Mobile-first UI** — designed for phones and tablets, works everywhere
+- **HTTPS** — automatic TLS via [mkcert](https://github.com/FiloSottile/mkcert), enabled by default
+- **PIN protection** — optional 6-digit PIN set at startup
+- **Permission control** — tool approval relayed to the browser (Allow / Allow for Session / Deny)
 - **Multi-session** — run multiple Claude Code sessions, switch between them
+- **Multi-device sync** — input, messages, and state sync across connected devices in real-time
 - **Streaming** — real-time token streaming, tool execution, thinking blocks
 - **Session persistence** — sessions survive server restarts and reconnects
 - **Tailscale-aware** — prefers Tailscale IP for secure remote access
 - **Slash commands** — full slash command support with autocomplete
+- **Keep awake** — optional macOS caffeinate to prevent sleep while running
 - **Zero config** — no API keys, no setup. Uses your local `claude` installation
 
 ## Requirements
 
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
 - Node.js 18+
+- [mkcert](https://github.com/FiloSottile/mkcert) (optional, for HTTPS)
 
 ## Install
 
@@ -63,27 +84,37 @@ claude-relay
 # Start in current directory
 npx claude-relay
 
-# Custom port
+# Custom port (default: 2633)
 npx claude-relay -p 8080
+
+# Disable HTTPS
+npx claude-relay --no-https
 ```
 
-Then open the URL on any device connected to the same network.
+Then open the URL on any device connected to the same network, or scan the QR code shown in the terminal.
+
+### HTTPS setup
+
+HTTPS is enabled by default when [mkcert](https://github.com/FiloSottile/mkcert) is installed. To set it up:
+
+```bash
+brew install mkcert
+mkcert -install
+```
+
+claude-relay will automatically generate certificates on first run. If mkcert is not installed, it falls back to HTTP.
 
 ### Remote access with Tailscale
 
-claude-relay automatically detects [Tailscale](https://tailscale.com) and uses your Tailscale IP. Install Tailscale on your machine and phone, and you can access Claude Code from anywhere — coffee shop, commute, couch.
+claude-relay automatically detects [Tailscale](https://tailscale.com) and uses your Tailscale IP. Install Tailscale on your machine and phone, and you can access Claude Code from anywhere.
 
-## Limitations
+## Issues
 
-- Permission prompts (tool approval) are not yet relayed to the browser
-- File attachments from the browser are not yet supported
-- Session persistence is unstable
-
-These are planned for future releases. Contributions welcome.
+Found a bug or have a feature request? [Open an issue](https://github.com/chadbyte/claude-relay/issues).
 
 ## Security
 
-**claude-relay has no built-in authentication or encryption.** Anyone with access to the URL gets full Claude Code access to your machine — reading, writing, and executing files with your user permissions.
+**Anyone with access to the URL gets full Claude Code access to your machine**, including reading, writing, and executing files with your user permissions. PIN protection adds a layer of access control, but is not a substitute for network-level security.
 
 We strongly recommend using a private network layer such as [Tailscale](https://tailscale.com), WireGuard, or a VPN. claude-relay automatically detects Tailscale and prefers its IP for this reason.
 

--- a/bin/claude-relay
+++ b/bin/claude-relay
@@ -1,0 +1,1 @@
+../lib/node_modules/claude-relay/bin/cli.js

--- a/bin/claude-relay-dev
+++ b/bin/claude-relay-dev
@@ -1,0 +1,1 @@
+../lib/node_modules/claude-relay/bin/cli.js

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1,8 +1,8 @@
-(function() {
+(function () {
   "use strict";
 
   // --- DOM refs ---
-  var $ = function(id) { return document.getElementById(id); };
+  var $ = function (id) { return document.getElementById(id); };
   var messagesEl = $("messages");
   var inputEl = $("input");
   var sendBtn = $("send-btn");
@@ -16,10 +16,14 @@
   var newSessionBtn = $("new-session-btn");
   var hamburgerBtn = $("hamburger-btn");
   var imagePreviewBar = $("image-preview-bar");
+  var connectOverlay = $("connect-overlay");
+  var connectVerbEl = $("connect-verb");
+  var connectStatusEl = $("connect-status");
 
   // --- State ---
   var ws = null;
   var connected = false;
+  var verbCycleTimer = null;
   var processing = false;
   var isComposing = false;
   var reconnectTimer = null;
@@ -35,6 +39,8 @@
   var slashActiveIdx = -1;
   var slashFiltered = [];
   var pendingImages = []; // [{data: base64, mediaType: "image/png"}]
+  var pendingPermissions = {}; // requestId -> container element
+  var cliSessionId = null;
 
   var builtinCommands = [
     { name: "clear", desc: "Clear conversation" },
@@ -45,7 +51,7 @@
   var _iconTimer = null;
   function refreshIcons() {
     if (_iconTimer) return;
-    _iconTimer = requestAnimationFrame(function() {
+    _iconTimer = requestAnimationFrame(function () {
       _iconTimer = null;
       lucide.createIcons();
     });
@@ -60,37 +66,37 @@
 
   // --- Activity verbs ---
   var thinkingVerbs = [
-    "Accomplishing","Actioning","Actualizing","Architecting","Baking","Beaming",
-    "Beboppin'","Befuddling","Billowing","Blanching","Bloviating","Boogieing",
-    "Boondoggling","Booping","Bootstrapping","Brewing","Burrowing","Calculating",
-    "Canoodling","Caramelizing","Cascading","Catapulting","Cerebrating","Channeling",
-    "Channelling","Choreographing","Churning","Clauding","Coalescing","Cogitating",
-    "Combobulating","Composing","Computing","Concocting","Considering","Contemplating",
-    "Cooking","Crafting","Creating","Crunching","Crystallizing","Cultivating",
-    "Deciphering","Deliberating","Determining","Dilly-dallying","Discombobulating",
-    "Doing","Doodling","Drizzling","Ebbing","Effecting","Elucidating","Embellishing",
-    "Enchanting","Envisioning","Evaporating","Fermenting","Fiddle-faddling","Finagling",
-    "Flambing","Flibbertigibbeting","Flowing","Flummoxing","Fluttering","Forging",
-    "Forming","Frolicking","Frosting","Gallivanting","Galloping","Garnishing",
-    "Generating","Germinating","Gitifying","Grooving","Gusting","Harmonizing",
-    "Hashing","Hatching","Herding","Honking","Hullaballooing","Hyperspacing",
-    "Ideating","Imagining","Improvising","Incubating","Inferring","Infusing",
-    "Ionizing","Jitterbugging","Julienning","Kneading","Leavening","Levitating",
-    "Lollygagging","Manifesting","Marinating","Meandering","Metamorphosing","Misting",
-    "Moonwalking","Moseying","Mulling","Mustering","Musing","Nebulizing","Nesting",
-    "Newspapering","Noodling","Nucleating","Orbiting","Orchestrating","Osmosing",
-    "Perambulating","Percolating","Perusing","Philosophising","Photosynthesizing",
-    "Pollinating","Pondering","Pontificating","Pouncing","Precipitating",
-    "Prestidigitating","Processing","Proofing","Propagating","Puttering","Puzzling",
-    "Quantumizing","Razzle-dazzling","Razzmatazzing","Recombobulating","Reticulating",
-    "Roosting","Ruminating","Sauting","Scampering","Schlepping","Scurrying","Seasoning",
-    "Shenaniganing","Shimmying","Simmering","Skedaddling","Sketching","Slithering",
-    "Smooshing","Sock-hopping","Spelunking","Spinning","Sprouting","Stewing",
-    "Sublimating","Swirling","Swooping","Symbioting","Synthesizing","Tempering",
-    "Thinking","Thundering","Tinkering","Tomfoolering","Topsy-turvying","Transfiguring",
-    "Transmuting","Twisting","Undulating","Unfurling","Unravelling","Vibing","Waddling",
-    "Wandering","Warping","Whatchamacalliting","Whirlpooling","Whirring","Whisking",
-    "Wibbling","Working","Wrangling","Zesting","Zigzagging"
+    "Accomplishing", "Actioning", "Actualizing", "Architecting", "Baking", "Beaming",
+    "Beboppin'", "Befuddling", "Billowing", "Blanching", "Bloviating", "Boogieing",
+    "Boondoggling", "Booping", "Bootstrapping", "Brewing", "Burrowing", "Calculating",
+    "Canoodling", "Caramelizing", "Cascading", "Catapulting", "Cerebrating", "Channeling",
+    "Channelling", "Choreographing", "Churning", "Clauding", "Coalescing", "Cogitating",
+    "Combobulating", "Composing", "Computing", "Concocting", "Considering", "Contemplating",
+    "Cooking", "Crafting", "Creating", "Crunching", "Crystallizing", "Cultivating",
+    "Deciphering", "Deliberating", "Determining", "Dilly-dallying", "Discombobulating",
+    "Doing", "Doodling", "Drizzling", "Ebbing", "Effecting", "Elucidating", "Embellishing",
+    "Enchanting", "Envisioning", "Evaporating", "Fermenting", "Fiddle-faddling", "Finagling",
+    "Flambing", "Flibbertigibbeting", "Flowing", "Flummoxing", "Fluttering", "Forging",
+    "Forming", "Frolicking", "Frosting", "Gallivanting", "Galloping", "Garnishing",
+    "Generating", "Germinating", "Gitifying", "Grooving", "Gusting", "Harmonizing",
+    "Hashing", "Hatching", "Herding", "Honking", "Hullaballooing", "Hyperspacing",
+    "Ideating", "Imagining", "Improvising", "Incubating", "Inferring", "Infusing",
+    "Ionizing", "Jitterbugging", "Julienning", "Kneading", "Leavening", "Levitating",
+    "Lollygagging", "Manifesting", "Marinating", "Meandering", "Metamorphosing", "Misting",
+    "Moonwalking", "Moseying", "Mulling", "Mustering", "Musing", "Nebulizing", "Nesting",
+    "Newspapering", "Noodling", "Nucleating", "Orbiting", "Orchestrating", "Osmosing",
+    "Perambulating", "Percolating", "Perusing", "Philosophising", "Photosynthesizing",
+    "Pollinating", "Pondering", "Pontificating", "Pouncing", "Precipitating",
+    "Prestidigitating", "Processing", "Proofing", "Propagating", "Puttering", "Puzzling",
+    "Quantumizing", "Razzle-dazzling", "Razzmatazzing", "Recombobulating", "Reticulating",
+    "Roosting", "Ruminating", "Sauting", "Scampering", "Schlepping", "Scurrying", "Seasoning",
+    "Shenaniganing", "Shimmying", "Simmering", "Skedaddling", "Sketching", "Slithering",
+    "Smooshing", "Sock-hopping", "Spelunking", "Spinning", "Sprouting", "Stewing",
+    "Sublimating", "Swirling", "Swooping", "Symbioting", "Synthesizing", "Tempering",
+    "Thinking", "Thundering", "Tinkering", "Tomfoolering", "Topsy-turvying", "Transfiguring",
+    "Transmuting", "Twisting", "Undulating", "Unfurling", "Unravelling", "Vibing", "Waddling",
+    "Wandering", "Warping", "Whatchamacalliting", "Whirlpooling", "Whirring", "Whisking",
+    "Wibbling", "Working", "Wrangling", "Zesting", "Zigzagging"
   ];
 
   function randomThinkingVerb() {
@@ -105,7 +111,7 @@
   }
 
   function highlightCodeBlocks(el) {
-    el.querySelectorAll("pre code:not(.hljs)").forEach(function(block) {
+    el.querySelectorAll("pre code:not(.hljs)").forEach(function (block) {
       hljs.highlightElement(block);
     });
   }
@@ -130,8 +136,8 @@
       html += escapeHtml(s.title || "New Session");
       el.innerHTML = html;
 
-      el.addEventListener("click", (function(id) {
-        return function() {
+      el.addEventListener("click", (function (id) {
+        return function () {
           if (ws && connected) {
             ws.send(JSON.stringify({ type: "switch_session", id: id }));
             closeSidebar();
@@ -153,18 +159,137 @@
     sidebarOverlay.classList.remove("visible");
   }
 
-  hamburgerBtn.addEventListener("click", function() {
+  hamburgerBtn.addEventListener("click", function () {
     sidebar.classList.contains("open") ? closeSidebar() : openSidebar();
   });
 
   sidebarOverlay.addEventListener("click", closeSidebar);
 
-  newSessionBtn.addEventListener("click", function() {
+  newSessionBtn.addEventListener("click", function () {
     if (ws && connected) {
       ws.send(JSON.stringify({ type: "new_session" }));
       closeSidebar();
     }
   });
+
+  // --- Connect overlay verb cycling ---
+  function startVerbCycle() {
+    if (verbCycleTimer) return;
+    connectVerbEl.textContent = randomThinkingVerb() + "...";
+    connectVerbEl.classList.remove("fade-out");
+    connectVerbEl.classList.add("fade-in");
+    verbCycleTimer = setInterval(function () {
+      connectVerbEl.classList.remove("fade-in");
+      connectVerbEl.classList.add("fade-out");
+      setTimeout(function () {
+        connectVerbEl.textContent = randomThinkingVerb() + "...";
+        connectVerbEl.classList.remove("fade-out");
+        connectVerbEl.classList.add("fade-in");
+      }, 400);
+    }, 10000);
+  }
+
+  function stopVerbCycle() {
+    if (verbCycleTimer) {
+      clearInterval(verbCycleTimer);
+      verbCycleTimer = null;
+    }
+    stopPixelAnim();
+  }
+
+  // --- Pixel character animation ---
+  var pixelAnimTimer = null;
+  var pixelBlocks = [];
+
+  (function initPixelAnim() {
+    var canvas = document.getElementById("pixel-canvas");
+    if (!canvas) return;
+
+    // Character grid: 1 = body, 2 = eye, 0 = empty
+    // 12 cols x 9 rows
+    var grid = [
+      [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+      [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+      [0, 0, 1, 2, 1, 1, 1, 1, 2, 1, 0, 0],
+      [0, 0, 1, 2, 1, 1, 1, 1, 2, 1, 0, 0],
+      [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+      [0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
+      [0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0],
+      [0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0],
+    ];
+
+    var CELL = 12;
+    var accent = "#DA7756";
+    var eye = "#2F2E2B";
+
+    for (var r = 0; r < grid.length; r++) {
+      for (var c = 0; c < grid[r].length; c++) {
+        if (grid[r][c] === 0) continue;
+        var el = document.createElement("div");
+        el.className = "px";
+        el.style.background = grid[r][c] === 2 ? eye : accent;
+        el.style.left = c * CELL + "px";
+        el.style.top = r * CELL + "px";
+        canvas.appendChild(el);
+        pixelBlocks.push(el);
+      }
+    }
+  })();
+
+  function pixelScatter() {
+    for (var i = 0; i < pixelBlocks.length; i++) {
+      var el = pixelBlocks[i];
+      var angle = Math.random() * Math.PI * 2;
+      var dist = 80 + Math.random() * 120;
+      var dx = Math.cos(angle) * dist;
+      var dy = Math.sin(angle) * dist;
+      var rot = (Math.random() - 0.5) * 360;
+      el.className = "px scatter";
+      el.style.transform = "translate(" + dx + "px," + dy + "px) rotate(" + rot + "deg)";
+      el.style.opacity = "0";
+    }
+  }
+
+  function pixelAssemble() {
+    for (var i = 0; i < pixelBlocks.length; i++) {
+      (function (el, delay) {
+        setTimeout(function () {
+          el.className = "px settle";
+          el.style.transform = "translate(0,0) rotate(0deg)";
+          el.style.opacity = "1";
+        }, delay);
+      })(pixelBlocks[i], Math.random() * 300);
+    }
+  }
+
+  function startPixelAnim() {
+    if (pixelAnimTimer) return;
+    // Start scattered
+    for (var i = 0; i < pixelBlocks.length; i++) {
+      var angle = Math.random() * Math.PI * 2;
+      var dist = 80 + Math.random() * 120;
+      pixelBlocks[i].className = "px";
+      pixelBlocks[i].style.transform = "translate(" + (Math.cos(angle) * dist) + "px," + (Math.sin(angle) * dist) + "px) rotate(" + ((Math.random() - 0.5) * 360) + "deg)";
+      pixelBlocks[i].style.opacity = "0";
+    }
+    function cycle() {
+      pixelAssemble();
+      pixelAnimTimer = setTimeout(function () {
+        pixelScatter();
+        pixelAnimTimer = setTimeout(cycle, 800);
+      }, 2200);
+    }
+    pixelAnimTimer = setTimeout(cycle, 300);
+  }
+
+  function stopPixelAnim() {
+    if (pixelAnimTimer) {
+      clearTimeout(pixelAnimTimer);
+      pixelAnimTimer = null;
+    }
+  }
 
   // --- Status & Activity ---
   function setSendBtnMode(mode) {
@@ -188,6 +313,8 @@
       processing = false;
       sendBtn.disabled = false;
       setSendBtnMode("send");
+      connectOverlay.classList.add("hidden");
+      stopVerbCycle();
     } else if (status === "processing") {
       statusDot.classList.add("processing");
       statusTextEl.textContent = "";
@@ -197,7 +324,10 @@
       statusTextEl.textContent = "Disconnected";
       connected = false;
       sendBtn.disabled = true;
-      setSendBtnMode("send");
+      connectOverlay.classList.remove("hidden");
+      connectStatusEl.textContent = "Reconnecting...";
+      startVerbCycle();
+      startPixelAnim();
     }
   }
 
@@ -223,7 +353,7 @@
   }
 
   function scrollToBottom() {
-    requestAnimationFrame(function() {
+    requestAnimationFrame(function () {
       messagesEl.scrollTop = messagesEl.scrollHeight;
     });
   }
@@ -248,18 +378,18 @@
   function toolSummary(name, input) {
     if (!input || typeof input !== "object") return "";
     switch (name) {
-      case "Read":       return shortPath(input.file_path);
-      case "Edit":       return shortPath(input.file_path);
-      case "Write":      return shortPath(input.file_path);
-      case "Bash":       return (input.command || "").substring(0, 80);
-      case "Glob":       return input.pattern || "";
-      case "Grep":       return (input.pattern || "") + (input.path ? " in " + shortPath(input.path) : "");
-      case "WebFetch":   return input.url || "";
-      case "WebSearch":  return input.query || "";
-      case "Task":       return input.description || "";
+      case "Read": return shortPath(input.file_path);
+      case "Edit": return shortPath(input.file_path);
+      case "Write": return shortPath(input.file_path);
+      case "Bash": return (input.command || "").substring(0, 80);
+      case "Glob": return input.pattern || "";
+      case "Grep": return (input.pattern || "") + (input.path ? " in " + shortPath(input.path) : "");
+      case "WebFetch": return input.url || "";
+      case "WebSearch": return input.query || "";
+      case "Task": return input.description || "";
       case "EnterPlanMode": return "";
-      case "ExitPlanMode":  return "";
-      default:           return JSON.stringify(input).substring(0, 60);
+      case "ExitPlanMode": return "";
+      default: return JSON.stringify(input).substring(0, 60);
     }
   }
 
@@ -299,7 +429,7 @@
     var answers = {};
     var multiSelections = {};
 
-    questions.forEach(function(q, qIdx) {
+    questions.forEach(function (q, qIdx) {
       var qDiv = document.createElement("div");
       qDiv.className = "ask-user-question";
 
@@ -314,7 +444,7 @@
       var isMulti = q.multiSelect || false;
       if (isMulti) multiSelections[qIdx] = new Set();
 
-      (q.options || []).forEach(function(opt) {
+      (q.options || []).forEach(function (opt) {
         var btn = document.createElement("button");
         btn.className = "ask-user-option";
         btn.innerHTML =
@@ -323,7 +453,7 @@
         btn.querySelector(".option-label").textContent = opt.label;
         if (opt.description) btn.querySelector(".option-desc").textContent = opt.description;
 
-        btn.addEventListener("click", function() {
+        btn.addEventListener("click", function () {
           if (container.classList.contains("answered")) return;
 
           if (isMulti) {
@@ -336,7 +466,7 @@
               btn.classList.add("selected");
             }
           } else {
-            optionsDiv.querySelectorAll(".ask-user-option").forEach(function(b) {
+            optionsDiv.querySelectorAll(".ask-user-option").forEach(function (b) {
               b.classList.remove("selected");
             });
             btn.classList.add("selected");
@@ -360,17 +490,17 @@
       var otherInput = document.createElement("input");
       otherInput.type = "text";
       otherInput.placeholder = "Other...";
-      otherInput.addEventListener("input", function() {
+      otherInput.addEventListener("input", function () {
         if (container.classList.contains("answered")) return;
         if (otherInput.value.trim()) {
-          optionsDiv.querySelectorAll(".ask-user-option").forEach(function(b) {
+          optionsDiv.querySelectorAll(".ask-user-option").forEach(function (b) {
             b.classList.remove("selected");
           });
           if (isMulti) multiSelections[qIdx] = new Set();
           answers[qIdx] = otherInput.value.trim();
         }
       });
-      otherInput.addEventListener("keydown", function(e) {
+      otherInput.addEventListener("keydown", function (e) {
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
           submitAskUserAnswer(container, toolId, questions, answers, multiSelections);
@@ -381,7 +511,7 @@
       var submitBtn = document.createElement("button");
       submitBtn.className = "ask-user-submit";
       submitBtn.textContent = "Submit";
-      submitBtn.addEventListener("click", function() {
+      submitBtn.addEventListener("click", function () {
         submitAskUserAnswer(container, toolId, questions, answers, multiSelections);
       });
       otherDiv.appendChild(submitBtn);
@@ -419,6 +549,171 @@
         answers: result,
       }));
     }
+  }
+
+  // --- Permission request ---
+  function permissionInputSummary(toolName, input) {
+    if (!input || typeof input !== "object") return "";
+    switch (toolName) {
+      case "Bash": return input.command || input.description || "";
+      case "Edit": return shortPath(input.file_path);
+      case "Write": return shortPath(input.file_path);
+      case "Read": return shortPath(input.file_path);
+      case "Glob": return input.pattern || "";
+      case "Grep": return (input.pattern || "") + (input.path ? " in " + shortPath(input.path) : "");
+      default: return toolSummary(toolName, input);
+    }
+  }
+
+  function renderPermissionRequest(requestId, toolName, toolInput, decisionReason) {
+    finalizeAssistantBlock();
+    stopThinking();
+
+    var container = document.createElement("div");
+    container.className = "permission-container";
+    container.dataset.requestId = requestId;
+
+    // Header
+    var header = document.createElement("div");
+    header.className = "permission-header";
+    header.innerHTML =
+      '<span class="permission-icon">' + iconHtml("shield") + '</span>' +
+      '<span class="permission-title">Permission Required</span>';
+
+    // Body
+    var body = document.createElement("div");
+    body.className = "permission-body";
+
+    var summary = document.createElement("div");
+    summary.className = "permission-summary";
+    var summaryText = permissionInputSummary(toolName, toolInput);
+    summary.innerHTML =
+      '<span class="permission-tool-name"></span>' +
+      (summaryText ? '<span class="permission-tool-desc"></span>' : '');
+    summary.querySelector(".permission-tool-name").textContent = toolName;
+    if (summaryText) {
+      summary.querySelector(".permission-tool-desc").textContent = summaryText;
+    }
+    body.appendChild(summary);
+
+    if (decisionReason) {
+      var reason = document.createElement("div");
+      reason.className = "permission-reason";
+      reason.textContent = decisionReason;
+      body.appendChild(reason);
+    }
+
+    // Collapsible details
+    var details = document.createElement("details");
+    details.className = "permission-details";
+    var detailsSummary = document.createElement("summary");
+    detailsSummary.textContent = "Details";
+    var detailsPre = document.createElement("pre");
+    detailsPre.textContent = JSON.stringify(toolInput, null, 2);
+    details.appendChild(detailsSummary);
+    details.appendChild(detailsPre);
+    body.appendChild(details);
+
+    // Actions
+    var actions = document.createElement("div");
+    actions.className = "permission-actions";
+
+    var allowBtn = document.createElement("button");
+    allowBtn.className = "permission-btn permission-allow";
+    allowBtn.textContent = "Allow";
+    allowBtn.addEventListener("click", function () {
+      sendPermissionResponse(container, requestId, "allow");
+    });
+
+    var allowAlwaysBtn = document.createElement("button");
+    allowAlwaysBtn.className = "permission-btn permission-allow-session";
+    allowAlwaysBtn.textContent = "Allow for Session";
+    allowAlwaysBtn.addEventListener("click", function () {
+      sendPermissionResponse(container, requestId, "allow_always");
+    });
+
+    var denyBtn = document.createElement("button");
+    denyBtn.className = "permission-btn permission-deny";
+    denyBtn.textContent = "Deny";
+    denyBtn.addEventListener("click", function () {
+      sendPermissionResponse(container, requestId, "deny");
+    });
+
+    actions.appendChild(allowBtn);
+    actions.appendChild(allowAlwaysBtn);
+    actions.appendChild(denyBtn);
+
+    container.appendChild(header);
+    container.appendChild(body);
+    container.appendChild(actions);
+    messagesEl.appendChild(container);
+
+    pendingPermissions[requestId] = container;
+    refreshIcons();
+    setActivity(null);
+    scrollToBottom();
+  }
+
+  function sendPermissionResponse(container, requestId, decision) {
+    if (container.classList.contains("resolved")) return;
+    container.classList.add("resolved");
+
+    var label = decision === "deny" ? "Denied" : "Allowed";
+    var resolvedClass = decision === "deny" ? "resolved-denied" : "resolved-allowed";
+    container.classList.add(resolvedClass);
+
+    // Replace actions with decision label
+    var actions = container.querySelector(".permission-actions");
+    if (actions) {
+      actions.innerHTML = '<span class="permission-decision-label">' + label + '</span>';
+    }
+
+    if (ws && connected) {
+      ws.send(JSON.stringify({
+        type: "permission_response",
+        requestId: requestId,
+        decision: decision,
+      }));
+    }
+
+    delete pendingPermissions[requestId];
+  }
+
+  function markPermissionResolved(requestId, decision) {
+    var container = pendingPermissions[requestId];
+    if (!container) {
+      // Find by data attribute (history replay)
+      container = messagesEl.querySelector('[data-request-id="' + requestId + '"]');
+    }
+    if (!container || container.classList.contains("resolved")) return;
+
+    container.classList.add("resolved");
+    var resolvedClass = decision === "deny" ? "resolved-denied" : "resolved-allowed";
+    container.classList.add(resolvedClass);
+
+    var label = decision === "deny" ? "Denied" : "Allowed";
+    var actions = container.querySelector(".permission-actions");
+    if (actions) {
+      actions.innerHTML = '<span class="permission-decision-label">' + label + '</span>';
+    }
+
+    delete pendingPermissions[requestId];
+  }
+
+  function markPermissionCancelled(requestId) {
+    var container = pendingPermissions[requestId];
+    if (!container) {
+      container = messagesEl.querySelector('[data-request-id="' + requestId + '"]');
+    }
+    if (!container || container.classList.contains("resolved")) return;
+
+    container.classList.add("resolved", "resolved-cancelled");
+    var actions = container.querySelector(".permission-actions");
+    if (actions) {
+      actions.innerHTML = '<span class="permission-decision-label">Cancelled</span>';
+    }
+
+    delete pendingPermissions[requestId];
   }
 
   // --- Plan mode rendering ---
@@ -469,7 +764,7 @@
     body.innerHTML = renderMarkdown(content);
     highlightCodeBlocks(body);
 
-    header.addEventListener("click", function() {
+    header.addEventListener("click", function () {
       el.classList.toggle("collapsed");
     });
 
@@ -492,7 +787,7 @@
 
   function handleTodoWrite(input) {
     if (!input || !Array.isArray(input.todos)) return;
-    todoItems = input.todos.map(function(t, i) {
+    todoItems = input.todos.map(function (t, i) {
       return {
         id: t.id || String(i + 1),
         content: t.content || t.subject || "",
@@ -553,7 +848,7 @@
       '<span class="todo-header-icon">' + iconHtml("list-checks") + '</span>' +
       '<span class="todo-header-title">Tasks</span>' +
       '<span class="todo-header-count">' + completed + '/' + todoItems.length + '</span>' +
-    '</div>';
+      '</div>';
     html += '<div class="todo-progress"><div class="todo-progress-bar" style="width:' +
       (todoItems.length > 0 ? Math.round(completed / todoItems.length * 100) : 0) + '%"></div></div>';
     html += '<div class="todo-items">';
@@ -563,7 +858,7 @@
       html += '<div class="todo-item ' + statusClass + '">' +
         '<span class="todo-item-icon">' + todoStatusIcon(t.status) + '</span>' +
         '<span class="todo-item-text">' + escapeHtml(t.status === "in_progress" && t.activeForm ? t.activeForm : t.content) + '</span>' +
-      '</div>';
+        '</div>';
     }
     html += '</div>';
 
@@ -624,7 +919,7 @@
     contentEl.innerHTML = renderMarkdown(currentFullText);
 
     if (highlightTimer) clearTimeout(highlightTimer);
-    highlightTimer = setTimeout(function() {
+    highlightTimer = setTimeout(function () {
       highlightCodeBlocks(contentEl);
     }, 150);
 
@@ -649,6 +944,16 @@
     scrollToBottom();
   }
 
+  function updateTerminalBtn() {
+    var btn = document.getElementById("terminal-btn");
+    if (!btn) return;
+    if (cliSessionId) {
+      btn.classList.add("visible");
+    } else {
+      btn.classList.remove("visible");
+    }
+  }
+
   function resetClientState() {
     messagesEl.innerHTML = "";
     currentMsgEl = null;
@@ -661,6 +966,7 @@
     planContent = null;
     todoItems = [];
     todoWidgetEl = null;
+    pendingPermissions = {};
     setActivity(null);
     setStatus("connected");
   }
@@ -673,14 +979,14 @@
     el.className = "thinking-item";
     el.innerHTML =
       '<div class="thinking-header">' +
-        '<span class="thinking-chevron">' + iconHtml("chevron-right") + '</span>' +
-        '<span class="thinking-label">Thinking</span>' +
-        '<span class="thinking-duration"></span>' +
-        '<span class="thinking-spinner">' + iconHtml("loader", "icon-spin") + '</span>' +
+      '<span class="thinking-chevron">' + iconHtml("chevron-right") + '</span>' +
+      '<span class="thinking-label">Thinking</span>' +
+      '<span class="thinking-duration"></span>' +
+      '<span class="thinking-spinner">' + iconHtml("loader", "icon-spin") + '</span>' +
       '</div>' +
       '<div class="thinking-content"></div>';
 
-    el.querySelector(".thinking-header").addEventListener("click", function() {
+    el.querySelector(".thinking-header").addEventListener("click", function () {
       el.classList.toggle("expanded");
     });
 
@@ -716,14 +1022,14 @@
     el.dataset.toolId = id;
     el.innerHTML =
       '<div class="tool-header">' +
-        '<span class="tool-bullet"></span>' +
-        '<span class="tool-name"></span>' +
-        '<span class="tool-desc"></span>' +
-        '<span class="tool-status-icon">' + iconHtml("loader", "icon-spin") + '</span>' +
+      '<span class="tool-bullet"></span>' +
+      '<span class="tool-name"></span>' +
+      '<span class="tool-desc"></span>' +
+      '<span class="tool-status-icon">' + iconHtml("loader", "icon-spin") + '</span>' +
       '</div>' +
       '<div class="tool-subtitle">' +
-        '<span class="tool-connector">&#9492;</span>' +
-        '<span class="tool-subtitle-text">Running...</span>' +
+      '<span class="tool-connector">&#9492;</span>' +
+      '<span class="tool-subtitle-text">Running...</span>' +
       '</div>';
 
     el.querySelector(".tool-name").textContent = name;
@@ -750,6 +1056,43 @@
     scrollToBottom();
   }
 
+  function isDiffContent(text) {
+    var lines = text.split("\n");
+    var diffMarkers = 0;
+    for (var i = 0; i < Math.min(lines.length, 20); i++) {
+      var l = lines[i];
+      if (l.startsWith("@@") || l.startsWith("---") || l.startsWith("+++")) {
+        diffMarkers++;
+      }
+    }
+    return diffMarkers >= 2;
+  }
+
+  function renderDiffPre(text) {
+    var pre = document.createElement("pre");
+    pre.className = "diff-content";
+    var lines = text.split("\n");
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      var span = document.createElement("span");
+      if (line.startsWith("@@")) {
+        span.className = "diff-hunk";
+      } else if (line.startsWith("---") || line.startsWith("+++")) {
+        span.className = "diff-file-header";
+      } else if (line.startsWith("+")) {
+        span.className = "diff-add";
+      } else if (line.startsWith("-")) {
+        span.className = "diff-del";
+      } else {
+        span.className = "diff-ctx";
+      }
+      span.textContent = line;
+      pre.appendChild(span);
+      if (i < lines.length - 1) pre.appendChild(document.createTextNode("\n"));
+    }
+    return pre;
+  }
+
   function updateToolResult(id, content, isError) {
     var tool = tools[id];
     if (!tool) return;
@@ -761,15 +1104,20 @@
 
     var resultBlock = document.createElement("div");
     resultBlock.className = "tool-result-block";
-    var pre = document.createElement("pre");
-    if (isError) pre.className = "is-error";
     var displayContent = content || "(no output)";
     if (displayContent.length > 10000) displayContent = displayContent.substring(0, 10000) + "\n... (truncated)";
-    pre.textContent = displayContent;
-    resultBlock.appendChild(pre);
+
+    if (!isError && isDiffContent(displayContent)) {
+      resultBlock.appendChild(renderDiffPre(displayContent));
+    } else {
+      var pre = document.createElement("pre");
+      if (isError) pre.className = "is-error";
+      pre.textContent = displayContent;
+      resultBlock.appendChild(pre);
+    }
     tool.el.appendChild(resultBlock);
 
-    tool.el.querySelector(".tool-header").addEventListener("click", function() {
+    tool.el.querySelector(".tool-header").addEventListener("click", function () {
       resultBlock.classList.toggle("collapsed");
     });
 
@@ -818,30 +1166,57 @@
   }
 
   // --- WebSocket ---
+  var connectTimeoutId = null;
+
   function connect() {
     if (ws) { ws.onclose = null; ws.close(); }
+    if (connectTimeoutId) { clearTimeout(connectTimeoutId); connectTimeoutId = null; }
 
     var protocol = location.protocol === "https:" ? "wss:" : "ws:";
     ws = new WebSocket(protocol + "//" + location.host);
 
-    ws.onopen = function() {
+    connectStatusEl.textContent = "Connecting...";
+
+    // If not connected within 3s, force retry
+    connectTimeoutId = setTimeout(function () {
+      if (!connected) {
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.close();
+        connect();
+      }
+    }, 3000);
+
+    ws.onopen = function () {
+      if (connectTimeoutId) { clearTimeout(connectTimeoutId); connectTimeoutId = null; }
       setStatus("connected");
       reconnectDelay = 1000;
       if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
     };
 
-    ws.onclose = function() {
+    ws.onclose = function (e) {
+      if (connectTimeoutId) { clearTimeout(connectTimeoutId); connectTimeoutId = null; }
+      connectStatusEl.textContent = "Connection lost. Retrying...";
       setStatus("disconnected");
       processing = false;
       setActivity(null);
       scheduleReconnect();
     };
 
-    ws.onerror = function() {};
+    ws.onerror = function () {
+      connectStatusEl.textContent = "Connection error. Retrying...";
+    };
 
-    ws.onmessage = function(event) {
+    ws.onmessage = function (event) {
+      // Backup: if we're receiving messages, we're connected
+      if (!connected) {
+        setStatus("connected");
+        reconnectDelay = 1000;
+        if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+      }
+
       var msg;
-      try { msg = JSON.parse(event.data); } catch(e) { return; }
+      try { msg = JSON.parse(event.data); } catch (e) { return; }
 
       switch (msg.type) {
         case "info":
@@ -849,9 +1224,29 @@
           break;
 
         case "slash_commands":
-          slashCommands = (msg.commands || []).map(function(name) {
+          slashCommands = (msg.commands || []).map(function (name) {
             return { name: name, desc: "Skill" };
           });
+          break;
+
+        case "client_count":
+          var countEl = document.getElementById("client-count");
+          if (countEl) {
+            if (msg.count > 1) {
+              countEl.textContent = msg.count;
+              countEl.dataset.tip = msg.count + " devices connected";
+              countEl.classList.remove("hidden");
+            } else {
+              countEl.classList.add("hidden");
+            }
+          }
+          break;
+
+        case "input_sync":
+          isRemoteInput = true;
+          inputEl.value = msg.text;
+          autoResize();
+          isRemoteInput = false;
           break;
 
         case "session_list":
@@ -860,7 +1255,14 @@
 
         case "session_switched":
           activeSessionId = msg.id;
+          cliSessionId = msg.cliSessionId || null;
           resetClientState();
+          updateTerminalBtn();
+          break;
+
+        case "session_id":
+          cliSessionId = msg.cliSessionId;
+          updateTerminalBtn();
           break;
 
         case "user_message":
@@ -947,6 +1349,37 @@
           }
           break;
 
+        case "permission_request":
+          renderPermissionRequest(msg.requestId, msg.toolName, msg.toolInput, msg.decisionReason);
+          break;
+
+        case "permission_cancel":
+          markPermissionCancelled(msg.requestId);
+          break;
+
+        case "permission_resolved":
+          markPermissionResolved(msg.requestId, msg.decision);
+          break;
+
+        case "permission_request_pending":
+          renderPermissionRequest(msg.requestId, msg.toolName, msg.toolInput, msg.decisionReason);
+          break;
+
+        case "slash_command_result":
+          finalizeAssistantBlock();
+          var cmdBlock = document.createElement("div");
+          cmdBlock.className = "assistant-block";
+          cmdBlock.style.maxWidth = "var(--content-width)";
+          cmdBlock.style.margin = "12px auto";
+          cmdBlock.style.padding = "0 20px";
+          var pre = document.createElement("pre");
+          pre.style.cssText = "background:var(--code-bg);border:1px solid var(--border-subtle);border-radius:10px;padding:12px 14px;font-family:'SF Mono',Menlo,Monaco,monospace;font-size:12px;line-height:1.55;color:var(--text-secondary);white-space:pre-wrap;word-break:break-word;max-height:400px;overflow-y:auto;margin:0";
+          pre.textContent = msg.text;
+          cmdBlock.appendChild(pre);
+          messagesEl.appendChild(cmdBlock);
+          scrollToBottom();
+          break;
+
         case "result":
           setActivity(null);
           stopThinking();
@@ -969,6 +1402,10 @@
           addSystemMessage(msg.text, false);
           break;
 
+        case "info":
+          addSystemMessage(msg.text, false);
+          break;
+
         case "error":
           setActivity(null);
           addSystemMessage(msg.text, true);
@@ -979,7 +1416,7 @@
 
   function scheduleReconnect() {
     if (reconnectTimer) return;
-    reconnectTimer = setTimeout(function() {
+    reconnectTimer = setTimeout(function () {
       reconnectTimer = null;
       connect();
     }, reconnectDelay);
@@ -1012,6 +1449,7 @@
     ws.send(JSON.stringify(payload));
 
     inputEl.value = "";
+    sendInputSync();
     clearPendingImages();
     autoResize();
     inputEl.focus();
@@ -1053,7 +1491,7 @@
     }
     imagePreviewBar.classList.add("visible");
     for (var i = 0; i < pendingImages.length; i++) {
-      (function(idx) {
+      (function (idx) {
         var wrap = document.createElement("div");
         wrap.className = "image-preview-thumb";
         var img = document.createElement("img");
@@ -1061,7 +1499,7 @@
         var removeBtn = document.createElement("button");
         removeBtn.className = "image-preview-remove";
         removeBtn.innerHTML = iconHtml("x");
-        removeBtn.addEventListener("click", function() {
+        removeBtn.addEventListener("click", function () {
           removePendingImage(idx);
         });
         wrap.appendChild(img);
@@ -1074,13 +1512,13 @@
 
   function readImageBlob(blob) {
     var reader = new FileReader();
-    reader.onload = function(ev) {
+    reader.onload = function (ev) {
       addPendingImage(ev.target.result);
     };
     reader.readAsDataURL(blob);
   }
 
-  document.addEventListener("paste", function(e) {
+  document.addEventListener("paste", function (e) {
     var cd = e.clipboardData;
     if (!cd) return;
 
@@ -1119,22 +1557,22 @@
 
   function showSlashMenu(filter) {
     var query = filter.toLowerCase();
-    slashFiltered = getAllCommands().filter(function(c) {
+    slashFiltered = getAllCommands().filter(function (c) {
       return c.name.toLowerCase().indexOf(query) !== -1;
     });
     if (slashFiltered.length === 0) { hideSlashMenu(); return; }
 
     slashActiveIdx = 0;
-    slashMenu.innerHTML = slashFiltered.map(function(c, i) {
+    slashMenu.innerHTML = slashFiltered.map(function (c, i) {
       return '<div class="slash-item' + (i === 0 ? ' active' : '') + '" data-idx="' + i + '">' +
         '<span class="slash-cmd">/' + c.name + '</span>' +
         '<span class="slash-desc">' + c.desc + '</span>' +
-      '</div>';
+        '</div>';
     }).join("");
     slashMenu.classList.add("visible");
 
-    slashMenu.querySelectorAll(".slash-item").forEach(function(el) {
-      el.addEventListener("click", function() {
+    slashMenu.querySelectorAll(".slash-item").forEach(function (el) {
+      el.addEventListener("click", function () {
         selectSlashItem(parseInt(el.dataset.idx));
       });
     });
@@ -1157,16 +1595,27 @@
   }
 
   function updateSlashHighlight() {
-    slashMenu.querySelectorAll(".slash-item").forEach(function(el, i) {
+    slashMenu.querySelectorAll(".slash-item").forEach(function (el, i) {
       el.classList.toggle("active", i === slashActiveIdx);
     });
     var activeEl = slashMenu.querySelector(".slash-item.active");
     if (activeEl) activeEl.scrollIntoView({ block: "nearest" });
   }
 
+  // --- Input sync across devices ---
+  var isRemoteInput = false;
+
+  function sendInputSync() {
+    if (isRemoteInput) return;
+    if (ws && connected) {
+      ws.send(JSON.stringify({ type: "input_sync", text: inputEl.value }));
+    }
+  }
+
   // --- Input handlers ---
-  inputEl.addEventListener("input", function() {
+  inputEl.addEventListener("input", function () {
     autoResize();
+    sendInputSync();
     var val = inputEl.value;
     if (val.startsWith("/") && !val.includes(" ") && val.length > 1) {
       showSlashMenu(val.substring(1));
@@ -1177,10 +1626,10 @@
     }
   });
 
-  inputEl.addEventListener("compositionstart", function() { isComposing = true; });
-  inputEl.addEventListener("compositionend", function() { isComposing = false; });
+  inputEl.addEventListener("compositionstart", function () { isComposing = true; });
+  inputEl.addEventListener("compositionend", function () { isComposing = false; });
 
-  inputEl.addEventListener("keydown", function(e) {
+  inputEl.addEventListener("keydown", function (e) {
     if (slashFiltered.length > 0 && slashMenu.classList.contains("visible")) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -1212,27 +1661,118 @@
     }
   });
 
-  sendBtn.addEventListener("click", function() {
-    if (processing && ws && connected) {
+  sendBtn.addEventListener("click", function () {
+    if (processing && connected) {
       ws.send(JSON.stringify({ type: "stop" }));
       return;
     }
     sendMessage();
   });
+  sendBtn.addEventListener("dblclick", function (e) { e.preventDefault(); });
 
-  // --- Mobile viewport ---
-  if (window.visualViewport) {
-    window.visualViewport.addEventListener("resize", function() {
-      $("app").style.height = window.visualViewport.height + "px";
-      scrollToBottom();
+  // --- Terminal button (expand -> copy resume command) ---
+  var terminalBtn = document.getElementById("terminal-btn");
+  var terminalCmd = terminalBtn ? terminalBtn.querySelector(".terminal-cmd") : null;
+  if (terminalBtn) {
+    terminalBtn.addEventListener("click", function () {
+      if (!cliSessionId) return;
+      var cmd = "claude --resume " + cliSessionId;
+
+      if (!terminalBtn.classList.contains("expanded")) {
+        // First click: expand to show label
+        terminalCmd.textContent = "Copy resume command";
+        terminalBtn.classList.add("expanded");
+      } else {
+        // Second click: copy
+        navigator.clipboard.writeText(cmd).then(function () {
+          terminalBtn.classList.add("copied");
+          terminalCmd.textContent = "Copied!";
+          setTimeout(function () {
+            terminalBtn.classList.remove("copied", "expanded");
+          }, 1500);
+        });
+      }
     });
-    window.visualViewport.addEventListener("scroll", function() {
-      $("app").style.height = window.visualViewport.height + "px";
+
+    // Close when clicking elsewhere
+    document.addEventListener("click", function (e) {
+      if (!terminalBtn.contains(e.target) && terminalBtn.classList.contains("expanded")) {
+        terminalBtn.classList.remove("expanded");
+        terminalCmd.textContent = "";
+      }
     });
   }
 
+  // --- Mobile viewport (iOS keyboard handling) ---
+  if (window.visualViewport) {
+    var layout = $("layout");
+    function onViewportChange() {
+      layout.style.height = window.visualViewport.height + "px";
+      document.documentElement.scrollTop = 0;
+      scrollToBottom();
+    }
+    window.visualViewport.addEventListener("resize", onViewportChange);
+    window.visualViewport.addEventListener("scroll", onViewportChange);
+  }
+
+  // --- HTTPS banner / auto-redirect ---
+  (function () {
+    if (location.protocol === "https:") return;
+    var banner = $("https-banner");
+    var link = $("https-banner-link");
+    var closeBtn = $("https-banner-close");
+    if (!banner) return;
+
+    fetch("/https-info").then(function (r) { return r.json(); }).then(function (info) {
+      if (!info.httpsUrl) return;
+
+      // Try connecting to HTTPS - if cert is trusted, redirect
+      var ac = new AbortController();
+      setTimeout(function () { ac.abort(); }, 2000);
+      fetch(info.httpsUrl + "/info", { signal: ac.signal })
+        .then(function () { location.replace(info.httpsUrl); })
+        .catch(function () {
+          // Cert not trusted, show banner
+          link.href = "/setup";
+          banner.classList.remove("hidden");
+          refreshIcons();
+        });
+    }).catch(function () { });
+
+    if (closeBtn) {
+      closeBtn.addEventListener("click", function () {
+        banner.classList.add("hidden");
+      });
+    }
+  })();
+
+  // --- Tooltip ---
+  var tooltipEl = document.createElement("div");
+  tooltipEl.className = "tooltip";
+  document.body.appendChild(tooltipEl);
+  var tooltipTimer = null;
+
+  document.addEventListener("click", function (e) {
+    var target = e.target.closest("[data-tip]");
+    if (target) {
+      tooltipEl.textContent = target.dataset.tip;
+      var rect = target.getBoundingClientRect();
+      tooltipEl.style.top = (rect.bottom + 8) + "px";
+      tooltipEl.style.left = (rect.left + rect.width / 2) + "px";
+      tooltipEl.classList.add("visible");
+      clearTimeout(tooltipTimer);
+      tooltipTimer = setTimeout(function () {
+        tooltipEl.classList.remove("visible");
+      }, 2000);
+    } else {
+      tooltipEl.classList.remove("visible");
+    }
+  });
+
   // --- Init ---
   lucide.createIcons();
+  startVerbCycle();
+  startPixelAnim();
   connect();
   inputEl.focus();
 })();

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -5,10 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<link rel="manifest" href="/manifest.json">
+<meta name="theme-color" content="#2F2E2B">
 <title>Claude</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600&family=Styrene+A+Web:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark-dimmed.min.css">
 <link rel="stylesheet" href="/style.css">
 </head>
@@ -20,28 +22,46 @@
       <button id="new-session-btn" title="New session"><i data-lucide="plus"></i></button>
     </div>
     <div id="session-list"></div>
+    <div id="sidebar-footer">
+      <a href="https://github.com/chadbyte/claude-relay" target="_blank" rel="noopener">
+        <i data-lucide="github"></i> GitHub
+      </a>
+    </div>
   </div>
   <div id="sidebar-overlay"></div>
   <div id="app">
+    <div id="https-banner" class="hidden">
+      <span class="https-banner-text"><i data-lucide="shield"></i> Your connection is not encrypted. <a id="https-banner-link" href="/setup">Set up HTTPS</a></span>
+      <button id="https-banner-close" aria-label="Dismiss"><i data-lucide="x"></i></button>
+    </div>
     <div id="header">
       <div id="header-left">
         <button id="hamburger-btn" aria-label="Toggle sidebar"><i data-lucide="menu"></i></button>
         <span class="project-name" id="project-name">Connecting...</span>
       </div>
       <div class="status">
+        <button id="terminal-btn" title="Continue in terminal"><i data-lucide="terminal"></i><span class="terminal-cmd"></span></button>
+        <span id="client-count" class="hidden"></span>
         <span id="status-text">Disconnected</span>
         <span class="status-dot" id="status-dot"></span>
       </div>
     </div>
 
+    <div id="connect-overlay">
+      <div id="pixel-canvas"></div>
+      <div class="connect-verb" id="connect-verb"></div>
+      <div class="connect-status" id="connect-status">Connecting...</div>
+    </div>
     <div id="messages"></div>
 
     <div id="input-area">
       <div id="image-preview-bar"></div>
-      <div id="input-row" style="position:relative">
+      <div id="input-wrapper">
         <div id="slash-menu"></div>
-        <textarea id="input" rows="1" placeholder="Message Claude..." enterkeyhint="send"></textarea>
-        <button id="send-btn" disabled aria-label="Send"><i data-lucide="arrow-up"></i></button>
+        <div id="input-row">
+          <textarea id="input" rows="1" placeholder="Message Claude Code..." enterkeyhint="send"></textarea>
+          <button id="send-btn" disabled aria-label="Send"><i data-lucide="arrow-up"></i></button>
+        </div>
       </div>
     </div>
   </div>

--- a/lib/public/manifest.json
+++ b/lib/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Claude Relay",
+  "short_name": "Claude",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#2F2E2B",
+  "theme_color": "#2F2E2B"
+}

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -1,3 +1,7 @@
+/* ==========================================================================
+   Claude Relay — Design aligned with Claude Desktop
+   ========================================================================== */
+
 /* --- Reset & Variables --- */
 * {
   margin: 0;
@@ -7,33 +11,43 @@
 }
 
 :root {
-  --bg: #191919;
-  --text: #d4d4d4;
-  --text-muted: #8b8b8b;
-  --text-dimmer: #555;
-  --accent: #d4a574;
-  --code-bg: #0d1117;
-  --border: #2a2a2a;
-  --input-bg: #2a2a2a;
-  --user-bubble: #2a2a2a;
-  --error: #e55;
-  --success: #4a9;
-  --sidebar-bg: #141414;
+  --bg: #2F2E2B;
+  --bg-alt: #35332F;
+  --text: #E8E5DE;
+  --text-secondary: #B5B0A6;
+  --text-muted: #908B81;
+  --text-dimmer: #6D6860;
+  --accent: #DA7756;
+  --accent-hover: #E5886A;
+  --accent-bg: rgba(218, 119, 86, 0.12);
+  --code-bg: #1E1D1A;
+  --border: #3E3C37;
+  --border-subtle: #36342F;
+  --input-bg: #393733;
+  --user-bubble: #46423A;
+  --error: #E5534B;
+  --success: #57AB5A;
+  --sidebar-bg: #262522;
+  --sidebar-hover: #302E2A;
+  --sidebar-active: #3A3834;
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --content-width: 760px;
 }
 
 html, body {
   height: 100%;
   background: var(--bg);
   color: var(--text);
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 15px;
   line-height: 1.6;
   overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* --- Lucide icon defaults --- */
+/* --- Lucide icons --- */
 .lucide {
   vertical-align: middle;
   flex-shrink: 0;
@@ -46,7 +60,7 @@ html, body {
 }
 
 .icon-spin .lucide {
-  animation: spin 0.8s linear infinite;
+  animation: spin 1s linear infinite;
 }
 
 /* --- Layout --- */
@@ -56,12 +70,15 @@ html, body {
   height: 100dvh;
 }
 
-/* --- Sidebar --- */
+/* ==========================================================================
+   Sidebar
+   ========================================================================== */
+
 #sidebar {
   width: 260px;
   flex-shrink: 0;
   background: var(--sidebar-bg);
-  border-right: 1px solid var(--border);
+  border-right: 1px solid var(--border-subtle);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -71,60 +88,67 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px;
-  border-bottom: 1px solid var(--border);
+  padding: 16px 16px 12px;
 }
 
 .sidebar-title {
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 #new-session-btn {
-  width: 28px;
-  height: 28px;
-  border-radius: 6px;
-  border: 1px solid var(--border);
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: none;
   background: transparent;
-  color: var(--text);
+  color: var(--text-secondary);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.15s;
+  transition: background 0.15s, color 0.15s;
 }
 
 #new-session-btn .lucide {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
 }
 
 #new-session-btn:hover {
-  background: rgba(255,255,255,0.06);
+  background: var(--sidebar-hover);
+  color: var(--text);
 }
 
 #session-list {
   flex: 1;
   overflow-y: auto;
-  padding: 8px;
+  padding: 4px 8px;
 }
 
 .session-item {
   padding: 10px 12px;
-  border-radius: 8px;
+  border-radius: 10px;
   cursor: pointer;
-  font-size: 13px;
-  color: var(--text-muted);
+  font-size: 14px;
+  color: var(--text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   margin-bottom: 2px;
-  transition: background 0.15s;
+  transition: background 0.15s, color 0.15s;
 }
 
-.session-item:hover { background: rgba(255,255,255,0.05); }
+.session-item:hover {
+  background: var(--sidebar-hover);
+  color: var(--text);
+}
+
 .session-item.active {
-  background: rgba(255,255,255,0.08);
+  background: var(--sidebar-active);
   color: var(--text);
 }
 
@@ -134,9 +158,33 @@ html, body {
   height: 6px;
   border-radius: 50%;
   background: var(--accent);
-  animation: pulse 1.2s infinite;
-  margin-right: 6px;
+  animation: pulse 1.5s ease-in-out infinite;
+  margin-right: 8px;
   vertical-align: middle;
+}
+
+#sidebar-footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+#sidebar-footer a {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: color 0.15s;
+}
+
+#sidebar-footer a:hover {
+  color: var(--text-secondary);
+}
+
+#sidebar-footer .lucide {
+  width: 14px;
+  height: 14px;
 }
 
 /* --- Sidebar overlay (mobile) --- */
@@ -144,18 +192,20 @@ html, body {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0, 0, 0, 0.6);
   z-index: 99;
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
 }
 
 #sidebar-overlay.visible { display: block; }
 
-/* --- Hamburger button --- */
+/* --- Hamburger --- */
 #hamburger-btn {
   display: none;
   background: none;
   border: none;
-  color: var(--text);
+  color: var(--text-secondary);
   cursor: pointer;
   padding: 4px;
   margin-right: 10px;
@@ -167,23 +217,151 @@ html, body {
   height: 20px;
 }
 
-/* --- Main app area --- */
+/* ==========================================================================
+   Main App Area
+   ========================================================================== */
+
 #app {
   flex: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;
+  position: relative;
 }
 
-/* --- Header --- */
+/* --- HTTPS banner --- */
+#https-banner {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: rgba(218, 119, 86, 0.08);
+  border-bottom: 1px solid rgba(218, 119, 86, 0.15);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+#https-banner.hidden { display: none; }
+
+.https-banner-text {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.https-banner-text .lucide { width: 13px; height: 13px; color: var(--accent); }
+
+.https-banner-text a {
+  color: var(--accent);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.https-banner-text a:hover { text-decoration: underline; }
+
+#https-banner-close {
+  background: none;
+  border: none;
+  color: var(--text-dimmer);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+#https-banner-close .lucide { width: 14px; height: 14px; }
+#https-banner-close:hover { color: var(--text-secondary); }
+
+/* --- Connect overlay --- */
+#connect-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  z-index: 50;
+  transition: opacity 0.6s ease;
+}
+
+#connect-overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+#pixel-canvas {
+  position: relative;
+  width: 144px;
+  height: 108px;
+}
+
+.px {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  transition: none;
+}
+
+.px.settle {
+  transition: transform 0.6s cubic-bezier(0.34, 1.56, 0.64, 1), opacity 0.4s ease;
+}
+
+.px.scatter {
+  transition: transform 0.5s cubic-bezier(0.55, 0, 1, 0.45), opacity 0.5s ease;
+}
+
+.connect-verb {
+  margin-top: 24px;
+  font-size: 16px;
+  font-weight: 500;
+  min-height: 1.4em;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  background: linear-gradient(
+    90deg,
+    var(--accent) 0%,
+    var(--accent) 35%,
+    #f0c0a0 50%,
+    var(--accent) 65%,
+    var(--accent) 100%
+  );
+  background-size: 250% 100%;
+  background-position: 100% 0;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 2.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+.connect-verb.fade-out { opacity: 0; transform: translateY(-6px); }
+.connect-verb.fade-in { opacity: 1; transform: translateY(0); }
+
+.connect-status {
+  margin-top: 8px;
+  font-size: 13px;
+  color: var(--text-dimmer);
+}
+
+/* ==========================================================================
+   Header
+   ========================================================================== */
+
 #header {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: calc(var(--safe-top) + 10px) 20px 10px;
-  border-bottom: 1px solid var(--border);
-  min-height: 44px;
+  padding: calc(var(--safe-top) + 12px) 20px 12px;
+  min-height: 48px;
 }
 
 #header-left {
@@ -195,7 +373,7 @@ html, body {
 
 .project-name {
   font-weight: 600;
-  font-size: 14px;
+  font-size: 15px;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -219,89 +397,172 @@ html, body {
   transition: background 0.3s;
 }
 
+#terminal-btn {
+  display: none;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 3px 8px;
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 11px;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  max-width: 32px;
+  transition: max-width 0.3s ease, border-color 0.2s, color 0.15s, background 0.15s;
+}
+
+#terminal-btn .lucide { width: 12px; height: 12px; flex-shrink: 0; }
+#terminal-btn .terminal-cmd {
+  display: none;
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+#terminal-btn.visible { display: inline-flex; }
+#terminal-btn:hover { background: rgba(255,255,255,0.07); color: var(--text); border-color: var(--text-dimmer); }
+
+#terminal-btn.expanded {
+  max-width: 240px;
+  background: rgba(255,255,255,0.06);
+  border-color: var(--text-dimmer);
+}
+
+#terminal-btn.expanded .terminal-cmd { display: inline; }
+
+#terminal-btn.copied { color: var(--success); border-color: var(--success); }
+#terminal-btn.copied .terminal-cmd { color: var(--success); }
+
+#client-count {
+  background: var(--accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+}
+
+#client-count.hidden { display: none; }
+#client-count { cursor: pointer; }
+
+.tooltip {
+  position: fixed;
+  transform: translateX(-50%);
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 200;
+}
+
+.tooltip.visible { opacity: 1; }
+
 .status-dot.connected { background: var(--success); }
 .status-dot.processing {
   background: var(--accent);
-  animation: pulse 1.2s infinite;
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
-/* --- Messages area --- */
+/* ==========================================================================
+   Messages
+   ========================================================================== */
+
 #messages {
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  padding: 16px 0 8px;
+  padding: 20px 0 12px;
 }
 
 /* --- User message --- */
 .msg-user {
   display: flex;
   justify-content: flex-end;
-  max-width: 800px;
-  margin: 0 auto 14px;
+  max-width: var(--content-width);
+  margin: 0 auto 16px;
   padding: 0 20px;
 }
 
 .msg-user .bubble {
   background: var(--user-bubble);
-  border-radius: 18px;
-  padding: 10px 16px;
+  border-radius: 20px 20px 4px 20px;
+  padding: 12px 18px;
   max-width: 85%;
   font-size: 15px;
-  line-height: 1.5;
+  line-height: 1.55;
   word-break: break-word;
   white-space: pre-wrap;
+  color: var(--text);
 }
 
 /* --- Assistant message --- */
 .msg-assistant {
-  max-width: 800px;
-  margin: 0 auto 8px;
+  max-width: var(--content-width);
+  margin: 0 auto 12px;
   padding: 0 20px;
 }
 
-/* --- Markdown content --- */
+/* ==========================================================================
+   Markdown Content
+   ========================================================================== */
+
 .md-content {
   font-size: 15px;
-  line-height: 1.65;
+  line-height: 1.7;
   word-break: break-word;
+  color: var(--text);
 }
 
-.md-content p { margin-bottom: 12px; }
+.md-content p { margin-bottom: 14px; }
 .md-content p:last-child { margin-bottom: 0; }
 
 .md-content h1, .md-content h2, .md-content h3,
 .md-content h4, .md-content h5, .md-content h6 {
-  margin: 20px 0 10px;
+  margin: 24px 0 12px;
   font-weight: 600;
   line-height: 1.3;
+  color: var(--text);
 }
-.md-content h1 { font-size: 1.4em; }
+.md-content h1 { font-size: 1.35em; }
 .md-content h2 { font-size: 1.2em; }
 .md-content h3 { font-size: 1.1em; }
 
 .md-content code {
-  background: rgba(255,255,255,0.06);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-family: "SF Mono", Menlo, Monaco, "Cascadia Code", monospace;
-  font-size: 0.88em;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 2px 7px;
+  border-radius: 6px;
+  font-family: "SF Mono", "Fira Code", Menlo, Monaco, "Cascadia Code", monospace;
+  font-size: 0.87em;
 }
 
 .md-content pre {
   background: var(--code-bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  margin: 12px 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  margin: 14px 0;
   overflow: hidden;
 }
 
 .md-content pre code {
   display: block;
-  padding: 14px 16px;
+  padding: 16px 18px;
   overflow-x: auto;
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.55;
   background: none;
   border-radius: 0;
 }
@@ -317,53 +578,63 @@ html, body {
 
 .md-content ul, .md-content ol {
   padding-left: 24px;
-  margin: 8px 0;
+  margin: 10px 0;
 }
-.md-content li { margin-bottom: 4px; }
+.md-content li { margin-bottom: 5px; }
 
 .md-content blockquote {
-  border-left: 3px solid var(--border);
-  padding-left: 14px;
-  color: var(--text-muted);
-  margin: 10px 0;
+  border-left: 3px solid var(--accent);
+  padding-left: 16px;
+  color: var(--text-secondary);
+  margin: 12px 0;
 }
 
 .md-content hr {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 16px 0;
+  margin: 20px 0;
 }
 
 .md-content table {
   border-collapse: collapse;
-  margin: 12px 0;
+  margin: 14px 0;
   width: 100%;
   font-size: 14px;
 }
 .md-content th, .md-content td {
   border: 1px solid var(--border);
-  padding: 6px 10px;
+  padding: 8px 12px;
   text-align: left;
 }
 .md-content th {
-  background: rgba(255,255,255,0.04);
+  background: rgba(255, 255, 255, 0.04);
   font-weight: 600;
 }
 
-/* --- Thinking --- */
+/* ==========================================================================
+   Thinking
+   ========================================================================== */
+
 .thinking-item {
-  max-width: 800px;
-  margin: 4px auto;
+  max-width: var(--content-width);
+  margin: 6px auto;
   padding: 0 20px;
 }
 
 .thinking-header {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
   cursor: pointer;
-  padding: 6px 0;
+  padding: 6px 12px;
   user-select: none;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+
+.thinking-header:hover {
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .thinking-chevron {
@@ -385,11 +656,9 @@ html, body {
 .thinking-label {
   font-size: 13px;
   color: var(--text-muted);
-  font-style: italic;
 }
 
 .thinking-duration {
-  font-style: normal;
   color: var(--text-dimmer);
   font-size: 12px;
 }
@@ -408,45 +677,58 @@ html, body {
 
 .thinking-content {
   display: none;
-  padding: 4px 0 8px 18px;
+  padding: 8px 14px;
+  margin-top: 4px;
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--text-muted);
   white-space: pre-wrap;
   word-break: break-word;
   max-height: 300px;
   overflow-y: auto;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 8px;
 }
 
 .thinking-item.expanded .thinking-content { display: block; }
 
-/* --- Tool items --- */
+/* ==========================================================================
+   Tool Items
+   ========================================================================== */
+
 .tool-item {
-  max-width: 800px;
-  margin: 2px auto;
+  max-width: var(--content-width);
+  margin: 4px auto;
   padding: 0 20px;
 }
 
 .tool-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 0;
+  gap: 10px;
+  padding: 8px 12px;
   cursor: pointer;
   user-select: none;
+  background: rgba(255, 255, 255, 0.025);
+  border-radius: 10px;
+  transition: background 0.15s;
+}
+
+.tool-header:hover {
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .tool-bullet {
-  width: 6px;
-  height: 6px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
-  background: var(--accent);
+  background: var(--text-muted);
   flex-shrink: 0;
-  animation: pulse 1.2s infinite;
+  animation: pulse 1.5s ease-in-out infinite;
 }
 
 .tool-item.done .tool-bullet {
-  background: var(--success);
+  background: var(--text-dimmer);
   animation: none;
 }
 
@@ -458,7 +740,7 @@ html, body {
 .tool-name {
   font-weight: 600;
   font-size: 13px;
-  color: var(--accent);
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
@@ -482,24 +764,15 @@ html, body {
   justify-content: center;
 }
 
-.tool-status-icon .lucide {
-  width: 14px;
-  height: 14px;
-}
-
-.tool-status-icon .icon-spin .lucide {
-  width: 14px;
-  height: 14px;
-  color: var(--accent);
-}
-
-.tool-status-icon .check { color: var(--success); }
+.tool-status-icon .lucide { width: 14px; height: 14px; }
+.tool-status-icon .icon-spin .lucide { width: 14px; height: 14px; color: var(--text-muted); }
+.tool-status-icon .check { color: var(--text-dimmer); }
 .tool-status-icon .err-icon { color: var(--error); }
 
 .tool-subtitle {
   display: flex;
   gap: 6px;
-  padding: 0 0 4px 14px;
+  padding: 2px 0 4px 22px;
   font-size: 12px;
   color: var(--text-dimmer);
   font-style: italic;
@@ -514,23 +787,21 @@ html, body {
 }
 
 .tool-result-block {
-  margin: 4px 0 8px 0;
+  margin: 4px 0 8px 12px;
   background: var(--code-bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
   overflow: hidden;
   cursor: pointer;
 }
 
-.tool-result-block.collapsed {
-  display: none;
-}
+.tool-result-block.collapsed { display: none; }
 
 .tool-result-block pre {
   padding: 12px 14px;
   font-family: "SF Mono", Menlo, Monaco, monospace;
   font-size: 12px;
-  line-height: 1.5;
+  line-height: 1.55;
   color: var(--text-muted);
   white-space: pre-wrap;
   word-break: break-all;
@@ -543,16 +814,48 @@ html, body {
   color: var(--error);
 }
 
-/* --- Plan mode --- */
+/* --- Diff rendering --- */
+.tool-result-block pre.diff-content {
+  padding: 12px 14px;
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.diff-content .diff-add {
+  color: #3FB950;
+  background: rgba(63, 185, 80, 0.08);
+  display: inline-block;
+  width: 100%;
+}
+
+.diff-content .diff-del {
+  color: #F85149;
+  background: rgba(248, 81, 73, 0.08);
+  display: inline-block;
+  width: 100%;
+}
+
+.diff-content .diff-hunk { color: #8B949E; font-style: italic; }
+.diff-content .diff-file-header { color: #8B949E; font-weight: 600; }
+.diff-content .diff-ctx { color: var(--text-muted); }
+
+/* ==========================================================================
+   Plan Mode
+   ========================================================================== */
+
 .plan-banner {
-  max-width: 800px;
-  margin: 8px auto;
+  max-width: var(--content-width);
+  margin: 10px auto;
   padding: 0 20px;
 }
 
-.plan-banner > * {
-  vertical-align: middle;
-}
+.plan-banner > * { vertical-align: middle; }
 
 .plan-banner .plan-banner-icon {
   display: inline-flex;
@@ -560,39 +863,18 @@ html, body {
   margin-right: 8px;
 }
 
-.plan-banner .plan-banner-icon .lucide {
-  width: 16px;
-  height: 16px;
-}
-
-.plan-banner.plan-enter {
-  color: var(--accent);
-}
-
+.plan-banner .plan-banner-icon .lucide { width: 16px; height: 16px; }
+.plan-banner.plan-enter { color: var(--accent); }
 .plan-banner.plan-enter .plan-banner-icon { color: var(--accent); }
-
-.plan-banner .plan-banner-text {
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.plan-banner .plan-banner-hint {
-  font-size: 12px;
-  color: var(--text-muted);
-  font-style: italic;
-  margin-left: 8px;
-}
-
-.plan-banner.plan-exit {
-  color: var(--success);
-}
-
+.plan-banner .plan-banner-text { font-size: 13px; font-weight: 600; }
+.plan-banner .plan-banner-hint { font-size: 12px; color: var(--text-muted); font-style: italic; margin-left: 8px; }
+.plan-banner.plan-exit { color: var(--success); }
 .plan-banner.plan-exit .plan-banner-icon { color: var(--success); }
 
-/* Plan card */
+/* --- Plan card --- */
 .plan-card {
-  max-width: 800px;
-  margin: 8px auto;
+  max-width: var(--content-width);
+  margin: 10px auto;
   padding: 0 20px;
 }
 
@@ -600,116 +882,58 @@ html, body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 14px;
-  background: rgba(212, 165, 116, 0.08);
-  border: 1px solid rgba(212, 165, 116, 0.2);
-  border-radius: 10px 10px 0 0;
+  padding: 12px 16px;
+  background: var(--accent-bg);
+  border: 1px solid rgba(218, 119, 86, 0.2);
+  border-radius: 12px 12px 0 0;
   cursor: pointer;
   user-select: none;
 }
 
-.plan-card.collapsed .plan-card-header {
-  border-radius: 10px;
-}
+.plan-card.collapsed .plan-card-header { border-radius: 12px; }
 
-.plan-card-icon {
-  display: inline-flex;
-  color: var(--accent);
-}
-
-.plan-card-icon .lucide {
-  width: 16px;
-  height: 16px;
-}
-
-.plan-card-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--accent);
-  flex: 1;
-}
-
-.plan-card-chevron {
-  display: inline-flex;
-  color: var(--text-muted);
-  transition: transform 0.2s;
-}
-
-.plan-card-chevron .lucide {
-  width: 14px;
-  height: 14px;
-}
-
-.plan-card.collapsed .plan-card-chevron {
-  transform: rotate(-90deg);
-}
+.plan-card-icon { display: inline-flex; color: var(--accent); }
+.plan-card-icon .lucide { width: 16px; height: 16px; }
+.plan-card-title { font-size: 14px; font-weight: 600; color: var(--accent); flex: 1; }
+.plan-card-chevron { display: inline-flex; color: var(--text-muted); transition: transform 0.2s; }
+.plan-card-chevron .lucide { width: 14px; height: 14px; }
+.plan-card.collapsed .plan-card-chevron { transform: rotate(-90deg); }
 
 .plan-card-body {
-  padding: 14px 16px;
+  padding: 16px 18px;
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid var(--border);
   border-top: none;
-  border-radius: 0 0 10px 10px;
+  border-radius: 0 0 12px 12px;
   font-size: 14px;
-  line-height: 1.6;
+  line-height: 1.65;
   max-height: 500px;
   overflow-y: auto;
 }
 
-.plan-card.collapsed .plan-card-body {
-  display: none;
-}
+.plan-card.collapsed .plan-card-body { display: none; }
 
-/* Inherit markdown styles in plan card */
 .plan-card-body p { margin-bottom: 10px; }
 .plan-card-body p:last-child { margin-bottom: 0; }
-.plan-card-body h1, .plan-card-body h2, .plan-card-body h3 {
-  margin: 14px 0 8px;
-  font-weight: 600;
-  line-height: 1.3;
-}
+.plan-card-body h1, .plan-card-body h2, .plan-card-body h3 { margin: 14px 0 8px; font-weight: 600; line-height: 1.3; }
 .plan-card-body h1 { font-size: 1.3em; }
 .plan-card-body h2 { font-size: 1.15em; }
 .plan-card-body h3 { font-size: 1.05em; }
-.plan-card-body code {
-  background: rgba(255,255,255,0.06);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-family: "SF Mono", Menlo, Monaco, monospace;
-  font-size: 0.88em;
-}
-.plan-card-body pre {
-  background: var(--code-bg);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  margin: 8px 0;
-}
-.plan-card-body pre code {
-  display: block;
-  padding: 10px 12px;
-  overflow-x: auto;
-  font-size: 12px;
-  line-height: 1.5;
-  background: none;
-  border-radius: 0;
-}
-.plan-card-body ul, .plan-card-body ol {
-  padding-left: 22px;
-  margin: 6px 0;
-}
+.plan-card-body code { background: rgba(255,255,255,0.06); padding: 2px 6px; border-radius: 4px; font-family: "SF Mono", Menlo, Monaco, monospace; font-size: 0.88em; }
+.plan-card-body pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; margin: 8px 0; }
+.plan-card-body pre code { display: block; padding: 10px 12px; overflow-x: auto; font-size: 12px; line-height: 1.5; background: none; border-radius: 0; }
+.plan-card-body ul, .plan-card-body ol { padding-left: 22px; margin: 6px 0; }
 .plan-card-body li { margin-bottom: 3px; }
 .plan-card-body strong { font-weight: 600; }
-.plan-card-body blockquote {
-  border-left: 3px solid var(--border);
-  padding-left: 12px;
-  color: var(--text-muted);
-  margin: 8px 0;
-}
+.plan-card-body blockquote { border-left: 3px solid var(--border); padding-left: 12px; color: var(--text-muted); margin: 8px 0; }
 
-/* --- Todo widget --- */
+/* ==========================================================================
+   Todo Widget
+   ========================================================================== */
+
 .todo-widget {
-  max-width: 800px;
-  margin: 10px auto;
+  max-width: var(--content-width);
+  margin: 12px auto;
   padding: 0 20px;
 }
 
@@ -717,34 +941,16 @@ html, body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 14px;
+  padding: 10px 16px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--border);
-  border-radius: 10px 10px 0 0;
+  border-radius: 12px 12px 0 0;
 }
 
-.todo-header-icon {
-  display: inline-flex;
-  color: var(--accent);
-}
-
-.todo-header-icon .lucide {
-  width: 16px;
-  height: 16px;
-}
-
-.todo-header-title {
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-  flex: 1;
-}
-
-.todo-header-count {
-  font-size: 12px;
-  color: var(--text-muted);
-  font-family: "SF Mono", Menlo, Monaco, monospace;
-}
+.todo-header-icon { display: inline-flex; color: var(--accent); }
+.todo-header-icon .lucide { width: 16px; height: 16px; }
+.todo-header-title { font-size: 13px; font-weight: 600; color: var(--text); flex: 1; }
+.todo-header-count { font-size: 12px; color: var(--text-muted); font-family: "SF Mono", Menlo, Monaco, monospace; }
 
 .todo-progress {
   height: 2px;
@@ -762,7 +968,7 @@ html, body {
 .todo-items {
   border: 1px solid var(--border);
   border-top: none;
-  border-radius: 0 0 10px 10px;
+  border-radius: 0 0 12px 12px;
   overflow: hidden;
 }
 
@@ -770,54 +976,39 @@ html, body {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 14px;
+  padding: 10px 16px;
   font-size: 13px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
-.todo-item:last-child {
-  border-bottom: none;
-}
+.todo-item:last-child { border-bottom: none; }
 
-.todo-item-icon {
-  display: inline-flex;
-  flex-shrink: 0;
-}
-
-.todo-item-icon .lucide {
-  width: 16px;
-  height: 16px;
-}
-
+.todo-item-icon { display: inline-flex; flex-shrink: 0; }
+.todo-item-icon .lucide { width: 16px; height: 16px; }
 .todo-item.pending .todo-item-icon { color: var(--text-dimmer); }
 .todo-item.in-progress .todo-item-icon { color: var(--accent); }
 .todo-item.completed .todo-item-icon { color: var(--success); }
 
-.todo-item-text {
-  flex: 1;
-  line-height: 1.4;
-}
-
+.todo-item-text { flex: 1; line-height: 1.4; }
 .todo-item.pending .todo-item-text { color: var(--text-muted); }
 .todo-item.in-progress .todo-item-text { color: var(--text); }
-.todo-item.completed .todo-item-text {
-  color: var(--text-dimmer);
-  text-decoration: line-through;
-}
+.todo-item.completed .todo-item-text { color: var(--text-dimmer); text-decoration: line-through; }
 
-/* --- Turn metadata --- */
+/* ==========================================================================
+   Turn Metadata & System Messages
+   ========================================================================== */
+
 .turn-meta {
-  max-width: 800px;
-  margin: 4px auto 16px;
+  max-width: var(--content-width);
+  margin: 4px auto 20px;
   padding: 0 20px;
   font-size: 12px;
   color: var(--text-dimmer);
 }
 
-/* --- System messages --- */
 .sys-msg {
-  max-width: 800px;
-  margin: 4px auto;
+  max-width: var(--content-width);
+  margin: 6px auto;
   padding: 0 20px;
   text-align: center;
 }
@@ -830,10 +1021,13 @@ html, body {
 
 .sys-msg.error .sys-text { color: var(--error); }
 
-/* --- Inline activity indicator --- */
+/* ==========================================================================
+   Activity Indicator
+   ========================================================================== */
+
 .activity-inline {
-  max-width: 800px;
-  margin: 8px auto;
+  max-width: var(--content-width);
+  margin: 10px auto;
   padding: 0 20px;
   display: flex;
   align-items: center;
@@ -857,38 +1051,52 @@ html, body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  background: linear-gradient(90deg, var(--accent) 0%, #F0C8A0 50%, var(--accent) 100%);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: text-shimmer 3s ease-in-out infinite;
 }
 
-/* --- AskUserQuestion --- */
+@keyframes text-shimmer {
+  0% { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+
+/* ==========================================================================
+   AskUserQuestion
+   ========================================================================== */
+
 .ask-user-container {
-  max-width: 800px;
-  margin: 8px auto;
+  max-width: var(--content-width);
+  margin: 12px auto;
   padding: 0 20px;
 }
 
 .ask-user-question {
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
 .ask-user-question-text {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 500;
   color: var(--text);
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .ask-user-options {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .ask-user-option {
-  background: var(--input-bg);
+  background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 8px 14px;
+  border-radius: 12px;
+  padding: 10px 16px;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
   text-align: left;
@@ -898,7 +1106,7 @@ html, body {
 }
 
 .ask-user-option:hover {
-  background: rgba(255,255,255,0.08);
+  background: rgba(255, 255, 255, 0.06);
   border-color: var(--accent);
 }
 
@@ -911,12 +1119,12 @@ html, body {
 .ask-user-option .option-desc {
   font-size: 12px;
   color: var(--text-muted);
-  margin-top: 2px;
+  margin-top: 3px;
 }
 
 .ask-user-option.selected {
   border-color: var(--accent);
-  background: rgba(212, 165, 116, 0.1);
+  background: var(--accent-bg);
 }
 
 .ask-user-other {
@@ -929,64 +1137,182 @@ html, body {
   flex: 1;
   background: var(--input-bg);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 10px;
   color: var(--text);
   font-size: 14px;
   font-family: inherit;
-  padding: 8px 12px;
+  padding: 10px 14px;
   outline: none;
   transition: border-color 0.2s;
 }
 
-.ask-user-other input:focus {
-  border-color: #444;
-}
-
-.ask-user-other input::placeholder {
-  color: var(--text-muted);
-}
+.ask-user-other input:focus { border-color: var(--text-dimmer); }
+.ask-user-other input::placeholder { color: var(--text-muted); }
 
 .ask-user-submit {
   background: var(--accent);
-  color: var(--bg);
+  color: #fff;
   border: none;
-  border-radius: 8px;
-  padding: 8px 16px;
+  border-radius: 10px;
+  padding: 10px 18px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
   flex-shrink: 0;
-  transition: opacity 0.15s;
+  transition: background 0.15s;
 }
 
-.ask-user-submit:hover {
-  opacity: 0.85;
+.ask-user-submit:hover { background: var(--accent-hover); }
+.ask-user-submit:disabled { opacity: 0.4; cursor: default; }
+
+.ask-user-container.answered .ask-user-option { cursor: default; opacity: 0.5; }
+.ask-user-container.answered .ask-user-option.selected { opacity: 1; }
+.ask-user-container.answered .ask-user-other input { opacity: 0.5; pointer-events: none; }
+.ask-user-container.answered .ask-user-submit { display: none; }
+
+/* ==========================================================================
+   Permission Request
+   ========================================================================== */
+
+.permission-container {
+  max-width: var(--content-width);
+  margin: 12px auto;
+  padding: 0 20px;
 }
 
-.ask-user-submit:disabled {
-  opacity: 0.4;
-  cursor: default;
+.permission-container > :not(:last-child) { margin-bottom: 0; }
+
+.permission-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-bottom: none;
+  border-radius: 12px 12px 0 0;
+  color: var(--text-secondary);
 }
 
-.ask-user-container.answered .ask-user-option {
-  cursor: default;
-  opacity: 0.5;
+.permission-icon { display: inline-flex; flex-shrink: 0; color: var(--text-muted); }
+.permission-icon .lucide { width: 16px; height: 16px; }
+.permission-title { font-size: 13px; font-weight: 500; }
+
+.permission-body {
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-top: none;
+  border-bottom: none;
+  background: rgba(255, 255, 255, 0.015);
 }
 
-.ask-user-container.answered .ask-user-option.selected {
-  opacity: 1;
+.permission-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
 }
 
-.ask-user-container.answered .ask-user-other input {
-  opacity: 0.5;
-  pointer-events: none;
+.permission-tool-name {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--text);
+  flex-shrink: 0;
 }
 
-.ask-user-container.answered .ask-user-submit {
-  display: none;
+.permission-tool-desc {
+  font-size: 13px;
+  color: var(--text-muted);
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-/* --- Images in user bubbles --- */
+.permission-reason {
+  font-size: 12px;
+  color: var(--text-dimmer);
+  font-style: italic;
+  margin-bottom: 8px;
+}
+
+.permission-details { margin-top: 8px; }
+.permission-details summary {
+  font-size: 12px;
+  color: var(--text-dimmer);
+  cursor: pointer;
+  user-select: none;
+  padding: 4px 0;
+}
+.permission-details summary:hover { color: var(--text-muted); }
+
+.permission-details pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 6px 0 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.permission-actions {
+  display: flex;
+  gap: 8px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-top: none;
+  border-radius: 0 0 12px 12px;
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.permission-btn {
+  padding: 7px 16px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s;
+}
+
+.permission-btn:hover { opacity: 0.85; }
+
+.permission-allow { background: var(--text-dimmer); color: #fff; }
+.permission-allow:hover { background: var(--text-muted); opacity: 1; }
+.permission-allow-session { background: var(--bg-alt); color: var(--text-secondary); border-color: var(--border); }
+.permission-allow-session:hover { background: var(--input-bg); opacity: 1; }
+.permission-deny { background: transparent; border-color: var(--border); color: var(--text-muted); }
+.permission-deny:hover { background: rgba(229, 83, 75, 0.08); border-color: var(--error); color: var(--error); opacity: 1; }
+
+/* Resolved states */
+.permission-container.resolved .permission-btn { display: none; }
+.permission-decision-label { font-size: 13px; font-weight: 500; }
+
+.permission-container.resolved-allowed .permission-decision-label { color: var(--text-muted); }
+
+.permission-container.resolved-denied .permission-header {
+  border-color: rgba(229, 83, 75, 0.15);
+}
+.permission-container.resolved-denied .permission-body { border-color: rgba(229, 83, 75, 0.15); }
+.permission-container.resolved-denied .permission-actions { border-color: rgba(229, 83, 75, 0.15); }
+.permission-container.resolved-denied .permission-decision-label { color: var(--error); }
+
+.permission-container.resolved-cancelled .permission-decision-label { color: var(--text-dimmer); }
+
+.permission-container.resolved { opacity: 0.5; }
+
+/* ==========================================================================
+   Images
+   ========================================================================== */
+
 .bubble-images {
   display: flex;
   flex-wrap: wrap;
@@ -994,28 +1320,22 @@ html, body {
   margin-bottom: 8px;
 }
 
-.bubble-images:last-child {
-  margin-bottom: 0;
-}
+.bubble-images:last-child { margin-bottom: 0; }
 
 .bubble-img {
   max-width: 240px;
   max-height: 180px;
-  border-radius: 10px;
+  border-radius: 12px;
   object-fit: cover;
   cursor: pointer;
 }
 
-.bubble-img:hover {
-  opacity: 0.85;
-}
+.bubble-img:hover { opacity: 0.85; }
 
 /* --- Image preview bar --- */
 #image-preview-bar {
   display: none;
-  padding: 8px 16px 0;
-  max-width: 800px;
-  margin: 0 auto;
+  padding: 8px 0 4px;
 }
 
 #image-preview-bar.visible {
@@ -1030,10 +1350,10 @@ html, body {
 }
 
 .image-preview-thumb img {
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: 10px;
   border: 1px solid var(--border);
 }
 
@@ -1044,9 +1364,8 @@ html, body {
   width: 20px;
   height: 20px;
   border-radius: 50%;
-  border: none;
-  background: var(--bg);
   border: 1px solid var(--border);
+  background: var(--bg);
   color: var(--text-muted);
   cursor: pointer;
   display: flex;
@@ -1055,10 +1374,7 @@ html, body {
   padding: 0;
 }
 
-.image-preview-remove .lucide {
-  width: 12px;
-  height: 12px;
-}
+.image-preview-remove .lucide { width: 12px; height: 12px; }
 
 .image-preview-remove:hover {
   background: var(--error);
@@ -1066,41 +1382,55 @@ html, body {
   border-color: var(--error);
 }
 
-/* --- Input area --- */
+/* ==========================================================================
+   Input Area — Claude-style unified container
+   ========================================================================== */
+
 #input-area {
   flex-shrink: 0;
-  border-top: 1px solid var(--border);
-  padding: 10px 16px calc(var(--safe-bottom) + 10px);
+  padding: 8px 16px calc(var(--safe-bottom) + 12px);
+}
+
+#input-wrapper {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  position: relative;
 }
 
 #input-row {
   display: flex;
   align-items: flex-end;
-  gap: 8px;
-  max-width: 800px;
-  margin: 0 auto;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 6px 6px 6px 20px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+#input-row:focus-within {
+  border-color: var(--text-dimmer);
+  box-shadow: 0 0 0 1px rgba(109, 104, 96, 0.15);
 }
 
 #input {
   flex: 1;
-  background: var(--input-bg);
-  border: 1px solid var(--border);
-  border-radius: 12px;
+  background: transparent;
+  border: none;
   color: var(--text);
   font-size: 16px;
   font-family: inherit;
   line-height: 1.4;
-  padding: 10px 16px;
+  padding: 8px 0;
   resize: none;
   outline: none;
-  min-height: 42px;
+  min-height: 24px;
   max-height: 120px;
   overflow-y: auto;
-  transition: border-color 0.2s;
 }
 
-#input:focus { border-color: #444; }
-#input::placeholder { color: var(--text-muted); }
+#input::placeholder {
+  color: var(--text-muted);
+}
 
 #send-btn {
   flex-shrink: 0;
@@ -1109,12 +1439,13 @@ html, body {
   border-radius: 50%;
   border: none;
   background: var(--accent);
-  color: var(--bg);
+  color: #fff;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: opacity 0.2s;
+  transition: background 0.15s, opacity 0.15s;
+  touch-action: manipulation;
 }
 
 #send-btn .lucide {
@@ -1122,20 +1453,23 @@ html, body {
   height: 18px;
 }
 
-#send-btn:disabled { opacity: 0.3; cursor: default; }
-#send-btn:active:not(:disabled) { opacity: 0.7; }
-
-#send-btn.stop {
-  background: var(--error);
-  color: #fff;
+#send-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
 }
 
-#send-btn.stop .lucide {
-  width: 14px;
-  height: 14px;
+#send-btn:disabled {
+  opacity: 0.25;
+  cursor: default;
 }
 
-/* --- Slash command autocomplete --- */
+#send-btn:active:not(:disabled) {
+  opacity: 0.7;
+}
+
+/* ==========================================================================
+   Slash Command Autocomplete
+   ========================================================================== */
+
 #slash-menu {
   display: none;
   position: absolute;
@@ -1144,11 +1478,11 @@ html, body {
   right: 0;
   max-height: 240px;
   overflow-y: auto;
-  background: #252525;
+  background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 10px;
+  border-radius: 14px;
   margin-bottom: 8px;
-  box-shadow: 0 -4px 20px rgba(0,0,0,0.4);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
   z-index: 10;
 }
 
@@ -1157,17 +1491,17 @@ html, body {
 .slash-item {
   display: flex;
   align-items: center;
-  padding: 10px 14px;
+  padding: 12px 16px;
   cursor: pointer;
-  gap: 10px;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  gap: 12px;
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .slash-item:last-child { border-bottom: none; }
 
 .slash-item:hover,
 .slash-item.active {
-  background: rgba(255,255,255,0.06);
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .slash-item .slash-cmd {
@@ -1182,7 +1516,10 @@ html, body {
   font-size: 13px;
 }
 
-/* --- Animations --- */
+/* ==========================================================================
+   Animations
+   ========================================================================== */
+
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.3; }
@@ -1197,7 +1534,10 @@ html, body {
   50% { opacity: 0.5; transform: scale(0.85); }
 }
 
-/* --- Mobile responsive --- */
+/* ==========================================================================
+   Mobile Responsive
+   ========================================================================== */
+
 @media (max-width: 768px) {
   #sidebar {
     position: fixed;
@@ -1217,5 +1557,13 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .msg-user .bubble {
+    max-width: 90%;
+  }
+
+  #input-row {
+    border-radius: 20px;
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,10 +1,114 @@
 const http = require("http");
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
-const { spawn } = require("child_process");
 const { WebSocketServer } = require("ws");
 
+// SDK loaded dynamically (ESM module)
+var sdkModule = null;
+function getSDK() {
+  if (!sdkModule) sdkModule = import("@anthropic-ai/claude-agent-sdk");
+  return sdkModule;
+}
+
+// Async message queue for streaming input to SDK
+function createMessageQueue() {
+  var queue = [];
+  var waiting = null;
+  var ended = false;
+  return {
+    push: function(msg) {
+      if (waiting) {
+        var resolve = waiting;
+        waiting = null;
+        resolve({ value: msg, done: false });
+      } else {
+        queue.push(msg);
+      }
+    },
+    end: function() {
+      ended = true;
+      if (waiting) {
+        var resolve = waiting;
+        waiting = null;
+        resolve({ value: undefined, done: true });
+      }
+    },
+    [Symbol.asyncIterator]: function() {
+      return {
+        next: function() {
+          if (queue.length > 0) {
+            return Promise.resolve({ value: queue.shift(), done: false });
+          }
+          if (ended) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          return new Promise(function(resolve) {
+            waiting = resolve;
+          });
+        }
+      };
+    }
+  };
+}
+
 const publicDir = path.join(__dirname, "public");
+
+function generateAuthToken(pin) {
+  return crypto.createHash("sha256").update("claude-relay:" + pin).digest("hex");
+}
+
+function parseCookies(req) {
+  var cookies = {};
+  var header = req.headers.cookie || "";
+  header.split(";").forEach(function(part) {
+    var pair = part.trim().split("=");
+    if (pair.length === 2) cookies[pair[0]] = pair[1];
+  });
+  return cookies;
+}
+
+function isAuthed(req, authToken) {
+  if (!authToken) return true;
+  var cookies = parseCookies(req);
+  return cookies["relay_auth"] === authToken;
+}
+
+function pinPageHtml() {
+  return '<!DOCTYPE html><html lang="en"><head>' +
+    '<meta charset="UTF-8">' +
+    '<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">' +
+    '<meta name="apple-mobile-web-app-capable" content="yes">' +
+    '<title>Claude Relay</title>' +
+    '<style>' +
+    '*{margin:0;padding:0;box-sizing:border-box}' +
+    'body{background:#2F2E2B;color:#E8E5DE;font-family:system-ui,-apple-system,sans-serif;' +
+    'min-height:100dvh;display:flex;align-items:center;justify-content:center;padding:20px}' +
+    '.c{max-width:320px;width:100%;text-align:center}' +
+    'h1{color:#DA7756;font-size:22px;margin-bottom:8px}' +
+    '.sub{color:#908B81;font-size:14px;margin-bottom:32px}' +
+    'input{width:100%;background:#393733;border:1px solid #3E3C37;border-radius:12px;' +
+    'color:#E8E5DE;font-size:24px;letter-spacing:12px;text-align:center;padding:14px;' +
+    'outline:none;font-family:inherit;-webkit-text-security:disc}' +
+    'input:focus{border-color:#DA7756}' +
+    'input::placeholder{letter-spacing:0;font-size:15px;color:#6D6860}' +
+    '.err{color:#E5534B;font-size:13px;margin-top:12px;min-height:1.3em}' +
+    '</style></head><body><div class="c">' +
+    '<h1>Claude Relay</h1>' +
+    '<div class="sub">Enter PIN to continue</div>' +
+    '<input id="pin" type="tel" maxlength="6" placeholder="6-digit PIN" autocomplete="off" inputmode="numeric">' +
+    '<div class="err" id="err"></div>' +
+    '<script>' +
+    'var inp=document.getElementById("pin"),err=document.getElementById("err");' +
+    'inp.focus();' +
+    'inp.addEventListener("input",function(){' +
+    'if(inp.value.length===6){' +
+    'fetch("/auth",{method:"POST",headers:{"Content-Type":"application/json"},' +
+    'body:JSON.stringify({pin:inp.value})})' +
+    '.then(function(r){if(r.ok)location.reload();else{err.textContent="Wrong PIN";inp.value="";inp.focus()}})' +
+    '.catch(function(){err.textContent="Connection error"})}});' +
+    '</script></div></body></html>';
+}
 
 const MIME_TYPES = {
   ".html": "text/html",
@@ -41,7 +145,94 @@ function serveStatic(req, res) {
   }
 }
 
-function createServer(cwd) {
+function setupPageHtml(httpsUrl) {
+  var httpUrl = "/app";
+  return '<!DOCTYPE html><html lang="en"><head>' +
+    '<meta charset="UTF-8">' +
+    '<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">' +
+    '<meta name="apple-mobile-web-app-capable" content="yes">' +
+    '<title>Claude Relay</title>' +
+    '<style>' +
+    '*{margin:0;padding:0;box-sizing:border-box}' +
+    'body{background:#2F2E2B;color:#E8E5DE;font-family:system-ui,-apple-system,sans-serif;min-height:100dvh;display:flex;justify-content:center;padding:env(safe-area-inset-top,0) 20px 40px}' +
+    '.c{max-width:480px;width:100%;text-align:center;padding-top:25dvh}' +
+    '.c.show-setup{padding-top:40px}' +
+    'h1{color:#DA7756;font-size:24px;margin:0 0 6px}' +
+    // Loading state
+    '#loading{display:flex;flex-direction:column;align-items:center;gap:20px;padding:32px 0}' +
+    '.glow{width:100px;height:100px;border-radius:50%;' +
+    'background:radial-gradient(circle,rgba(218,119,86,0.15) 0%,transparent 70%);' +
+    'display:flex;align-items:center;justify-content:center;' +
+    'animation:breathe 3s ease-in-out infinite}' +
+    '.dot{width:12px;height:12px;border-radius:50%;background:#DA7756;' +
+    'animation:pulse 2s ease-in-out infinite}' +
+    '@keyframes breathe{0%,100%{transform:scale(1);opacity:.7}50%{transform:scale(1.2);opacity:1}}' +
+    '@keyframes pulse{0%,100%{box-shadow:0 0 15px rgba(218,119,86,0.3)}50%{box-shadow:0 0 35px rgba(218,119,86,0.7)}}' +
+    '.loading-text{color:#908B81;font-size:14px}' +
+    // Setup section
+    '#setup{display:none;text-align:left}' +
+    '.explain{background:rgba(218,119,86,0.06);border:1px solid rgba(218,119,86,0.15);border-radius:12px;padding:16px 18px;margin-bottom:28px;text-align:left}' +
+    '.explain-title{font-size:14px;font-weight:600;color:#DA7756;margin-bottom:6px}' +
+    '.explain-text{font-size:13px;line-height:1.6;color:#908B81}' +
+    '.step{display:flex;gap:14px;margin-bottom:20px}' +
+    '.num{width:28px;height:28px;border-radius:50%;background:#DA7756;color:#fff;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14px;flex-shrink:0;margin-top:2px}' +
+    '.txt{font-size:15px;line-height:1.6}' +
+    '.txt .note{font-size:13px;color:#6D6860;margin-top:4px}' +
+    'a.btn{display:inline-block;background:#DA7756;color:#fff;text-decoration:none;padding:12px 28px;border-radius:12px;font-weight:600;font-size:15px;margin:8px 0;text-align:center}' +
+    'a.btn.outline{background:transparent;border:1px solid #DA7756;color:#DA7756}' +
+    '.sep{border:none;border-top:1px solid #3E3C37;margin:28px 0}' +
+    '.skip{display:block;text-align:center;color:#6D6860;font-size:13px;text-decoration:none;margin-top:16px}' +
+    '.skip:hover{color:#908B81}' +
+    '</style></head><body><div class="c" id="container">' +
+    '<h1>Claude Relay</h1>' +
+    '<div id="loading"><div class="glow"><div class="dot"></div></div>' +
+    '<div class="loading-text">Connecting...</div></div>' +
+    '<div id="setup">' +
+    '<div class="explain">' +
+    '<div class="explain-title">Secure your connection</div>' +
+    '<div class="explain-text">' +
+    'Install a certificate to encrypt all traffic between this device and the relay. ' +
+    'Without it, anyone on the same network could intercept your data.<br><br>' +
+    'The certificate is generated locally on your machine and does not grant any additional access.' +
+    '</div></div>' +
+    '<div class="step"><div class="num">1</div><div class="txt">' +
+    'Download the certificate.<br>' +
+    '<a class="btn" href="/ca/download">Download Certificate</a>' +
+    '</div></div>' +
+    '<div id="steps-ios">' +
+    '<div class="step"><div class="num">2</div><div class="txt">' +
+    'Open <b>Settings</b> and tap the <b>Profile Downloaded</b> banner to install.' +
+    '<div class="note">If the banner is gone: Settings &gt; General &gt; VPN &amp; Device Management</div>' +
+    '</div></div>' +
+    '<div class="step"><div class="num">3</div><div class="txt">' +
+    'Go to <b>Settings &gt; General &gt; About &gt; Certificate Trust Settings</b> and enable full trust.' +
+    '</div></div></div>' +
+    '<div id="steps-android" style="display:none">' +
+    '<div class="step"><div class="num">2</div><div class="txt">' +
+    'Open the downloaded file, or go to <b>Settings &gt; Security &gt; Install a certificate &gt; CA certificate</b>.' +
+    '<div class="note">Path may vary by device. Search "certificate" in Settings if needed.</div>' +
+    '</div></div></div>' +
+    '<hr class="sep">' +
+    '<a class="btn" href="' + httpsUrl + '">Open Claude Relay</a>' +
+    '<a class="skip" href="' + httpUrl + '">Skip, use without HTTPS</a>' +
+    '</div>' +
+    '<script>' +
+    'if(/Android/i.test(navigator.userAgent)){' +
+    'document.getElementById("steps-ios").style.display="none";' +
+    'document.getElementById("steps-android").style.display="block"}' +
+    'var show=function(){document.getElementById("loading").style.display="none";' +
+    'document.getElementById("setup").style.display="block";' +
+    'document.getElementById("container").classList.add("show-setup")};' +
+    'var c=new AbortController();setTimeout(function(){c.abort()},2000);' +
+    'fetch("' + httpsUrl + '/info",{signal:c.signal})' +
+    '.then(function(){location.replace("' + httpsUrl + '")})' +
+    '.catch(show);' +
+    '</script>' +
+    '</div></body></html>';
+}
+
+function createServer(cwd, tlsOptions, caPath, pin, mainPort) {
+  var authToken = pin ? generateAuthToken(pin) : null;
   const project = path.basename(cwd);
 
   // --- Multi-session state ---
@@ -49,7 +240,8 @@ function createServer(cwd) {
   let sessions = new Map();     // localId -> session object
   let activeSessionId = null;   // currently active local ID
   let slashCommands = null;     // shared across sessions
-  let activeWs = null;
+  let skillNames = null;        // Claude-only skills to filter from slash menu
+  let clients = new Set();
 
   // --- Session persistence ---
   var sessionsDir = path.join(cwd, ".claude-relay", "sessions");
@@ -111,11 +303,13 @@ function createServer(cwd) {
       var localId = nextLocalId++;
       var session = {
         localId: localId,
-        proc: null,
+        queryInstance: null,
+        messageQueue: null,
         cliSessionId: m.cliSessionId,
-        buffer: "",
         blocks: {},
         sentToolResults: {},
+        pendingPermissions: {},
+        pendingAskUser: {},
         isProcessing: false,
         title: m.title || "",
         createdAt: m.createdAt || Date.now(),
@@ -129,8 +323,24 @@ function createServer(cwd) {
   loadSessions();
 
   function send(obj) {
-    if (activeWs && activeWs.readyState === 1) {
-      activeWs.send(JSON.stringify(obj));
+    var data = JSON.stringify(obj);
+    for (var ws of clients) {
+      if (ws.readyState === 1) ws.send(data);
+    }
+  }
+
+  function sendTo(ws, obj) {
+    if (ws.readyState === 1) ws.send(JSON.stringify(obj));
+  }
+
+  function broadcastClientCount() {
+    send({ type: "client_count", count: clients.size });
+  }
+
+  function sendToOthers(sender, obj) {
+    var data = JSON.stringify(obj);
+    for (var ws of clients) {
+      if (ws !== sender && ws.readyState === 1) ws.send(data);
     }
   }
 
@@ -165,18 +375,19 @@ function createServer(cwd) {
     var localId = nextLocalId++;
     var session = {
       localId: localId,
-      proc: null,
+      queryInstance: null,
+      messageQueue: null,
       cliSessionId: null,
-      buffer: "",
       blocks: {},
       sentToolResults: {},
+      pendingPermissions: {},
+      pendingAskUser: {},
       isProcessing: false,
       title: "",
       createdAt: Date.now(),
       history: [],
     };
     sessions.set(localId, session);
-    spawnProcess(session);
     switchSession(localId);
     return session;
   }
@@ -192,36 +403,54 @@ function createServer(cwd) {
     if (!session) return;
 
     activeSessionId = localId;
-    send({ type: "session_switched", id: localId });
+    send({ type: "session_switched", id: localId, cliSessionId: session.cliSessionId || null });
     broadcastSessionList();
     replayHistory(session);
 
     if (session.isProcessing) {
       send({ type: "status", status: "processing" });
     }
+
+    // Re-send any pending permission requests
+    var pendingIds = Object.keys(session.pendingPermissions);
+    for (var i = 0; i < pendingIds.length; i++) {
+      var p = session.pendingPermissions[pendingIds[i]];
+      send({
+        type: "permission_request_pending",
+        requestId: p.requestId,
+        toolName: p.toolName,
+        toolInput: p.toolInput,
+        toolUseId: p.toolUseId,
+        decisionReason: p.decisionReason,
+      });
+    }
   }
 
-  function processLine(session, line) {
-    if (!line.trim()) return;
+  // --- SDK message processing ---
 
-    var parsed;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      return;
-    }
-
+  function processSDKMessage(session, parsed) {
+    // Extract session_id from any message that carries it
     if (parsed.session_id && !session.cliSessionId) {
       session.cliSessionId = parsed.session_id;
       saveSessionFile(session);
+      if (session.localId === activeSessionId) {
+        send({ type: "session_id", cliSessionId: session.cliSessionId });
+      }
     } else if (parsed.session_id) {
       session.cliSessionId = parsed.session_id;
     }
 
     // Cache slash_commands from CLI init message
-    if (parsed.type === "system" && parsed.subtype === "init" && parsed.slash_commands) {
-      slashCommands = parsed.slash_commands;
-      send({ type: "slash_commands", commands: slashCommands });
+    if (parsed.type === "system" && parsed.subtype === "init") {
+      if (parsed.skills) {
+        skillNames = new Set(parsed.skills);
+      }
+      if (parsed.slash_commands) {
+        slashCommands = parsed.slash_commands.filter(function(name) {
+          return !skillNames || !skillNames.has(name);
+        });
+        send({ type: "slash_commands", commands: slashCommands });
+      }
     }
 
     if (parsed.type === "stream_event" && parsed.event) {
@@ -272,31 +501,55 @@ function createServer(cwd) {
 
     } else if ((parsed.type === "assistant" || parsed.type === "user") && parsed.message && parsed.message.content) {
       var content = parsed.message.content;
-      for (var i = 0; i < content.length; i++) {
-        var block = content[i];
-        if (block.type === "tool_result" && !session.sentToolResults[block.tool_use_id]) {
-          var resultText = "";
-          if (typeof block.content === "string") {
-            resultText = block.content;
-          } else if (Array.isArray(block.content)) {
-            resultText = block.content
-              .filter(function(c) { return c.type === "text"; })
-              .map(function(c) { return c.text; })
-              .join("\n");
+
+      // Check for local slash command output in user messages
+      if (parsed.type === "user") {
+        var fullText = "";
+        if (typeof content === "string") {
+          fullText = content;
+        } else if (Array.isArray(content)) {
+          fullText = content
+            .filter(function(c) { return c.type === "text"; })
+            .map(function(c) { return c.text; })
+            .join("\n");
+        }
+        if (fullText.indexOf("local-command-stdout") !== -1) {
+          var m = fullText.match(/<local-command-stdout>([\s\S]*?)<\/local-command-stdout>/);
+          if (m) {
+            sendAndRecord(session, { type: "slash_command_result", text: m[1].trim() });
           }
-          session.sentToolResults[block.tool_use_id] = true;
-          sendAndRecord(session, {
-            type: "tool_result",
-            id: block.tool_use_id,
-            content: resultText,
-            is_error: block.is_error || false,
-          });
+        }
+      }
+
+      if (Array.isArray(content)) {
+        for (var i = 0; i < content.length; i++) {
+          var block = content[i];
+          if (block.type === "tool_result" && !session.sentToolResults[block.tool_use_id]) {
+            var resultText = "";
+            if (typeof block.content === "string") {
+              resultText = block.content;
+            } else if (Array.isArray(block.content)) {
+              resultText = block.content
+                .filter(function(c) { return c.type === "text"; })
+                .map(function(c) { return c.text; })
+                .join("\n");
+            }
+            session.sentToolResults[block.tool_use_id] = true;
+            sendAndRecord(session, {
+              type: "tool_result",
+              id: block.tool_use_id,
+              content: resultText,
+              is_error: block.is_error || false,
+            });
+          }
         }
       }
 
     } else if (parsed.type === "result") {
       session.blocks = {};
       session.sentToolResults = {};
+      session.pendingPermissions = {};
+      session.pendingAskUser = {};
       session.isProcessing = false;
       sendAndRecord(session, {
         type: "result",
@@ -306,124 +559,157 @@ function createServer(cwd) {
       });
       sendAndRecord(session, { type: "done", code: 0 });
       broadcastSessionList();
+
+    } else if (parsed.type && parsed.type !== "system" && parsed.type !== "user") {
     }
   }
 
-  function spawnProcess(session) {
-    var args = [
-      "-p",
-      "--verbose",
-      "--output-format", "stream-json",
-      "--input-format", "stream-json",
-      "--include-partial-messages",
-    ];
+  // --- SDK query lifecycle ---
 
-    if (session.cliSessionId) {
-      args.push("--resume", session.cliSessionId);
+  function handleCanUseTool(session, toolName, input, opts) {
+    // AskUserQuestion: wait for user answers via WebSocket
+    if (toolName === "AskUserQuestion") {
+      return new Promise(function(resolve) {
+        session.pendingAskUser[opts.toolUseID] = {
+          resolve: resolve,
+          input: input,
+        };
+        // The client sees this tool via stream_event content blocks
+        // and renders the AskUserQuestion UI automatically.
+        // We just wait for the answer to come back.
+        if (opts.signal) {
+          opts.signal.addEventListener("abort", function() {
+            delete session.pendingAskUser[opts.toolUseID];
+            resolve({ behavior: "deny", message: "Cancelled" });
+          });
+        }
+      });
     }
 
-    session.buffer = "";
+    // Regular tool permission request: send to client and wait
+    return new Promise(function(resolve) {
+      var requestId = crypto.randomUUID();
+      session.pendingPermissions[requestId] = {
+        resolve: resolve,
+        requestId: requestId,
+        toolName: toolName,
+        toolInput: input,
+        toolUseId: opts.toolUseID,
+        decisionReason: opts.decisionReason || "",
+      };
+
+      var permMsg = {
+        type: "permission_request",
+        requestId: requestId,
+        toolName: toolName,
+        toolInput: input,
+        toolUseId: opts.toolUseID,
+        decisionReason: opts.decisionReason || "",
+      };
+      sendAndRecord(session, permMsg);
+
+      if (opts.signal) {
+        opts.signal.addEventListener("abort", function() {
+          delete session.pendingPermissions[requestId];
+          sendAndRecord(session, { type: "permission_cancel", requestId: requestId });
+          resolve({ behavior: "deny", message: "Request cancelled" });
+        });
+      }
+    });
+  }
+
+  async function processQueryStream(session) {
+    try {
+      for await (var msg of session.queryInstance) {
+        processSDKMessage(session, msg);
+      }
+    } catch (err) {
+      if (session.isProcessing) {
+        session.isProcessing = false;
+        if (err.name === "AbortError" || (session.abortController && session.abortController.signal.aborted)) {
+          sendAndRecord(session, { type: "info", text: "Interrupted \u00b7 What should Claude do instead?" });
+          sendAndRecord(session, { type: "done", code: 0 });
+        } else {
+          sendAndRecord(session, { type: "error", text: "Claude process error: " + err.message });
+          sendAndRecord(session, { type: "done", code: 1 });
+        }
+        broadcastSessionList();
+      }
+    } finally {
+      session.queryInstance = null;
+      session.messageQueue = null;
+      session.abortController = null;
+    }
+  }
+
+  async function startQuery(session, text, images) {
+    var sdk = await getSDK();
+
+    session.messageQueue = createMessageQueue();
     session.blocks = {};
     session.sentToolResults = {};
 
-    session.proc = spawn("claude", args, {
-      cwd: cwd,
-      env: Object.assign({}, process.env),
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    session.proc.stdout.on("data", function(chunk) {
-      session.buffer += chunk.toString();
-      var lines = session.buffer.split("\n");
-      session.buffer = lines.pop();
-
-      for (var i = 0; i < lines.length; i++) {
-        processLine(session, lines[i]);
-      }
-    });
-
-    session.proc.stderr.on("data", function(chunk) {
-      var errText = chunk.toString();
-      if (errText.includes("Error") || errText.includes("error")) {
-        if (session.localId === activeSessionId) {
-          send({ type: "stderr", text: errText });
-        }
-      }
-    });
-
-    session.proc.on("close", function(code) {
-      if (session.buffer.trim()) {
-        processLine(session, session.buffer);
-        session.buffer = "";
-      }
-
-      session.proc = null;
-      session.blocks = {};
-
-      if (session.isProcessing) {
-        session.isProcessing = false;
-        sendAndRecord(session, { type: "error", text: "Claude process exited unexpectedly (code " + code + ")" });
-        sendAndRecord(session, { type: "done", code: code || 1 });
-        broadcastSessionList();
-      }
-    });
-
-    session.proc.on("error", function(err) {
-      session.proc = null;
-      session.isProcessing = false;
-      sendAndRecord(session, { type: "error", text: "Failed to spawn claude: " + err.message });
-      sendAndRecord(session, { type: "done", code: 1 });
-      broadcastSessionList();
-    });
-  }
-
-  function writeMessage(session, text, images) {
+    // Build initial user message
     var content = [];
-
     if (images && images.length > 0) {
       for (var i = 0; i < images.length; i++) {
         content.push({
           type: "image",
-          source: {
-            type: "base64",
-            media_type: images[i].mediaType,
-            data: images[i].data,
-          },
+          source: { type: "base64", media_type: images[i].mediaType, data: images[i].data },
         });
       }
     }
-
     if (text) {
       content.push({ type: "text", text: text });
     }
 
-    var msg = {
+    session.messageQueue.push({
       type: "user",
-      session_id: "",
-      parent_tool_use_id: null,
-      message: {
-        role: "user",
-        content: content,
+      message: { role: "user", content: content },
+    });
+
+    session.abortController = new AbortController();
+
+    var queryOptions = {
+      cwd: cwd,
+      includePartialMessages: true,
+      extraArgs: { "replay-user-messages": null },
+      abortController: session.abortController,
+      canUseTool: function(toolName, input, opts) {
+        return handleCanUseTool(session, toolName, input, opts);
       },
     };
-    session.proc.stdin.write(JSON.stringify(msg) + "\n");
+
+    if (session.cliSessionId) {
+      queryOptions.resume = session.cliSessionId;
+    }
+
+    session.queryInstance = sdk.query({
+      prompt: session.messageQueue,
+      options: queryOptions,
+    });
+
+    processQueryStream(session).catch(function(err) {
+    });
   }
 
-  function writeToolResult(session, toolUseId, resultText) {
-    var msg = {
+  function pushMessage(session, text, images) {
+    var content = [];
+    if (images && images.length > 0) {
+      for (var i = 0; i < images.length; i++) {
+        content.push({
+          type: "image",
+          source: { type: "base64", media_type: images[i].mediaType, data: images[i].data },
+        });
+      }
+    }
+    if (text) {
+      content.push({ type: "text", text: text });
+    }
+    session.messageQueue.push({
       type: "user",
-      session_id: "",
-      parent_tool_use_id: null,
-      message: {
-        role: "user",
-        content: [{
-          type: "tool_result",
-          tool_use_id: toolUseId,
-          content: resultText,
-        }],
-      },
-    };
-    session.proc.stdin.write(JSON.stringify(msg) + "\n");
+      message: { role: "user", content: content },
+    });
   }
 
   // --- Spawn initial session only if no persisted sessions ---
@@ -435,11 +721,49 @@ function createServer(cwd) {
     activeSessionId = lastSession.localId;
   }
 
-  // --- HTTP server ---
-  var server = http.createServer(function(req, res) {
+  // --- App HTTP handler ---
+  var pinPage = pinPageHtml();
+
+  var appHandler = function(req, res) {
+    // PIN auth endpoint
+    if (req.method === "POST" && req.url === "/auth") {
+      var body = "";
+      req.on("data", function(chunk) { body += chunk; });
+      req.on("end", function() {
+        try {
+          var data = JSON.parse(body);
+          if (authToken && generateAuthToken(data.pin) === authToken) {
+            res.writeHead(200, {
+              "Set-Cookie": "relay_auth=" + authToken + "; Path=/; HttpOnly; SameSite=Strict; Max-Age=31536000",
+              "Content-Type": "application/json",
+            });
+            res.end('{"ok":true}');
+          } else {
+            res.writeHead(401, { "Content-Type": "application/json" });
+            res.end('{"ok":false}');
+          }
+        } catch (e) {
+          res.writeHead(400);
+          res.end("Bad request");
+        }
+      });
+      return;
+    }
+
+    // Allow /info without auth (used by setup page HTTPS check)
     if (req.method === "GET" && req.url === "/info") {
-      res.writeHead(200, { "Content-Type": "application/json" });
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      });
       res.end(JSON.stringify({ cwd: cwd, project: project }));
+      return;
+    }
+
+    // Check auth for everything else
+    if (!isAuthed(req, authToken)) {
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      res.end(pinPage);
       return;
     }
 
@@ -449,28 +773,124 @@ function createServer(cwd) {
 
     res.writeHead(404);
     res.end("Not found");
-  });
+  };
+
+  // --- Server setup ---
+  // Entry server (HTTP) always listens on the main branded port.
+  // When TLS is available, HTTPS runs on port+1 and the entry server
+  // auto-redirects (via setup page) once the CA is trusted.
+  var entryServer;
+  var httpsServer = null;
+  var wssTargets;
+
+  if (tlsOptions) {
+    var httpsPort = mainPort + 1;
+    httpsServer = require("https").createServer(tlsOptions, appHandler);
+
+    var caContent = caPath ? fs.readFileSync(caPath) : null;
+    entryServer = http.createServer(function(req, res) {
+      // CA certificate download
+      if (req.url === "/ca/download" && caContent) {
+        res.writeHead(200, {
+          "Content-Type": "application/x-pem-file",
+          "Content-Disposition": 'attachment; filename="claude-relay-ca.pem"',
+        });
+        res.end(caContent);
+        return;
+      }
+      // Certificate setup page
+      if (req.url === "/setup") {
+        var host = req.headers.host || "localhost";
+        var hostname = host.split(":")[0];
+        var httpsUrl = "https://" + hostname + ":" + httpsPort;
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(setupPageHtml(httpsUrl));
+        return;
+      }
+      // HTTPS info endpoint for client banner
+      if (req.url === "/https-info") {
+        var host = req.headers.host || "localhost";
+        var hostname = host.split(":")[0];
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          httpsPort: httpsPort,
+          httpsUrl: "https://" + hostname + ":" + httpsPort,
+          setupUrl: "/setup",
+        }));
+        return;
+      }
+      // Serve app directly over HTTP
+      appHandler(req, res);
+    });
+
+    wssTargets = [httpsServer, entryServer];
+  } else {
+    entryServer = http.createServer(appHandler);
+    wssTargets = [entryServer];
+  }
 
   // --- WebSocket ---
-  var wss = new WebSocketServer({ server: server });
+  var wss = new WebSocketServer({ noServer: true });
+
+  function handleUpgrade(req, socket, head) {
+    if (!isAuthed(req, authToken)) {
+      socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, function(ws) {
+      wss.emit("connection", ws, req);
+    });
+  }
+
+  for (var i = 0; i < wssTargets.length; i++) {
+    wssTargets[i].on("upgrade", handleUpgrade);
+  }
 
   wss.on("connection", function(ws) {
-    activeWs = ws;
+    clients.add(ws);
+    broadcastClientCount();
 
-    // Send cached state
-    send({ type: "info", cwd: cwd, project: project });
+    // Send cached state to this client only
+    sendTo(ws, { type: "info", cwd: cwd, project: project });
     if (slashCommands) {
-      send({ type: "slash_commands", commands: slashCommands });
+      sendTo(ws, { type: "slash_commands", commands: slashCommands });
     }
-    broadcastSessionList();
 
-    // Restore active session
+    // Session list to this client
+    sendTo(ws, {
+      type: "session_list",
+      sessions: [...sessions.values()].map(function(s) {
+        return {
+          id: s.localId,
+          title: s.title || "New Session",
+          active: s.localId === activeSessionId,
+          isProcessing: s.isProcessing,
+        };
+      }),
+    });
+
+    // Restore active session for this client
     var active = getActiveSession();
     if (active) {
-      send({ type: "session_switched", id: active.localId });
-      replayHistory(active);
+      sendTo(ws, { type: "session_switched", id: active.localId, cliSessionId: active.cliSessionId || null });
+      for (var i = 0; i < active.history.length; i++) {
+        sendTo(ws, active.history[i]);
+      }
       if (active.isProcessing) {
-        send({ type: "status", status: "processing" });
+        sendTo(ws, { type: "status", status: "processing" });
+      }
+      var pendingIds = Object.keys(active.pendingPermissions);
+      for (var i = 0; i < pendingIds.length; i++) {
+        var p = active.pendingPermissions[pendingIds[i]];
+        sendTo(ws, {
+          type: "permission_request_pending",
+          requestId: p.requestId,
+          toolName: p.toolName,
+          toolInput: p.toolInput,
+          toolUseId: p.toolUseId,
+          decisionReason: p.decisionReason,
+        });
       }
     }
 
@@ -496,21 +916,56 @@ function createServer(cwd) {
 
       if (msg.type === "stop") {
         var session = getActiveSession();
-        if (session && session.proc && session.isProcessing) {
-          session.proc.kill("SIGINT");
+        if (session && session.abortController && session.isProcessing) {
+          session.abortController.abort();
         }
         return;
       }
 
       if (msg.type === "ask_user_response") {
         var session = getActiveSession();
-        if (!session || !session.proc) return;
+        if (!session) return;
 
         var toolId = msg.toolId;
         var answers = msg.answers || {};
-        var resultText = JSON.stringify({ answers: answers });
+        var pending = session.pendingAskUser[toolId];
+        if (!pending) return;
 
-        writeToolResult(session, toolId, resultText);
+        delete session.pendingAskUser[toolId];
+        pending.resolve({
+          behavior: "allow",
+          updatedInput: Object.assign({}, pending.input, { answers: answers }),
+        });
+        return;
+      }
+
+      if (msg.type === "input_sync") {
+        sendToOthers(ws, msg);
+        return;
+      }
+
+      if (msg.type === "permission_response") {
+        var session = getActiveSession();
+        if (!session) return;
+
+        var requestId = msg.requestId;
+        var decision = msg.decision; // "allow" | "deny" | "allow_always"
+        var pending = session.pendingPermissions[requestId];
+        if (!pending) return;
+
+        delete session.pendingPermissions[requestId];
+
+        if (decision === "allow" || decision === "allow_always") {
+          pending.resolve({ behavior: "allow", updatedInput: pending.toolInput });
+        } else {
+          pending.resolve({ behavior: "deny", message: "User denied permission" });
+        }
+
+        sendAndRecord(session, {
+          type: "permission_resolved",
+          requestId: requestId,
+          decision: decision,
+        });
         return;
       }
 
@@ -535,6 +990,7 @@ function createServer(cwd) {
       }
       session.history.push(userMsg);
       appendToSessionFile(session, userMsg);
+      sendToOthers(ws, userMsg);
       send({ type: "status", status: "processing" });
 
       // Set title from first user message
@@ -544,22 +1000,56 @@ function createServer(cwd) {
         broadcastSessionList();
       }
 
-      // Respawn if process died
-      if (!session.proc) {
-        spawnProcess(session);
+      // Start new query or push to existing one
+      if (!session.queryInstance) {
+        startQuery(session, msg.text || "", msg.images);
+      } else {
+        pushMessage(session, msg.text || "", msg.images);
       }
-
-      writeMessage(session, msg.text || "", msg.images);
       broadcastSessionList();
     });
 
     ws.on("close", function() {
-      if (activeWs === ws) activeWs = null;
-      // Don't kill procs — they persist across reconnects
+      clients.delete(ws);
+      broadcastClientCount();
     });
   });
 
-  return server;
+  // Warm up: grab slash_commands from SDK init message, then abort
+  (async function warmup() {
+    try {
+      var sdk = await getSDK();
+      var ac = new AbortController();
+      var mq = createMessageQueue();
+      mq.push({ type: "user", message: { role: "user", content: [{ type: "text", text: "hi" }] } });
+      mq.end();
+      var stream = sdk.query({
+        prompt: mq,
+        options: { cwd: cwd, abortController: ac },
+      });
+      for await (var msg of stream) {
+        if (msg.type === "system" && msg.subtype === "init") {
+          if (msg.skills) {
+            skillNames = new Set(msg.skills);
+          }
+          if (msg.slash_commands) {
+            slashCommands = msg.slash_commands.filter(function(name) {
+              return !skillNames || !skillNames.has(name);
+            });
+            if (clients.size > 0) {
+              send({ type: "slash_commands", commands: slashCommands });
+            }
+          }
+          ac.abort();
+          break;
+        }
+      }
+    } catch (e) {
+      // Expected: AbortError after we abort
+    }
+  })();
+
+  return { entryServer: entryServer, httpsServer: httpsServer };
 }
 
 module.exports = { createServer };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,331 @@
 {
   "name": "claude-relay",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-relay",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.38",
         "qrcode-terminal": "^0.12.0",
         "ws": "^8.18.0"
       },
       "bin": {
-        "claude-relay": "bin/cli.js"
+        "claude-relay": "bin/cli.js",
+        "claude-relay-dev": "bin/cli.js"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.38.tgz",
+      "integrity": "sha512-U1vpf3rlSkw1qUlzC6CBibBA30ouQnla9JnuqYFLQ2zBb1U2NUCXIElrnV7RwWrI5e9ZKCHgR+1uaCwROONo7w==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-linuxmusl-arm64": "^0.33.5",
+        "@img/sharp-linuxmusl-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/qrcode-terminal": {
@@ -46,6 +355,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
   "name": "claude-relay",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Access Claude Code on your machine, from anywhere. One command, no config.",
   "bin": {
-    "claude-relay": "./bin/cli.js"
+    "claude-relay": "./bin/cli.js",
+    "claude-relay-dev": "./bin/cli.js"
+  },
+  "scripts": {
+    "prepack": "npm pkg delete bin.claude-relay-dev",
+    "postpack": "npm pkg set bin.claude-relay-dev=./bin/cli.js"
   },
   "files": [
     "bin/",
@@ -23,9 +28,13 @@
     "type": "git",
     "url": "git+https://github.com/chadbyte/claude-relay.git"
   },
+  "bugs": {
+    "url": "https://github.com/chadbyte/claude-relay/issues"
+  },
   "homepage": "https://github.com/chadbyte/claude-relay#readme",
   "author": "Chad",
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.38",
     "qrcode-terminal": "^0.12.0",
     "ws": "^8.18.0"
   },


### PR DESCRIPTION
- Add HTTPS with mkcert auto-cert generation and --no-https flag
- Replace confirm prompt with interactive clack-style setup (PIN, keep-awake toggle)
- Add permission request UI with Allow / Allow for Session / Deny
- Add real-time input sync and user message broadcast across devices
- Add connected client count badge
- Add terminal button to copy claude --resume command
- Add connection overlay with pixel character animation
- Add diff syntax highlighting in tool results
- Add PWA manifest for standalone mobile experience
- Redesign color palette and typography to align with Claude Desktop
- Change default port from 3456 to 2633