### PR TITLE
feat: v1.4.0 pasted content chips, input previews, rewind hints, and UI polish

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -42,6 +42,7 @@
   var slashActiveIdx = -1;
   var slashFiltered = [];
   var pendingImages = []; // [{data: base64, mediaType: "image/png"}]
+  var pendingPastes = []; // [{text: string, preview: string}]
   var pendingPermissions = {}; // requestId -> container element
   var cliSessionId = null;
   var projectName = "";
@@ -162,6 +163,20 @@
   var confirmText = $("confirm-text");
   var confirmOk = $("confirm-ok");
   var confirmCancel = $("confirm-cancel");
+  // --- Paste content viewer modal ---
+  function showPasteModal(text) {
+    var modal = $("paste-modal");
+    var body = $("paste-modal-body");
+    if (!modal || !body) return;
+    body.textContent = text;
+    modal.classList.remove("hidden");
+  }
+
+  function closePasteModal() {
+    var modal = $("paste-modal");
+    if (modal) modal.classList.add("hidden");
+  }
+
   var confirmCallback = null;
 
   function showConfirm(text, onConfirm) {
@@ -437,7 +452,7 @@
 
   document.addEventListener("click", function () { closeSessionCtxMenu(); });
 
-  function showSessionCtxMenu(anchorBtn, sessionId, title) {
+  function showSessionCtxMenu(anchorBtn, sessionId, title, cliSid) {
     closeSessionCtxMenu();
     sessionCtxSessionId = sessionId;
 
@@ -453,6 +468,21 @@
       startInlineRename(sessionId, title);
     });
     menu.appendChild(renameItem);
+
+    if (cliSid) {
+      var copyResumeItem = document.createElement("button");
+      copyResumeItem.className = "session-ctx-item";
+      copyResumeItem.innerHTML = iconHtml("copy") + " <span>Copy resume command</span>";
+      copyResumeItem.addEventListener("click", function (e) {
+        e.stopPropagation();
+        navigator.clipboard.writeText("claude --resume " + cliSid).then(function () {
+          copyResumeItem.innerHTML = iconHtml("check") + " <span>Copied!</span>";
+          refreshIcons();
+          setTimeout(function () { closeSessionCtxMenu(); }, 800);
+        });
+      });
+      menu.appendChild(copyResumeItem);
+    }
 
     var deleteItem = document.createElement("button");
     deleteItem.className = "session-ctx-item session-ctx-delete";
@@ -545,12 +575,12 @@
       moreBtn.className = "session-more-btn";
       moreBtn.innerHTML = iconHtml("ellipsis");
       moreBtn.title = "More options";
-      moreBtn.addEventListener("click", (function(id, title, btn) {
+      moreBtn.addEventListener("click", (function(id, title, cliSid, btn) {
         return function(e) {
           e.stopPropagation();
-          showSessionCtxMenu(btn, id, title);
+          showSessionCtxMenu(btn, id, title, cliSid);
         };
-      })(s.id, s.title, moreBtn));
+      })(s.id, s.title, s.cliSessionId, moreBtn));
       el.appendChild(moreBtn);
 
       el.addEventListener("click", (function (id) {
@@ -1471,7 +1501,7 @@
   }
 
   // --- DOM: Messages ---
-  function addUserMessage(text, images) {
+  function addUserMessage(text, images, pastes) {
     var div = document.createElement("div");
     div.className = "msg-user";
     div.dataset.turn = ++turnCounter;
@@ -1488,6 +1518,26 @@
         imgRow.appendChild(img);
       }
       bubble.appendChild(imgRow);
+    }
+
+    if (pastes && pastes.length > 0) {
+      var pasteRow = document.createElement("div");
+      pasteRow.className = "bubble-pastes";
+      for (var p = 0; p < pastes.length; p++) {
+        (function (pasteText) {
+          var chip = document.createElement("div");
+          chip.className = "bubble-paste";
+          var preview = pasteText.substring(0, 60).replace(/\n/g, " ");
+          if (pasteText.length > 60) preview += "...";
+          chip.innerHTML = '<span class="bubble-paste-preview">' + escapeHtml(preview) + '</span><span class="bubble-paste-label">PASTED</span>';
+          chip.addEventListener("click", function (e) {
+            e.stopPropagation();
+            showPasteModal(pasteText);
+          });
+          pasteRow.appendChild(chip);
+        })(pastes[p]);
+      }
+      bubble.appendChild(pasteRow);
     }
 
     if (text) {
@@ -1595,9 +1645,7 @@
   }
 
   function updateResumeBtn() {
-    var btn = $("notif-resume-btn");
-    if (!btn) return;
-    btn.style.display = cliSessionId ? "flex" : "none";
+    // resume command moved to session context menu
   }
 
   function resetClientState() {
@@ -2126,7 +2174,7 @@
           break;
 
         case "user_message":
-          addUserMessage(msg.text, msg.images || null);
+          addUserMessage(msg.text, msg.images || null, msg.pastes || null);
           break;
 
         case "status":
@@ -2418,7 +2466,7 @@
   function sendMessage() {
     var text = inputEl.value.trim();
     var images = pendingImages.slice();
-    if (!text && images.length === 0) return;
+    if (!text && images.length === 0 && pendingPastes.length === 0) return;
     hideSlashMenu();
 
     if (text === "/clear") {
@@ -2447,11 +2495,15 @@
     }
     if (processing) return;
 
-    addUserMessage(text, images.length > 0 ? images : null);
+    var pastes = pendingPastes.map(function (p) { return p.text; });
+    addUserMessage(text, images.length > 0 ? images : null, pastes.length > 0 ? pastes : null);
 
     var payload = { type: "message", text: text || "" };
     if (images.length > 0) {
       payload.images = images;
+    }
+    if (pastes.length > 0) {
+      payload.pastes = pastes;
     }
     ws.send(JSON.stringify(payload));
 
@@ -2477,26 +2529,34 @@
     var typeMatch = header.match(/data:(image\/[^;,]+)/);
     if (!typeMatch || !data) return;
     pendingImages.push({ mediaType: typeMatch[1], data: data });
-    renderImagePreviews();
+    renderInputPreviews();
   }
 
   function removePendingImage(idx) {
     pendingImages.splice(idx, 1);
-    renderImagePreviews();
+    renderInputPreviews();
   }
 
   function clearPendingImages() {
     pendingImages = [];
-    renderImagePreviews();
+    pendingPastes = [];
+    renderInputPreviews();
   }
 
-  function renderImagePreviews() {
+  function removePendingPaste(idx) {
+    pendingPastes.splice(idx, 1);
+    renderInputPreviews();
+  }
+
+  function renderInputPreviews() {
     imagePreviewBar.innerHTML = "";
-    if (pendingImages.length === 0) {
+    if (pendingImages.length === 0 && pendingPastes.length === 0) {
       imagePreviewBar.classList.remove("visible");
       return;
     }
     imagePreviewBar.classList.add("visible");
+
+    // Image thumbnails
     for (var i = 0; i < pendingImages.length; i++) {
       (function (idx) {
         var wrap = document.createElement("div");
@@ -2514,6 +2574,32 @@
         imagePreviewBar.appendChild(wrap);
       })(i);
     }
+
+    // Pasted content chips
+    for (var j = 0; j < pendingPastes.length; j++) {
+      (function (idx) {
+        var chip = document.createElement("div");
+        chip.className = "pasted-chip";
+        var preview = document.createElement("span");
+        preview.className = "pasted-chip-preview";
+        preview.textContent = pendingPastes[idx].preview;
+        var label = document.createElement("span");
+        label.className = "pasted-chip-label";
+        label.textContent = "PASTED";
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "pasted-chip-remove";
+        removeBtn.innerHTML = iconHtml("x");
+        removeBtn.addEventListener("click", function (e) {
+          e.stopPropagation();
+          removePendingPaste(idx);
+        });
+        chip.appendChild(preview);
+        chip.appendChild(label);
+        chip.appendChild(removeBtn);
+        imagePreviewBar.appendChild(chip);
+      })(j);
+    }
+
     refreshIcons();
   }
 
@@ -2551,6 +2637,19 @@
             readImageBlob(blob);
           }
         }
+      }
+    }
+
+    // Long text paste → pasted chip
+    if (!found) {
+      var pastedText = cd.getData("text/plain");
+      if (pastedText && pastedText.length >= 500) {
+        e.preventDefault();
+        var preview = pastedText.substring(0, 50).replace(/\n/g, " ");
+        if (pastedText.length > 50) preview += "...";
+        pendingPastes.push({ text: pastedText, preview: preview });
+        renderInputPreviews();
+        found = true;
       }
     }
 
@@ -2980,24 +3079,7 @@
     localStorage.setItem("notif-sound", notifSoundEnabled ? "1" : "0");
   });
 
