### PR TITLE
fix: auto-restart daemon with TLS when mkcert is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## WIP
 
+- Auto-restart daemon with HTTPS when mkcert is installed but TLS was not active (#90)
+- Reload config from disk after setup guide completes (pick up TLS state changes)
+
 ## v2.2.4
 
 - Fix Windows IPC failure: use named pipe (`\\.\pipe\claude-relay-daemon`) instead of Unix domain socket


### PR DESCRIPTION
## Summary

- When mkcert is installed but the running daemon has TLS disabled (e.g., mkcert was installed after daemon start), the setup QR code showed `http://` on the HTTPS port, causing 404 errors
- Added `restartDaemonWithTLS()` that shuts down the old daemon, generates certs, and re-forks with TLS enabled
- If TLS restart fails, falls back to HTTP so the server never stays dead
- Config is reloaded from disk after setup guide completes to pick up TLS state changes

## Context

Reported in #90: user with mkcert installed saw `http://172.16.135.239:2633/setup?mode=lan` which returned 404 because the daemon was serving HTTPS on port 2633 (or running old code that didn't strip query params from `/setup`).

## Test plan

- [ ] Start daemon without mkcert, then install mkcert, go to Setup notifications > push yes > verify daemon auto-restarts with HTTPS
- [ ] Verify QR URL shows `http://ip:port+1/setup?mode=lan` after restart
- [ ] Verify normal flow (daemon already has TLS) does not trigger unnecessary restart
- [ ] Verify failure fallback: if TLS cert generation fails, daemon falls back to HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)