### PR TITLE
Fix WebSocket 403 when behind reverse proxy with different port

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -403,11 +403,17 @@ function createServer(opts) {
       try {
         var originUrl = new URL(origin);
         var originPort = String(originUrl.port || (originUrl.protocol === "https:" ? "443" : "80"));
-        var host = req.headers.host || "";
-        var colonIndex = host.lastIndexOf(":");
-        var hostPort = colonIndex > 0
-          ? String(host.substring(colonIndex + 1))
-          : String(tlsOptions ? "443" : "80");
+        // Extract port from Host header for reverse proxy support.
+        // Use URL parser to correctly handle IPv6 addresses (e.g. [::1])
+        // and infer default port from origin protocol (not backend tlsOptions)
+        // so TLS-terminating proxies on :443 with HTTP backends work.
+        var hostPort;
+        try {
+          var hostUrl = new URL(originUrl.protocol + "//" + (req.headers.host || ""));
+          hostPort = String(hostUrl.port || (originUrl.protocol === "https:" ? "443" : "80"));
+        } catch (e2) {
+          hostPort = String(portNum);
+        }
         if (originPort !== String(portNum) && originPort !== hostPort) {
           socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
           socket.destroy();


### PR DESCRIPTION
## Summary

- Fixes the WebSocket origin port check to also accept the `Host` header port, not just the server's own `portNum`
- When behind a reverse proxy (e.g. Tailscale Serve on `:8099` → relay on `:8092`), the browser sends `Origin: https://hostname:8099` which didn't match `portNum` (8092), causing a 403 on every WebSocket upgrade
- CSRF protection is preserved — the origin port must still match either the server's port or the proxied `Host` header port

## Test plan

- [x] Verified with `tailscale serve --https=8099 https+insecure://localhost:8092`
- [x] WebSocket upgrade returns `101 Switching Protocols` through the proxy
- [x] Direct connections (origin port = server port) continue to work
- [x] Invalid origin ports are still rejected with 403

Fixes #104

🤖 Generated with [Claude Code](https://claude.ai/code)