-  // --- Resume button in notif menu ---
-  var notifResumeBtn = $("notif-resume-btn");
-  notifResumeBtn.style.display = "none";
-
-  notifResumeBtn.addEventListener("click", function (e) {
-    e.stopPropagation();
-    if (!cliSessionId) return;
-    var cmd = "claude --resume " + cliSessionId;
-    var labelSpan = notifResumeBtn.querySelector("span");
-    navigator.clipboard.writeText(cmd).then(function () {
-      notifResumeBtn.classList.add("copied");
-      labelSpan.textContent = "Copied!";
-      setTimeout(function () {
-        notifResumeBtn.classList.remove("copied");
-        labelSpan.textContent = "Copy resume command";
-      }, 1500);
-    });
-  });
+  // --- Resume button removed from notif menu (now in session context menu) ---
 
   // --- Push notifications toggle ---
   var notifPushRow = $("notif-push-row");

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -78,26 +78,21 @@
           <button id="notif-btn" title="Notifications"><i data-lucide="sliders-horizontal"></i></button>
           <div id="notif-menu" class="hidden">
             <label class="notif-option" id="notif-push-row">
-              <span>Push notifications</span>
+              <span><i data-lucide="smartphone" style="width:14px;height:14px"></i> Push notifications</span>
               <input type="checkbox" id="notif-toggle-push">
               <span class="toggle-track"><span class="toggle-thumb"></span></span>
             </label>
             <label class="notif-option">
