### PR TITLE
Collapse tool result blocks by default with expand chevron

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1115,6 +1115,7 @@
     el.dataset.toolId = id;
     el.innerHTML =
       '<div class="tool-header">' +
+      '<span class="tool-chevron">' + iconHtml("chevron-right") + '</span>' +
       '<span class="tool-bullet"></span>' +
       '<span class="tool-name"></span>' +
       '<span class="tool-desc"></span>' +
@@ -1196,7 +1197,7 @@
     }
 
     var resultBlock = document.createElement("div");
-    resultBlock.className = "tool-result-block";
+    resultBlock.className = "tool-result-block collapsed";
     var displayContent = content || "(no output)";
     if (displayContent.length > 10000) displayContent = displayContent.substring(0, 10000) + "\n... (truncated)";
 
@@ -1212,6 +1213,7 @@
 
     tool.el.querySelector(".tool-header").addEventListener("click", function () {
       resultBlock.classList.toggle("collapsed");
+      tool.el.classList.toggle("expanded");
     });
 
     markToolDone(id, isError);

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -754,6 +754,22 @@ html, body {
   transition: background 0.15s;
 }
 
+.tool-chevron {
+  color: var(--text-dimmer);
+  transition: transform 0.2s;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.tool-chevron .lucide {
+  width: 14px;
+  height: 14px;
+}
+
+.tool-item.expanded .tool-chevron {
+  transform: rotate(90deg);
+}
+
 .tool-header:hover {
   background: rgba(255, 255, 255, 0.05);
 }


### PR DESCRIPTION
## Summary

- Tool result blocks (Read, Edit, Bash, etc.) now default to collapsed to reduce scrolling
- Added chevron icon to tool header as a visual hint for expand/collapse
- Chevron rotates 90 degrees when expanded, matching the thinking block pattern

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)