### PR TITLE
v2.1.1: Fix session reordering and project switcher state loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## WIP
 
+## v2.1.1
+
+- Fix session list reordering on every click (only update order on actual messages, not view switches)
+- Fix project switcher losing name/count after incomplete `info` message (defensive caching)
+- Remove unselected projects from `~/.clayrc` during restore prompt
+
 ## v2.1.0
 
 - **Project persistence via `~/.clayrc`**: project list saved automatically; on daemon restart, CLI prompts to restore previous projects with multi-select

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -46,11 +46,13 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   var projectHint = $("project-hint");
   var projectHintDismiss = $("project-hint-dismiss");
   var cachedProjects = [];
+  var cachedProjectCount = 0;
   var currentSlug = slugMatch ? slugMatch[1] : null;
 
   function updateProjectSwitcher(msg) {
-    var count = msg.projectCount || 0;
-    cachedProjects = msg.projects || [];
+    if (typeof msg.projectCount === "number") cachedProjectCount = msg.projectCount;
+    if (msg.projects) cachedProjects = msg.projects;
+    var count = cachedProjectCount || 0;
     projectSwitcherName.textContent = projectName || "Project";
     projectSwitcherCount.textContent = count ? count + (count === 1 ? " project" : " projects") : "";
     if (count === 1 && projectHint) {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -187,7 +187,6 @@ function createSessionManager(opts) {
     var session = sessions.get(localId);
     if (!session) return;
 
-    session.lastActivity = Date.now();
     activeSessionId = localId;
     send({ type: "session_switched", id: localId, cliSessionId: session.cliSessionId || null });
     broadcastSessionList();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-relay",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Web UI for Claude Code. Any device. Push notifications.",
   "bin": {
     "claude-relay": "./bin/cli.js",


### PR DESCRIPTION
## Summary

- **Session list stability**: stop reordering sessions on every click — `lastActivity` only updates on actual messages (send/receive), not view switches
- **Project switcher fix**: cache `projectCount` and `projects` defensively so incomplete `info` messages don't wipe the display
- **Restore cleanup**: unselected projects are removed from `~/.clayrc` so they don't reappear on next restart

## Test plan

- [ ] Click between sessions — verify list order stays stable
- [ ] Send a message in a session — verify it moves to top
- [ ] Restart server, verify project switcher shows correct name and count
- [ ] Restore prompt: deselect a project, restart again — verify it's gone from the prompt