-              <span>Browser alerts</span>
+              <span><i data-lucide="bell" style="width:14px;height:14px"></i> Browser alerts</span>
               <input type="checkbox" id="notif-toggle-alert">
               <span class="toggle-track"><span class="toggle-thumb"></span></span>
             </label>
             <div id="notif-blocked-hint" class="hidden">Blocked by browser. <a href="#" id="notif-learn-more">Learn more</a></div>
             <label class="notif-option">
-              <span>Sound</span>
+              <span><i data-lucide="volume-2" style="width:14px;height:14px"></i> Sound</span>
               <input type="checkbox" id="notif-toggle-sound">
               <span class="toggle-track"><span class="toggle-thumb"></span></span>
             </label>
-            <div class="notif-divider"></div>
-            <button class="notif-action" id="notif-resume-btn">
-              <i data-lucide="terminal" style="width:14px;height:14px"></i>
-              <span>Copy resume command</span>
-            </button>
           </div>
         </div>
         <span id="client-count" class="hidden"></span>
@@ -113,15 +108,28 @@
     <div id="messages"></div>
 
     <div id="input-area">
-      <div id="image-preview-bar"></div>
       <div id="input-wrapper">
         <div id="slash-menu"></div>
         <div id="input-row">
-          <textarea id="input" rows="1" placeholder="Message Claude Code..." enterkeyhint="send"></textarea>
-          <button id="send-btn" disabled aria-label="Send"><i data-lucide="arrow-up"></i></button>
+          <div id="image-preview-bar"></div>
+          <div id="input-inner">
+            <textarea id="input" rows="1" placeholder="Message Claude Code..." enterkeyhint="send"></textarea>
+            <button id="send-btn" disabled aria-label="Send"><i data-lucide="arrow-up"></i></button>
+          </div>
         </div>
       </div>
     </div>
