### PR TITLE
fix: remove /https-info from onboarding server to prevent auto-redirect

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -288,14 +288,6 @@ function createServer(opts) {
         return;
       }
 
-      // /https-info — the setup page already fetches this to discover the HTTPS URL
-      if (url === "/https-info" && req.method === "GET") {
-        var hostname = (req.headers.host || "localhost").split(":")[0];
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ httpsUrl: "https://" + hostname + ":" + portNum }));
-        return;
-      }
-
       // /info — CORS-enabled, used by setup page to verify HTTPS
       if (url === "/info" && req.method === "GET") {
         res.writeHead(200, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-relay",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Web UI for Claude Code. Any device. Push notifications.",
   "bin": {
     "claude-relay": "./bin/cli.js",


### PR DESCRIPTION
The setup page fetches /https-info to discover the HTTPS URL and redirects automatically if the cert is trusted. This defeats the purpose of the HTTP onboarding port — users never see the setup steps.