### PR TITLE
feat: add HTTP onboarding port for new device certificate setup

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1266,6 +1266,10 @@ function showSetupGuide(config, ip, goBack) {
       } else {
         log(sym.bar + "  " + a.dim + "Can't connect? Your phone must be on the same Wi-Fi network." + a.reset);
       }
+      if (config.tls) {
+        var httpOnboardUrl = "http://" + (tsIP || ip) + ":" + (config.port + 1) + "/setup";
+        log(sym.bar + "  " + a.dim + "Certificate warning? Open " + a.reset + httpOnboardUrl);
+      }
       log(sym.bar);
       log(sym.done + "  " + a.dim + "Setup complete." + a.reset);
       log(sym.end);

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -187,6 +187,17 @@ relay.server.listen(config.port, function () {
   saveConfig(config);
 });
 
+// --- HTTP onboarding server (only when TLS is active) ---
+if (relay.onboardingServer) {
+  var onboardingPort = config.port + 1;
+  relay.onboardingServer.on("error", function (err) {
+    console.error("[daemon] Onboarding HTTP server error:", err.message);
+  });
+  relay.onboardingServer.listen(onboardingPort, function () {
+    console.log("[daemon] Onboarding HTTP on http://0.0.0.0:" + onboardingPort);
+  });
+}
+
 // --- Caffeinate (macOS) ---
 var caffeinateProc = null;
 if (config.keepAwake && process.platform === "darwin") {
@@ -215,6 +226,10 @@ function gracefulShutdown() {
       saveConfig(c);
     }
   } catch (e) {}
+
+  if (relay.onboardingServer) {
+    relay.onboardingServer.close();
+  }
 
   relay.server.close(function () {
     console.log("[daemon] Server closed");

--- a/lib/server.js
+++ b/lib/server.js
@@ -261,6 +261,67 @@ function createServer(opts) {
     server = http.createServer(appHandler);
   }
 
+  // --- HTTP onboarding server (only when TLS is active) ---
+  var onboardingServer = null;
+  if (tlsOptions) {
+    onboardingServer = http.createServer(function (req, res) {
+      var url = req.url.split("?")[0];
+
+      // CA certificate download
+      if (url === "/ca/download" && req.method === "GET" && caContent) {
+        res.writeHead(200, {
+          "Content-Type": "application/x-pem-file",
+          "Content-Disposition": 'attachment; filename="claude-relay-ca.pem"',
+        });
+        res.end(caContent);
+        return;
+      }
+
+      // Setup page
+      if (url === "/setup" && req.method === "GET") {
+        var host = req.headers.host || "localhost";
+        var hostname = host.split(":")[0];
+        var httpsSetupUrl = "https://" + hostname + ":" + portNum;
+        var httpSetupUrl = "http://" + hostname + ":" + (portNum + 1);
+        res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+        res.end(setupPageHtml(httpsSetupUrl, httpSetupUrl, !!caContent));
+        return;
+      }
+
+      // /https-info — the setup page already fetches this to discover the HTTPS URL
+      if (url === "/https-info" && req.method === "GET") {
+        var hostname = (req.headers.host || "localhost").split(":")[0];
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ httpsUrl: "https://" + hostname + ":" + portNum }));
+        return;
+      }
+
+      // /info — CORS-enabled, used by setup page to verify HTTPS
+      if (url === "/info" && req.method === "GET") {
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        });
+        var projectList = [];
+        projects.forEach(function (ctx, slug) {
+          projectList.push({ slug: slug, project: ctx.project, path: ctx.cwd });
+        });
+        res.end(JSON.stringify({ projects: projectList, version: currentVersion }));
+        return;
+      }
+
+      // Favicon
+      if (url === "/favicon.svg" || url === "/favicon.ico") {
+        if (serveStatic(url, res)) return;
+      }
+
+      // Everything else → redirect to HTTPS setup
+      var hostname = (req.headers.host || "localhost").split(":")[0];
+      res.writeHead(302, { "Location": "https://" + hostname + ":" + portNum + "/setup" });
+      res.end();
+    });
+  }
+
   // --- WebSocket ---
   var wss = new WebSocketServer({ noServer: true });
 
@@ -334,6 +395,7 @@ function createServer(opts) {
 
   return {
     server: server,
+    onboardingServer: onboardingServer,
     isTLS: !!tlsOptions,
     addProject: addProject,
     removeProject: removeProject,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-relay",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Web UI for Claude Code. Any device. Push notifications.",
   "bin": {
     "claude-relay": "./bin/cli.js",


### PR DESCRIPTION
New devices can't reach the HTTPS setup page because the mkcert CA isn't installed yet. A secondary HTTP server on port+1 (default 2634) serves only the setup page and CA download, letting users install the certificate before switching to HTTPS.