### PR TITLE
feat(ui): add message search with Cmd/Ctrl+F

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -16,6 +16,13 @@
   var newSessionBtn = $("new-session-btn");
   var hamburgerBtn = $("hamburger-btn");
   var imagePreviewBar = $("image-preview-bar");
+  var searchBtn = $("search-btn");
+  var searchBar = $("search-bar");
+  var searchInput = $("search-input");
+  var searchCount = $("search-count");
+  var searchPrevBtn = $("search-prev");
+  var searchNextBtn = $("search-next");
+  var searchCloseBtn = $("search-close");
   var connectOverlay = $("connect-overlay");
   var connectVerbEl = $("connect-verb");
   var connectStatusEl = $("connect-status");
@@ -39,6 +46,10 @@
   var slashActiveIdx = -1;
   var slashFiltered = [];
   var pendingImages = []; // [{data: base64, mediaType: "image/png"}]
+  var searchOpen = false;
+  var searchMatches = [];
+  var searchCurrentIdx = -1;
+  var searchDebounce = null;
   var pendingPermissions = {}; // requestId -> container element
   var cliSessionId = null;
 
@@ -955,6 +966,9 @@
   }
 
   function resetClientState() {
+    clearSearchHighlights();
+    searchMatches = [];
+    searchCurrentIdx = -1;
     messagesEl.innerHTML = "";
     currentMsgEl = null;
     currentFullText = "";
@@ -1258,6 +1272,9 @@
           cliSessionId = msg.cliSessionId || null;
           resetClientState();
           updateTerminalBtn();
+          if (searchOpen && searchInput.value.trim()) {
+            setTimeout(performSearch, 100);
+          }
           break;
 
         case "session_id":
@@ -1409,6 +1426,12 @@
         case "error":
           setActivity(null);
           addSystemMessage(msg.text, true);
+          break;
+
+        case "search_results":
+          if (searchOpen) {
+            renderSearchSessionResults(msg.results || []);
+          }
           break;
       }
     };