+  </div>
+</div>
+
+<div id="paste-modal" class="hidden">
+  <div class="confirm-backdrop" onclick="document.getElementById('paste-modal').classList.add('hidden')"></div>
+  <div class="confirm-dialog paste-modal-dialog">
+    <div class="paste-modal-header">
+      <span class="paste-modal-title">Pasted content</span>
+      <button class="paste-modal-close" onclick="document.getElementById('paste-modal').classList.add('hidden')"><i data-lucide="x" style="width:16px;height:16px"></i></button>
+    </div>
+    <pre class="paste-modal-body" id="paste-modal-body"></pre>
   </div>
 </div>
 

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -272,6 +272,7 @@ html, body {
 @media (hover: none) {
   .session-more-btn { display: flex; }
   .msg-copy-hint { opacity: 1; }
+  .msg-user[data-uuid] .bubble::after { display: none; }
 }
 
 #sidebar-footer {
@@ -1113,6 +1114,18 @@ html, body {
   transition: background 0.15s;
 }
 
+.notif-option > span:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.notif-option > span:first-child .lucide {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
 .notif-option:hover { background: rgba(255, 255, 255, 0.03); }
 .notif-option input { display: none; }
 
@@ -1885,13 +1898,36 @@ pre:hover .code-copy-btn { opacity: 1; }
 .msg-user[data-uuid] .bubble {
   cursor: pointer;
   transition: box-shadow 0.2s;
+  position: relative;
 }
 
 .msg-user[data-uuid] .bubble:hover {
   box-shadow: 0 0 0 1.5px var(--text-dimmer);
 }
 
+.msg-user[data-uuid] .bubble::after {
+  content: "Click to rewind";
+  position: absolute;
+  bottom: -22px;
+  right: 0;
+  font-size: 11px;
+  color: var(--text-dimmer);
+  opacity: 0;
+  transition: opacity 0.15s;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+.msg-user[data-uuid] .bubble:hover::after {
+  opacity: 1;
+}
+
 /* --- Rewind mode (timeline visible, strong markers) --- */
+#app.rewind-mode .msg-user[data-uuid] .bubble::after {
+  content: "Rewind to here";
+  color: var(--accent);
+}
+
 #app.rewind-mode .msg-user[data-uuid] .bubble {
   box-shadow: 0 0 0 2px var(--accent);
 }
@@ -2387,16 +2423,167 @@ pre:hover .code-copy-btn { opacity: 1; }
 
 .bubble-img:hover { opacity: 0.85; }
 
+/* --- Pasted content chips (in chat bubble) --- */
+.bubble-pastes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.bubble-pastes:last-child { margin-bottom: 0; }
+
+.bubble-paste {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+  max-width: 220px;
+}
+
+.bubble-paste:hover {
+  border-color: var(--text-dimmer);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.bubble-paste-preview {
+  font-size: 12px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.bubble-paste-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-dimmer);
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+/* --- Pasted content chips (input preview) --- */
+.pasted-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 6px 10px;
+  font-size: 12px;
+  max-width: 200px;
+}
+
+.pasted-chip-preview {
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.pasted-chip-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--text-dimmer);
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.pasted-chip-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+}
+
+.pasted-chip-remove .lucide { width: 12px; height: 12px; }
+.pasted-chip-remove:hover { color: var(--text); background: rgba(255, 255, 255, 0.1); }
+
+/* --- Paste viewer modal --- */
+#paste-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
+#paste-modal.hidden { display: none; }
+
+.paste-modal-dialog {
+  max-width: 620px;
+  width: 94%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+.paste-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+
+.paste-modal-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.paste-modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.paste-modal-close:hover { color: var(--text); background: rgba(255, 255, 255, 0.06); }
+
+.paste-modal-body {
+  margin: 0;
+  padding: 16px 20px;
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-y: auto;
+  min-height: 0;
+}
+
 /* --- Image preview bar --- */
 #image-preview-bar {
   display: none;
-  padding: 8px 0 4px;
+  width: 100%;
+  padding: 6px 0 4px;
 }
 
 #image-preview-bar.visible {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
 }
 
 .image-preview-thumb {
@@ -2405,11 +2592,11 @@ pre:hover .code-copy-btn { opacity: 1; }
 }
 
 .image-preview-thumb img {
-  width: 56px;
-  height: 56px;
+  width: 48px;
+  height: 48px;
   object-fit: cover;
-  border-radius: 10px;
-  border: 1px solid var(--border);
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
 }
 
 .image-preview-remove {
@@ -2454,12 +2641,18 @@ pre:hover .code-copy-btn { opacity: 1; }
 
 #input-row {
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
   background: var(--input-bg);
   border: 1px solid var(--border);
   border-radius: 24px;
   padding: 6px 6px 6px 20px;
   transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+#input-inner {
+  display: flex;
+  align-items: flex-end;
+  width: 100%;
 }
 
 #input-row:focus-within {

