### PR TITLE
fix: iOS cert trust detection on onboarding page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## WIP
 
+## v2.1.3
+
+- Fix certificate trust detection on iOS: onboarding page always showed "Certificate not trusted yet" even after installing and trusting the mkcert CA
+  - HTTPS `/info` 401 response lacked CORS headers → browser treated as network error → misreported as untrusted cert
+  - Switch certificate check fetch to `no-cors` mode so any TLS handshake success = cert trusted
+
 ## v2.1.2
 
 - Fix session list reordering on every click (only update order on actual messages, not view switches)

--- a/lib/pages.js
+++ b/lib/pages.js
@@ -444,8 +444,9 @@ function checkHttps() {
 
   var ac = new AbortController();
   setTimeout(function() { ac.abort(); }, 3000);
-  fetch(httpsUrl + "/info", { signal: ac.signal })
+  fetch(httpsUrl + "/info", { signal: ac.signal, mode: "no-cors" })
     .then(function() {
+      // Any response (even opaque/401) means TLS handshake succeeded = cert is trusted
       certStatus.className = "check-status ok";
       certStatus.textContent = "HTTPS connection verified. Certificate is trusted.";
       certNext.disabled = false;
@@ -614,7 +615,7 @@ if (!isHttps && !isLocal) {
     if (!info.httpsUrl) { init(); return; }
     var ac = new AbortController();
     setTimeout(function() { ac.abort(); }, 3000);
-    fetch(info.httpsUrl + "/info", { signal: ac.signal })
+    fetch(info.httpsUrl + "/info", { signal: ac.signal, mode: "no-cors" })
       .then(function() { location.replace(info.httpsUrl + "/setup"); })
       .catch(function() { init(); });
   }).catch(function() { init(); });

--- a/lib/server.js
+++ b/lib/server.js
@@ -262,7 +262,10 @@ function createServer(opts) {
     // Global info endpoint (auth required)
     if (req.method === "GET" && req.url === "/info") {
       if (!isAuthed(req, authToken)) {
-        res.writeHead(401, { "Content-Type": "application/json" });
+        res.writeHead(401, {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+        });
         res.end('{"error":"unauthorized"}');
         return;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-relay",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Web UI for Claude Code. Any device. Push notifications.",
   "bin": {
     "claude-relay": "./bin/cli.js",


### PR DESCRIPTION
## Summary

- Fix onboarding page always showing "Certificate not trusted yet" on iOS even after installing and trusting the mkcert CA certificate
- HTTPS `/info` endpoint returned 401 without CORS headers, causing the browser to treat it as a network error — indistinguishable from an untrusted certificate
- Switch `checkHttps()` fetch to `no-cors` mode: any successful TLS handshake confirms certificate trust

## Changes

- `server.js`: Add `Access-Control-Allow-Origin: *` header to `/info` 401 response
- `pages.js`: Add `mode: "no-cors"` to certificate verification fetch in 2 places
- Version bump to 2.1.3

## Test plan

- [ ] Install + trust mkcert CA on iPhone, open onboarding page → should show "HTTPS connection verified"
- [ ] Without certificate installed, onboarding page → should show "Certificate not trusted yet"
- [ ] Desktop browser setup flow still works as expected