@@ -1766,6 +1789,184 @@
       }, 2000);
     } else {
       tooltipEl.classList.remove("visible");
+    }
+  });
+
+  // --- Message search ---
+  var searchSessionResults = $("search-session-results");
+
+  function toggleSearch() {
+    searchOpen = !searchOpen;
+    if (searchOpen) {
+      searchBar.classList.remove("hidden");
+      searchInput.focus();
+    } else {
+      searchBar.classList.add("hidden");
+      clearSearchHighlights();
+      searchInput.value = "";
+      searchCount.textContent = "";
+      searchMatches = [];
+      searchCurrentIdx = -1;
+      searchSessionResults.innerHTML = "";
+      searchSessionResults.classList.add("hidden");
+    }
+  }
+
+  function performSearch() {
+    clearSearchHighlights();
+    var query = searchInput.value.trim().toLowerCase();
+    if (!query) {
+      searchCount.textContent = "";
+      searchMatches = [];
+      searchCurrentIdx = -1;
+      searchSessionResults.innerHTML = "";
+      searchSessionResults.classList.add("hidden");
+      return;
+    }
+
+    // Local DOM search for current session
+    searchMatches = [];
+    var nodes = messagesEl.querySelectorAll(
+      ".md-content, .bubble, .tool-desc, .thinking-content, .tool-result-block pre"
+    );
+
+    nodes.forEach(function(node) {
+      if (node.textContent.toLowerCase().indexOf(query) !== -1) {
+        highlightMatchesInNode(node, query);
+        searchMatches.push(node);
+      }
+    });
+
+    if (searchMatches.length > 0) {
+      searchCurrentIdx = 0;
+      searchCount.textContent = "1/" + searchMatches.length;
+      scrollToMatch(0);
+    } else {
+      searchCount.textContent = "0 results";
+      searchCurrentIdx = -1;
+    }
+
+    // Cross-session search via server
+    if (ws && connected) {
+      ws.send(JSON.stringify({ type: "search_sessions", query: query }));
+    }
+  }
+
+  function renderSearchSessionResults(results) {
+    var others = results.filter(function(r) { return !r.active; });
+    if (others.length === 0) {
+      searchSessionResults.innerHTML = "";
+      searchSessionResults.classList.add("hidden");
+      return;
+    }
+
+    searchSessionResults.classList.remove("hidden");
+    searchSessionResults.innerHTML = '<div class="search-sessions-label">Also found in:</div>';
+    for (var i = 0; i < others.length; i++) {
+      var r = others[i];
+      var el = document.createElement("button");
+      el.className = "search-session-item";
+      el.innerHTML = '<span class="search-session-title">' + escapeHtml(r.title) + '</span>' +
+        '<span class="search-session-count">' + r.matchCount + ' match' + (r.matchCount > 1 ? 'es' : '') + '</span>';
+      el.addEventListener("click", (function(id) {
+        return function() {
+          if (ws && connected) {
+            ws.send(JSON.stringify({ type: "switch_session", id: id }));
+          }
+        };
+      })(r.id));
+      searchSessionResults.appendChild(el);
+    }
+  }
+
+  function highlightMatchesInNode(el, query) {
+    var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    var nodesToProcess = [];
+    while (walker.nextNode()) {
+      nodesToProcess.push(walker.currentNode);
+    }
+    nodesToProcess.forEach(function(textNode) {
+      var text = textNode.textContent;
+      var lower = text.toLowerCase();
+      var idx = lower.indexOf(query);
+      if (idx === -1) return;
+
+      var frag = document.createDocumentFragment();
+      var lastIdx = 0;
+      while (idx !== -1) {
+        frag.appendChild(document.createTextNode(text.substring(lastIdx, idx)));
+        var mark = document.createElement("mark");
+        mark.className = "search-highlight";
+        mark.textContent = text.substring(idx, idx + query.length);
+        frag.appendChild(mark);
+        lastIdx = idx + query.length;
+        idx = lower.indexOf(query, lastIdx);
+      }
+      frag.appendChild(document.createTextNode(text.substring(lastIdx)));
+      textNode.parentNode.replaceChild(frag, textNode);
+    });
+  }
+
+  function clearSearchHighlights() {
+    messagesEl.querySelectorAll("mark.search-highlight").forEach(function(mark) {
+      var parent = mark.parentNode;
+      parent.replaceChild(document.createTextNode(mark.textContent), mark);
+      parent.normalize();
+    });
+  }
+
+  function scrollToMatch(idx) {
+    if (idx < 0 || idx >= searchMatches.length) return;
+
+    messagesEl.querySelectorAll(".search-current").forEach(function(el) {
+      el.classList.remove("search-current");
+    });
+
+    var node = searchMatches[idx];
+    var marks = node.querySelectorAll("mark.search-highlight");
+    if (marks.length > 0) {
+      marks[0].classList.add("search-current");
+      marks[0].scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+
+    searchCount.textContent = (idx + 1) + "/" + searchMatches.length;
+  }
+
+  function navigateSearch(dir) {
+    if (searchMatches.length === 0) return;
+    searchCurrentIdx = (searchCurrentIdx + dir + searchMatches.length) % searchMatches.length;
+    scrollToMatch(searchCurrentIdx);
+  }
+
+  searchBtn.addEventListener("click", toggleSearch);
+  searchCloseBtn.addEventListener("click", toggleSearch);
+
+  searchInput.addEventListener("input", function() {
+    if (searchDebounce) clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(performSearch, 200);
+  });
+
+  searchInput.addEventListener("keydown", function(e) {
+    if (e.key === "Escape") {
+      toggleSearch();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) {
+        navigateSearch(-1);
+      } else {
+        navigateSearch(1);
+      }
+    }
+  });
+
+  searchPrevBtn.addEventListener("click", function() { navigateSearch(-1); });
+  searchNextBtn.addEventListener("click", function() { navigateSearch(1); });
+
+  document.addEventListener("keydown", function(e) {
+    if ((e.ctrlKey || e.metaKey) && e.key === "f") {
+      e.preventDefault();
+      if (!searchOpen) toggleSearch();
+      else searchInput.focus();
     }
   });
 

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -39,6 +39,9 @@
         <button id="hamburger-btn" aria-label="Toggle sidebar"><i data-lucide="menu"></i></button>
         <span class="project-name" id="project-name">Connecting...</span>
       </div>
