### PR TITLE
feat(ui): add browser notifications when Claude finishes

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1396,6 +1396,10 @@
           processing = false;
           setStatus("connected");
           tools = {};
+          if (document.hidden && notifPermission === "granted") {
+            showDoneNotification();
+            playDoneSound();
+          }
           break;
 
         case "stderr":
@@ -1768,6 +1772,68 @@
       tooltipEl.classList.remove("visible");
     }
   });
+
+  // --- Browser notifications ---
+  var notifPermission = ("Notification" in window) ? Notification.permission : "denied";
+
+  function requestNotifPermission() {
+    if (!("Notification" in window)) return;
+    if (Notification.permission === "granted") {
+      notifPermission = "granted";
+      return;
+    }
+    if (Notification.permission !== "denied") {
+      Notification.requestPermission().then(function(p) {
+        notifPermission = p;
+      });
+    }
+  }
+
+  document.addEventListener("click", function requestOnce() {
+    requestNotifPermission();
+    document.removeEventListener("click", requestOnce);
+  }, { once: true });
+
+  function playDoneSound() {
+    try {
+      var ctx = new (window.AudioContext || window.webkitAudioContext)();
+      var osc = ctx.createOscillator();
+      var gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = 880;
+      gain.gain.value = 0.1;
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start();
+      gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.3);
+      osc.stop(ctx.currentTime + 0.3);
+    } catch(e) {}
+  }
+
+  function showDoneNotification() {
+    var lastAssistant = messagesEl.querySelector(".msg-assistant:last-of-type .md-content");
+    var preview = lastAssistant ? lastAssistant.textContent.substring(0, 100) : "Response ready";
+
+    var sessionTitle = "Claude";
+    var activeItem = sessionListEl.querySelector(".session-item.active");
+    if (activeItem) {
+      var textEl = activeItem.querySelector(".session-item-text");
+      if (textEl) sessionTitle = textEl.textContent || "Claude";
+      else sessionTitle = activeItem.textContent || "Claude";
+    }
+
+    var n = new Notification(sessionTitle, {
+      body: preview,
+      tag: "claude-done",
+    });
+
+    n.onclick = function() {
+      window.focus();
+      n.close();
+    };
+
+    setTimeout(function() { n.close(); }, 5000);
+  }
 
   // --- Init ---
   lucide.createIcons();


### PR DESCRIPTION
Shows a browser notification with response preview and plays a subtle sound when Claude finishes processing and the tab is not visible. Notification permission is requested on first user click. Auto-closes after 5s, clicking focuses the tab.