### PR TITLE
feat: add auto-update support and bump to v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## v1.2.0
+
+- Add auto-update check on startup with `--no-update` flag to opt out
+- Add session deletion from the web UI
+- Add browser notifications when Claude finishes a response
+- Add dynamic page title showing project name and session title
+- Add CLI branding with pixel character and dynamic favicon
+- Add response fallback for better error handling
+- Improve publish script with interactive version bump selection
+
+## v1.1.1
+
+- Add HTTPS support via mkcert with automatic certificate generation
+- Add interactive setup flow (accept prompt, PIN protection, keep awake toggle)
+- Add permission request UI for tool calls
+- Add multi-device session sync
+- Add stop button to interrupt Claude processing
+- Add QR code display for web UI URL in terminal
+- Update README
+
+## v1.0.1
+
+- Initial public release
+- WebSocket relay between Claude Code CLI and browser
+- Web UI with markdown rendering and streaming responses
+- Session management with create, list, resume
+- Tailscale IP auto-detection

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,7 @@ const { createServer } = require("../lib/server");
 const args = process.argv.slice(2);
 let port = 2633;
 let useHttps = true;
+let skipUpdate = false;
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "-p" || args[i] === "--port") {
@@ -21,12 +22,15 @@ for (let i = 0; i < args.length; i++) {
     i++;
   } else if (args[i] === "--no-https") {
     useHttps = false;
+  } else if (args[i] === "--no-update" || args[i] === "--skip-update") {
+    skipUpdate = true;
   } else if (args[i] === "-h" || args[i] === "--help") {
-    console.log("Usage: claude-relay [-p|--port <port>] [--no-https]");
+    console.log("Usage: claude-relay [-p|--port <port>] [--no-https] [--no-update]");
     console.log("");
     console.log("Options:");
     console.log("  -p, --port <port>  Port to listen on (default: 2633)");
     console.log("  --no-https         Disable HTTPS (enabled by default via mkcert)");
+    console.log("  --no-update        Skip auto-update check on startup");
     process.exit(0);
   }
 }
@@ -370,4 +374,10 @@ function start(pin) {
   });
 }
 
-setup(start);
+const { checkAndUpdate } = require("../lib/updater");
+const currentVersion = require("../package.json").version;
+
+(async () => {
+  const updated = await checkAndUpdate(currentVersion, skipUpdate);
+  if (!updated) setup(start);
+})();

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -1,0 +1,96 @@
+const https = require("https");
+const { execSync, spawn } = require("child_process");
+
+// ANSI helpers (mirrors cli.js)
+var a = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+};
+
+var sym = {
+  pointer: a.cyan + "\u25C6" + a.reset,
+  done: a.green + "\u25C7" + a.reset,
+  bar: a.dim + "\u2502" + a.reset,
+  warn: a.yellow + "\u25B2" + a.reset,
+};
+
+function log(s) { console.log("  " + s); }
+
+function fetchLatestVersion() {
+  return new Promise(function (resolve) {
+    var req = https.get("https://registry.npmjs.org/claude-relay/latest", function (res) {
+      var data = "";
+      res.on("data", function (chunk) { data += chunk; });
+      res.on("end", function () {
+        try {
+          resolve(JSON.parse(data).version || null);
+        } catch (e) {
+          resolve(null);
+        }
+      });
+    });
+    req.on("error", function () { resolve(null); });
+    req.setTimeout(3000, function () {
+      req.destroy();
+      resolve(null);
+    });
+  });
+}
+
+function isNewer(latest, current) {
+  if (!latest || !current) return false;
+  var lp = latest.split(".").map(Number);
+  var cp = current.split(".").map(Number);
+  for (var i = 0; i < 3; i++) {
+    var l = lp[i] || 0;
+    var c = cp[i] || 0;
+    if (l > c) return true;
+    if (l < c) return false;
+  }
+  return false;
+}
+
+function performUpdate() {
+  try {
+    execSync("npm install -g claude-relay@latest", { stdio: "pipe" });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function reExec() {
+  var args = process.argv.slice(1).concat("--no-update");
+  var child = spawn(process.execPath, args, { stdio: "inherit" });
+  child.on("exit", function (code) {
+    process.exit(code);
+  });
+}
+
+async function checkAndUpdate(currentVersion, skipUpdate) {
+  if (skipUpdate) return false;
+
+  var latest = await fetchLatestVersion();
+  if (!latest || !isNewer(latest, currentVersion)) return false;
+
+  log(sym.pointer + "  " + a.bold + "Update available" + a.reset + "  " + a.dim + currentVersion + " -> " + latest + a.reset);
+  log(sym.bar + "  Installing...");
+
+  if (performUpdate()) {
+    log(sym.done + "  Updated to " + a.green + latest + a.reset);
+    log("");
+    reExec();
+    return true;
+  }
+
+  log(sym.warn + "  " + a.yellow + "Update failed" + a.reset + a.dim + " (permission denied?)" + a.reset);
+  log(sym.bar + "  " + a.dim + "Run manually: npm install -g claude-relay@latest" + a.reset);
+  log("");
+  return false;
+}
+
+module.exports = { checkAndUpdate };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-relay",
-  "version": "1.0.1",
+  "version": "1.2.0",
   "description": "Access Claude Code on your machine, from anywhere. One command, no config.",
   "bin": {
     "claude-relay": "./bin/cli.js",


### PR DESCRIPTION
- Check npm registry on startup and install the latest version automatically.
- Add --no-update flag to skip the check. 
- Add CHANGELOG.