### PR TITLE
feat: add Ctrl+J newline shortcut and QR code overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## WIP
 
+- Add Ctrl+J shortcut to insert newline in input (matches Claude CLI behavior)
+- Add QR code button in header to share current URL with click-to-copy
+
+## v1.5.0
+
+- Refactor monolithic codebase into modules
+  - app.js 3,258 → 1,090 lines (8 client modules)
+  - server.js 2,035 → 704 lines (3 server modules)
+  - style.css 3,005 → 7 lines (7 CSS files)
+- Push notification titles now show context ("Claude wants to edit auth.ts" instead of just "Edit")
+- Auto-resize images >5 MB to JPEG before sending (iPhone screenshots)
+- Add mermaid.js diagram rendering with expandable modal viewer and PNG export
+- Move TLS certs from per-project to `~/.claude-relay/certs` with auto-migration
+- Re-generate certs when current IP is not in SAN
+- Add toast notification system and clipboard fallback for HTTP contexts
+- Use grayscale mascot for PWA app icon
+
+## v1.4.0
+
+- Pasted content feature: long text (≥500 chars) shows as compact "PASTED" chip with modal viewer on click
+- Image previews now render inside the input box (Claude-style)
+- Rewindable user messages show "Click to rewind" hint on hover
+- Copy resume command moved to session context menu (⋯ button)
+- Notification menu: added icons to toggle labels, removed resume button
+- Security: shell injection fix (execFileSync), secure cookie flag, session I/O try/catch
+- Fix session rename persistence
+- Fix sending paste/image-only messages without text
+
 ## v1.3.0
 
 - Consolidate notification bell and terminal button into unified settings panel

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ npx claude-relay --debug      # debug panel
 
 ## Security
 
-**Anyone with the URL gets full Claude Code access to your machine.** Read, write, execute — your user permissions.
+claude-relay only listens on your local network. It is not accessible from the internet unless you explicitly expose it.
 
-PIN protection is enabled during setup — every new device must enter the PIN shown in your terminal before accessing any session. This prevents casual shoulder-surfing of the QR code, but is not a substitute for network-level security.
+Within your network, anyone with the URL and PIN can access your Claude Code session with your user permissions. PIN protection is enabled during setup — every new device must enter the PIN shown in your terminal before connecting.
 
-Private network only. [Tailscale](https://tailscale.com), WireGuard, or a VPN. Never expose to the public internet.
+For remote access, use [Tailscale](https://tailscale.com), WireGuard, or a VPN. Never expose to the public internet.
 
 **Entirely at your own risk.**
 

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -5,6 +5,7 @@ import { initSidebar, renderSessionList, updatePageTitle } from './modules/sideb
 import { initRewind, setRewindMode, showRewindModal, clearPendingRewindUuid } from './modules/rewind.js';
 import { initNotifications, showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './modules/notifications.js';
 import { initInput, clearPendingImages, handleInputSync } from './modules/input.js';
+import { initQrCode } from './modules/qrcode.js';
 import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUserQuestion, renderPermissionRequest, markPermissionResolved, markPermissionCancelled, renderPlanBanner, renderPlanCard, handleTodoWrite, handleTaskCreate, handleTaskUpdate, startThinking, appendThinking, stopThinking, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, addTurnMeta, enableMainInput, getTools, getPlanContent, setPlanContent, isPlanFilePath, getTodoTools } from './modules/tools.js';
 
 // --- DOM refs ---
@@ -1081,6 +1082,9 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     sessionListEl: sessionListEl,
     scrollToBottom: scrollToBottom,
   });
+
+  // --- QR code ---
+  initQrCode();
 
   // --- Init ---
   lucide.createIcons();

--- a/lib/public/css/menus.css
+++ b/lib/public/css/menus.css
@@ -85,6 +85,71 @@
   flex-shrink: 0;
 }
 
