### PR TITLE
feat: add RTL (bidi) text support for prompt field and responses

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -974,6 +974,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     div.dataset.turn = ++turnCounter;
     var bubble = document.createElement("div");
     bubble.className = "bubble";
+    bubble.dir = "auto";
 
     if (images && images.length > 0) {
       var imgRow = document.createElement("div");
@@ -1024,7 +1025,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
       currentMsgEl = document.createElement("div");
       currentMsgEl.className = "msg-assistant";
       currentMsgEl.dataset.turn = turnCounter;
-      currentMsgEl.innerHTML = '<div class="md-content"></div>';
+      currentMsgEl.innerHTML = '<div class="md-content" dir="auto"></div>';
       addToMessages(currentMsgEl);
       currentFullText = "";
     }

--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -245,6 +245,8 @@
   max-height: 120px;
   overflow-y: auto;
   box-sizing: border-box;
+  unicode-bidi: plaintext;
+  text-align: start;
 }
 
 #input::placeholder {

--- a/lib/public/css/messages.css
+++ b/lib/public/css/messages.css
@@ -130,6 +130,8 @@
   word-break: break-word;
   white-space: pre-wrap;
   color: var(--text);
+  unicode-bidi: plaintext;
+  text-align: start;
 }
 
 /* --- Assistant message --- */
@@ -176,6 +178,8 @@
   line-height: 1.7;
   word-break: break-word;
   color: var(--text);
+  unicode-bidi: plaintext;
+  text-align: start;
 }
 
 .md-content p { margin-bottom: 14px; }
@@ -282,7 +286,7 @@ pre:hover .code-copy-btn { opacity: 1; }
 .md-content th, .md-content td {
   border: 1px solid var(--border);
   padding: 8px 12px;
-  text-align: left;
+  text-align: start;
 }
 .md-content th {
   background: rgba(255, 255, 255, 0.04);

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -259,7 +259,7 @@
             <span class="context-mini-label" id="context-mini-label">0%</span>
           </div>
           <div id="image-preview-bar"></div>
-          <textarea id="input" rows="1" placeholder="Message Claude Code..." enterkeyhint="send"></textarea>
+          <textarea id="input" rows="1" placeholder="Message Claude Code..." enterkeyhint="send" dir="auto"></textarea>
           <div id="input-bottom">
             <div id="attach-wrap">
               <button id="attach-btn" type="button" aria-label="Attach"><i data-lucide="plus"></i></button>


### PR DESCRIPTION
Add dir="auto" and unicode-bidi: plaintext to the input textarea, user message bubbles, and assistant markdown content so that RTL languages (Arabic, Hebrew, etc.) are displayed with correct text direction. Use text-align: start instead of left for direction-aware alignment.

#115 