--- a/lib/server.js
+++ b/lib/server.js
@@ -881,6 +881,7 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort, debug) {
       sessions: [...sessions.values()].map(function(s) {
         return {
           id: s.localId,
+          cliSessionId: s.cliSessionId || null,
           title: s.title || "New Session",
           active: s.localId === activeSessionId,
           isProcessing: s.isProcessing,
@@ -1651,6 +1652,7 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort, debug) {
       sessions: [...sessions.values()].map(function(s) {
         return {
           id: s.localId,
+          cliSessionId: s.cliSessionId || null,
           title: s.title || "New Session",
           active: s.localId === activeSessionId,
           isProcessing: s.isProcessing,
@@ -1936,7 +1938,7 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort, debug) {
       }
 
       if (msg.type !== "message") return;
-      if (!msg.text && (!msg.images || msg.images.length === 0)) return;
+      if (!msg.text && (!msg.images || msg.images.length === 0) && (!msg.pastes || msg.pastes.length === 0)) return;
 
       var session = getActiveSession();
       if (!session) return;
@@ -1954,6 +1956,9 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort, debug) {
       if (msg.images && msg.images.length > 0) {
         userMsg.imageCount = msg.images.length;
       }
+      if (msg.pastes && msg.pastes.length > 0) {
+        userMsg.pastes = msg.pastes;
+      }
       session.history.push(userMsg);
       appendToSessionFile(session, userMsg);
       sendToOthers(ws, userMsg);
@@ -1966,11 +1971,20 @@ function createServer(cwd, tlsOptions, caPath, pin, mainPort, debug) {
         broadcastSessionList();
       }
 
+      // Combine text with pasted content for Claude
+      var fullText = msg.text || "";
+      if (msg.pastes && msg.pastes.length > 0) {
+        for (var pi = 0; pi < msg.pastes.length; pi++) {
+          if (fullText) fullText += "\n\n";
+          fullText += msg.pastes[pi];
+        }
+      }
+
       // Start new query or push to existing one
       if (!session.queryInstance) {
-        startQuery(session, msg.text || "", msg.images);
+        startQuery(session, fullText, msg.images);
       } else {
-        pushMessage(session, msg.text || "", msg.images);
+        pushMessage(session, fullText, msg.images);
       }
       broadcastSessionList();
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-relay",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Access Claude Code on your machine, from anywhere. One command, no config.",
   "bin": {
     "claude-relay": "./bin/cli.js",


### PR DESCRIPTION
- Pasted content feature: long text (≥500 chars) shows as compact "PASTED" chip instead of dumping into textarea, with modal viewer on click
- Image previews now render inside the input box (Claude-style)
- Rewindable user messages show "Click to rewind" hint on hover
- Copy resume command moved to session context menu (⋯ button)
- Notification menu: added icons to toggle labels, removed resume button
- Security: shell injection fix (execFileSync), secure cookie flag, session I/O try/catch
- Bug fixes: session rename persistence, send paste/image-only messages