### PR TITLE
feat(ui): add session deletion

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -129,12 +129,29 @@
       el.className = "session-item" + (s.active ? " active" : "");
       el.dataset.sessionId = s.id;
 
-      var html = "";
+      var textSpan = document.createElement("span");
+      textSpan.className = "session-item-text";
+      var textHtml = "";
       if (s.isProcessing) {
-        html += '<span class="session-processing"></span>';
+        textHtml += '<span class="session-processing"></span>';
       }
-      html += escapeHtml(s.title || "New Session");
-      el.innerHTML = html;
+      textHtml += escapeHtml(s.title || "New Session");
+      textSpan.innerHTML = textHtml;
+      el.appendChild(textSpan);
+
+      var deleteBtn = document.createElement("button");
+      deleteBtn.className = "session-delete-btn";
+      deleteBtn.innerHTML = iconHtml("trash-2");
+      deleteBtn.title = "Delete session";
+      deleteBtn.addEventListener("click", (function(id) {
+        return function(e) {
+          e.stopPropagation();
+          if (ws && connected) {
+            ws.send(JSON.stringify({ type: "delete_session", id: id }));
+          }
+        };
+      })(s.id));
+      el.appendChild(deleteBtn);
 
       el.addEventListener("click", (function (id) {
         return function () {
@@ -147,6 +164,7 @@
 
       sessionListEl.appendChild(el);
     }
+    refreshIcons();
   }
 
   function openSidebar() {

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -130,16 +130,24 @@ html, body {
 }
 
 .session-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   padding: 10px 12px;
   border-radius: 10px;
   cursor: pointer;
   font-size: 14px;
   color: var(--text-secondary);
+  margin-bottom: 2px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.session-item-text {
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-bottom: 2px;
-  transition: background 0.15s, color 0.15s;
+  min-width: 0;
 }
 
 .session-item:hover {
@@ -161,6 +169,38 @@ html, body {
   animation: pulse 1.5s ease-in-out infinite;
   margin-right: 8px;
   vertical-align: middle;
+}
+
+.session-delete-btn {
+  display: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.session-item:hover .session-delete-btn { display: flex; }
+
+.session-delete-btn:hover {
+  color: var(--error);
+  background: rgba(238, 85, 85, 0.1);
+}
+
+.session-delete-btn .lucide {
+  width: 14px;
+  height: 14px;
+}
+
+@media (hover: none) {
+  .session-delete-btn { display: flex; }
 }
 
 #sidebar-footer {

--- a/lib/server.js
+++ b/lib/server.js
@@ -426,6 +426,35 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort) {
     }
   }
 
+  function deleteSession(localId) {
+    var session = sessions.get(localId);
+    if (!session) return;
+
+    if (session.abortController) {
+      try { session.abortController.abort(); } catch(e) {}
+    }
+    if (session.messageQueue) {
+      try { session.messageQueue.end(); } catch(e) {}
+    }
+
+    if (session.cliSessionId) {
+      try { fs.unlinkSync(sessionFilePath(session.cliSessionId)); } catch(e) {}
+    }
+
+    sessions.delete(localId);
+
+    if (activeSessionId === localId) {
+      var remaining = [...sessions.keys()];
+      if (remaining.length > 0) {
+        switchSession(remaining[remaining.length - 1]);
+      } else {
+        createSession();
+      }
+    } else {
+      broadcastSessionList();
+    }
+  }
+
   // --- SDK message processing ---
 
   function processSDKMessage(session, parsed) {
@@ -910,6 +939,13 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort) {
       if (msg.type === "switch_session") {
         if (msg.id && sessions.has(msg.id)) {
           switchSession(msg.id);
+        }
+        return;
+      }
+
+      if (msg.type === "delete_session") {
+        if (msg.id && sessions.has(msg.id)) {
+          deleteSession(msg.id);
         }
         return;
       }


### PR DESCRIPTION
Add delete button (trash icon) on each session in the sidebar. Server handles abort of running query, removal from memory, and deletion of the JSONL persistence file. If the active session is deleted, switches to the last remaining one or creates a new one.