+      <div id="header-actions">
+        <button id="search-btn" aria-label="Search messages"><i data-lucide="search"></i></button>
+      </div>
       <div class="status">
         <button id="terminal-btn" title="Continue in terminal"><i data-lucide="terminal"></i><span class="terminal-cmd"></span></button>
         <span id="client-count" class="hidden"></span>
@@ -46,6 +49,15 @@
         <span class="status-dot" id="status-dot"></span>
       </div>
     </div>
+
+    <div id="search-bar" class="hidden">
+      <input id="search-input" type="text" placeholder="Search messages..." />
+      <span id="search-count"></span>
+      <button id="search-prev" aria-label="Previous match"><i data-lucide="chevron-up"></i></button>
+      <button id="search-next" aria-label="Next match"><i data-lucide="chevron-down"></i></button>
+      <button id="search-close" aria-label="Close search"><i data-lucide="x"></i></button>
+    </div>
+    <div id="search-session-results" class="hidden"></div>
 
     <div id="connect-overlay">
       <div id="pixel-canvas"></div>

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -1534,6 +1534,148 @@ html, body {
   50% { opacity: 0.5; transform: scale(0.85); }
 }
 
+/* --- Search --- */
+#header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#search-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#search-btn .lucide { width: 18px; height: 18px; }
+#search-btn:hover { color: var(--text); }
+
+#search-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--sidebar-bg);
+}
+
+#search-bar.hidden { display: none; }
+
+#search-input {
+  flex: 1;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+  padding: 6px 12px;
+  outline: none;
+  min-width: 0;
+}
+
+#search-input:focus { border-color: #444; }
+#search-input::placeholder { color: var(--text-muted); }
+
+#search-count {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  min-width: 50px;
+  text-align: center;
+}
+
+#search-bar button {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+#search-bar button:hover {
+  background: rgba(255,255,255,0.06);
+  color: var(--text);
+}
+
+#search-bar button .lucide { width: 16px; height: 16px; }
+
+mark.search-highlight {
+  background: rgba(212, 165, 116, 0.3);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+mark.search-highlight.search-current {
+  background: rgba(212, 165, 116, 0.6);
+  outline: 1px solid var(--accent);
+}
+
+#search-session-results {
+  padding: 6px 16px 8px;
+  border-bottom: 1px solid var(--border);
+  background: var(--sidebar-bg);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+#search-session-results.hidden { display: none; }
+
+.search-sessions-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-right: 2px;
+}
+
+.search-session-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 4px 10px;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.search-session-item:hover {
+  background: rgba(255,255,255,0.08);
+  border-color: var(--accent);
+}
+
+.search-session-title {
+  font-size: 13px;
+  color: var(--text);
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-session-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 /* ==========================================================================
    Mobile Responsive
    ========================================================================== */

--- a/lib/server.js
+++ b/lib/server.js
@@ -914,6 +914,35 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort) {
         return;
       }
 
+      if (msg.type === "search_sessions") {
+        var query = (msg.query || "").toLowerCase().trim();
+        if (!query) {
+          sendTo(ws, { type: "search_results", results: [] });
+          return;
+        }
+        var results = [];
+        sessions.forEach(function(session) {
+          var matchCount = 0;
+          for (var i = 0; i < session.history.length; i++) {
+            var entry = session.history[i];
+            var text = entry.text || entry.content || "";
+            if (typeof text === "string" && text.toLowerCase().indexOf(query) !== -1) {
+              matchCount++;
+            }
+          }
+          if (matchCount > 0) {
+            results.push({
+              id: session.localId,
+              title: session.title || "New Session",
+              matchCount: matchCount,
+              active: session.localId === activeSessionId,
+            });
+          }
+        });
+        sendTo(ws, { type: "search_results", results: results });
+        return;
+      }
+
       if (msg.type === "stop") {
         var session = getActiveSession();
         if (session && session.abortController && session.isProcessing) {


### PR DESCRIPTION
Adds a search bar in the header to search through messages in the current session and suggest presence in others. Highlights matching text using <mark> elements, supports navigating between matches with Enter/Shift+Enter or prev/next buttons. Search is debounced and operates on rendered DOM content. Clears on session switch.