+/* --- QR code button & overlay --- */
+#qr-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--text-dimmer);
+  cursor: pointer;
+  padding: 4px;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+#qr-btn .lucide { width: 15px; height: 15px; }
+#qr-btn:hover { color: var(--text-secondary); background: rgba(255,255,255,0.04); border-color: var(--border); }
+#qr-btn.active { color: var(--text); background: rgba(255,255,255,0.06); border-color: var(--border); }
+
+#qr-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 500;
+}
+#qr-overlay.hidden { display: none; }
+
+#qr-overlay-inner {
+  background: #fff;
+  border-radius: 16px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+#qr-canvas table { border-collapse: collapse; }
+#qr-canvas td { width: 4px; height: 4px; padding: 0; }
+
+#qr-url {
+  font-size: 13px;
+  color: #555;
+  word-break: break-all;
+  text-align: center;
+  max-width: 260px;
+  font-family: system-ui, sans-serif;
+  cursor: pointer;
+  padding: 4px 10px;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+#qr-url:hover { background: #eee; color: #222; }
+#qr-url:active { background: #ddd; }
+#qr-url.copied { color: #16a34a; font-weight: 600; }
+.qr-hint {
+  display: block;
+  font-size: 11px;
+  color: #999;
+  margin-top: 2px;
+  font-weight: 400;
+}
+
 /* --- Notification menu --- */
 #notif-menu-wrap {
   position: relative;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -74,6 +74,13 @@
             </label>
           </div>
         </div>
+        <button id="qr-btn" title="QR Code"><i data-lucide="qr-code"></i></button>
+        <div id="qr-overlay" class="hidden">
+          <div id="qr-overlay-inner">
+            <div id="qr-canvas"></div>
+            <div id="qr-url"></div>
+          </div>
+        </div>
         <div id="notif-menu-wrap">
           <button id="notif-btn" title="Notifications"><i data-lucide="sliders-horizontal"></i></button>
           <div id="notif-menu" class="hidden">
@@ -216,6 +223,7 @@
 <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
 <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/lib/public/modules/input.js
+++ b/lib/public/modules/input.js
@@ -356,6 +356,19 @@ export function initInput(_ctx) {
       }
     }
 
+    // Ctrl+J: insert newline (like Claude CLI)
+    if (e.key === "j" && e.ctrlKey && !e.metaKey) {
+      e.preventDefault();
+      var ta = ctx.inputEl;
+      var start = ta.selectionStart;
+      var end = ta.selectionEnd;
+      var val = ta.value;
+      ta.value = val.substring(0, start) + "\n" + val.substring(end);
+      ta.selectionStart = ta.selectionEnd = start + 1;
+      autoResize();
+      return;
+    }
+
     if (e.key === "Enter" && !e.shiftKey && !isComposing) {
       e.preventDefault();
       sendMessage();

--- a/lib/public/modules/qrcode.js
+++ b/lib/public/modules/qrcode.js
@@ -1,0 +1,55 @@
+import { copyToClipboard } from './utils.js';
+
+export function initQrCode() {
+  var $ = function (id) { return document.getElementById(id); };
+  var qrBtn = $("qr-btn");
+  var qrOverlay = $("qr-overlay");
+  var qrCanvas = $("qr-canvas");
+  var qrUrl = $("qr-url");
+
+  qrBtn.addEventListener("click", function (e) {
+    e.stopPropagation();
+    var url = window.location.href;
+
+    // generate QR
+    var qr = qrcode(0, "M");
+    qr.addData(url);
+    qr.make();
+    qrCanvas.innerHTML = qr.createSvgTag(5, 0);
+    qrUrl.innerHTML = url + '<span class="qr-hint">click to copy</span>';
+
+    qrOverlay.classList.remove("hidden");
+    qrBtn.classList.add("active");
+  });
+
+  // click URL to copy
+  qrUrl.addEventListener("click", function () {
+    var url = window.location.href;
+    copyToClipboard(url).then(function () {
+      qrUrl.innerHTML = "Copied!";
+      qrUrl.classList.add("copied");
+      setTimeout(function () {
+        qrUrl.innerHTML = url + '<span class="qr-hint">click to copy</span>';
+        qrUrl.classList.remove("copied");
+      }, 1500);
+    });
+  });
+
+  qrOverlay.addEventListener("click", function () {
+    qrOverlay.classList.add("hidden");
+    qrBtn.classList.remove("active");
+  });
+
+  // prevent closing when clicking the inner card
+  $("qr-overlay-inner").addEventListener("click", function (e) {
+    e.stopPropagation();
+  });
+
+  // ESC to close
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && !qrOverlay.classList.contains("hidden")) {
+      qrOverlay.classList.add("hidden");
+      qrBtn.classList.remove("active");
+    }
+  });
+}


### PR DESCRIPTION
Ctrl+J in the input textarea now inserts a newline (matching Claude CLI behavior). Added a QR code button next to the notification icon that shows the current URL as a scannable QR code with click-to-copy support.