### PR TITLE
Fix LAN setup flow and multi-IP cert generation

### DIFF
--- a/lib/pages.js
+++ b/lib/pages.js
@@ -40,7 +40,7 @@ function pinPageHtml() {
     '</script></div></body></html>';
 }
 
-function setupPageHtml(httpsUrl, httpUrl, hasCert) {
+function setupPageHtml(httpsUrl, httpUrl, hasCert, lanMode) {
   return `<!DOCTYPE html><html lang="en"><head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
@@ -195,6 +195,7 @@ h1{color:#DA7756;font-size:22px;margin:0 0 4px;text-align:center}
   <div class="step-desc">Install Claude Relay as an app for quick access and a full-screen experience.</div>
 
   <div class="platform-ios">
+    <div class="check-status warn">On iOS, push notifications only work from the installed app. This step is required.</div>
     <div id="ios-not-safari" class="check-status warn" style="display:none">You must use <b>Safari</b> to install. Open this page in Safari first.</div>
     <div id="ios-safari-steps">
       <div class="instruction"><div class="inst-num">1</div>
@@ -237,6 +238,7 @@ h1{color:#DA7756;font-size:22px;margin:0 0 4px;text-align:center}
   </div>
 
   <div id="pwa-status" class="check-status pending">After installing, open Claude Relay from your home screen to continue setup.</div>
+  <button class="skip-link" id="pwa-skip" onclick="nextStep()" style="display:none">Skip for now</button>
 </div>
 
 <!-- Step 3: Push Notifications -->
@@ -270,6 +272,7 @@ h1{color:#DA7756;font-size:22px;margin:0 0 4px;text-align:center}
 var httpsUrl = ${JSON.stringify(httpsUrl)};
 var httpUrl = ${JSON.stringify(httpUrl)};
 var hasCert = ${hasCert ? 'true' : 'false'};
+var lanMode = ${lanMode ? 'true' : 'false'};
 var isHttps = location.protocol === "https:";
 var ua = navigator.userAgent;
 var isIOS = /iPhone|iPad|iPod/.test(ua);
@@ -326,10 +329,17 @@ if (isStandalone && localStorage.getItem("setup-pending")) {
 
 function buildSteps(hasPushSub) {
   steps = [];
-  if (!isTailscale && !isLocal) steps.push("tailscale");
+  if (!isTailscale && !isLocal && !lanMode) steps.push("tailscale");
   if (hasCert && !isHttps) steps.push("cert");
-  if (!isStandalone) steps.push("pwa");
-  if ((isHttps || isLocal) && !hasPushSub) steps.push("push");
+  if (isAndroid) {
+    // Android: push first (works in browser), then PWA as optional
+    if ((isHttps || isLocal) && !hasPushSub) steps.push("push");
+    if (!isStandalone) steps.push("pwa");
+  } else {
+    // iOS: PWA required for push, so install first
+    if (!isStandalone) steps.push("pwa");
+    if ((isHttps || isLocal) && !hasPushSub) steps.push("push");
+  }
   steps.push("done");
 
   // Trigger HTTPS check now that steps are built
@@ -348,6 +358,14 @@ function buildSteps(hasPushSub) {
   if (steps.indexOf("pwa") !== -1) {
     var stepsBeforePwa = steps.indexOf("pwa");
     localStorage.setItem("setup-pending", String(stepsBeforePwa + 1));
+  }
+
+  // Android: PWA is optional, show skip button and update text
+  if (isAndroid && steps.indexOf("pwa") !== -1) {
+    var pwaSkip = document.getElementById("pwa-skip");
+    var pwaStatus = document.getElementById("pwa-status");
+    if (pwaSkip) pwaSkip.style.display = "block";
+    if (pwaStatus) pwaStatus.textContent = "Optional: install for quick access and full-screen experience.";
   }
 
   // Push: show warning if not on HTTPS
@@ -393,7 +411,7 @@ function showStep(idx) {
 function nextStep() {
   // After cert step on HTTP, redirect to HTTPS for remaining steps
   if (!isHttps && steps[currentStep] === "cert") {
-    location.replace(httpsUrl + "/setup");
+    location.replace(httpsUrl + "/setup" + (lanMode ? "?mode=lan" : ""));
     return;
   }
   if (currentStep < steps.length - 1) showStep(currentStep + 1);
@@ -616,7 +634,7 @@ if (!isHttps && !isLocal) {
     var ac = new AbortController();
     setTimeout(function() { ac.abort(); }, 3000);
     fetch(info.httpsUrl + "/info", { signal: ac.signal, mode: "no-cors" })
-      .then(function() { location.replace(info.httpsUrl + "/setup"); })
+      .then(function() { location.replace(info.httpsUrl + "/setup" + (lanMode ? "?mode=lan" : "")); })
       .catch(function() { init(); });
   }).catch(function() { init(); });
 } else {

--- a/lib/server.js
+++ b/lib/server.js
@@ -202,16 +202,17 @@ function createServer(opts) {
     }
 
     // Setup page
-    if (req.url === "/setup" && req.method === "GET") {
+    if (fullUrl === "/setup" && req.method === "GET") {
       var host = req.headers.host || "localhost";
       var hostname = host.split(":")[0];
       var protocol = tlsOptions ? "https" : "http";
       var setupUrl = protocol + "://" + hostname + ":" + portNum;
+      var lanMode = /[?&]mode=lan/.test(req.url);
       res.writeHead(200, {
         "Content-Type": "text/html; charset=utf-8",
         "Access-Control-Allow-Origin": "*",
       });
-      res.end(setupPageHtml(setupUrl, setupUrl, !!caContent));
+      res.end(setupPageHtml(setupUrl, setupUrl, !!caContent, lanMode));
       return;
     }
 
@@ -364,8 +365,9 @@ function createServer(opts) {
         var hostname = host.split(":")[0];
         var httpsSetupUrl = "https://" + hostname + ":" + portNum;
         var httpSetupUrl = "http://" + hostname + ":" + (portNum + 1);
+        var lanMode = /[?&]mode=lan/.test(req.url);
         res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
-        res.end(setupPageHtml(httpsSetupUrl, httpSetupUrl, !!caContent));
+        res.end(setupPageHtml(httpsSetupUrl, httpSetupUrl, !!caContent, lanMode));
         return;
       }
 


### PR DESCRIPTION
## Summary
- Add `?mode=lan` query parameter to skip Tailscale onboarding step when user selects "Access from outside? No" in CLI
- Always ask "Access from outside your network?" even when Tailscale is installed (removed fast-path skip)
- Use LAN IP (not Tailscale IP) for QR code when remote access is not wanted
- Generate mkcert certificates with all routable IPs (both Tailscale and LAN) using a whitelist approach (`10.x`, `172.16-31.x`, `192.168.x`, `100.64-127.x`)
- Auto-regenerate cert when any routable IP is missing from SAN
- Preserve `?mode=lan` across HTTPS redirects during setup
- Reorder Android setup: push notifications first, PWA install second (optional, with skip button)
- Add iOS notice that PWA install is required for push notifications

## Test plan
- [ ] CLI "Access from outside? No" + "Want push? Yes" generates QR with LAN IP and `?mode=lan`
- [ ] CLI "Access from outside? Yes" generates QR with Tailscale IP, no query param
- [ ] Setup page on LAN IP skips Tailscale step
- [ ] HTTPS redirect preserves `?mode=lan`
- [ ] Cert is regenerated to include both Tailscale and LAN IPs
- [ ] Android setup shows push before PWA with skip option
- [ ] iOS setup shows PWA requirement notice before push step

🤖 Generated with [Claude Code](https://claude.com/claude-code)