### PR TITLE
feat: add Anthropic theme with light/dark mode

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -9,6 +9,10 @@ import { initQrCode } from './modules/qrcode.js';
 import { initFileBrowser, loadRootDirectory, refreshTree, handleFsList, handleFsRead, handleDirChanged, refreshIfOpen, handleFileChanged, handleFileHistory, handleGitDiff, handleFileAt, getPendingNavigate, closeFileViewer } from './modules/filebrowser.js';
 import { initTerminal, openTerminal, closeTerminal, resetTerminals, handleTermList, handleTermCreated, handleTermOutput, handleTermExited, handleTermClosed } from './modules/terminal.js';
 import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionResolved, markPermissionCancelled, renderPlanBanner, renderPlanCard, handleTodoWrite, handleTaskCreate, handleTaskUpdate, startThinking, appendThinking, stopThinking, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, addTurnMeta, enableMainInput, getTools, getPlanContent, setPlanContent, isPlanFilePath, getTodoTools } from './modules/tools.js';
+import { initTheme } from './modules/theme.js';
+
+// --- Initialize theme early (before render) ---
+initTheme();
 
 // --- Base path for multi-project routing ---
   var slugMatch = location.pathname.match(/^\/p\/([a-z0-9_-]+)/);

--- a/lib/public/css/base.css
+++ b/lib/public/css/base.css
@@ -9,14 +9,15 @@
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
   scrollbar-width: thin;
-  scrollbar-color: rgba(255,255,255,0.15) transparent;
+  scrollbar-color: var(--scrollbar-thumb) transparent;
 }
 
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.25); }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
+/* --- Default theme (warm dark) --- */
 :root {
   --bg: #2F2E2B;
   --bg-alt: #35332F;
@@ -40,6 +41,95 @@
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --content-width: 760px;
+  /* Overlay / shadow / scrollbar */
+  --overlay-hover: rgba(255, 255, 255, 0.04);
+  --overlay-active: rgba(255, 255, 255, 0.06);
+  --overlay-strong: rgba(255, 255, 255, 0.1);
+  --overlay-subtle: rgba(255, 255, 255, 0.02);
+  --overlay-mid: rgba(255, 255, 255, 0.05);
+  --shadow-color: rgba(0, 0, 0, 0.3);
+  --shadow-heavy: rgba(0, 0, 0, 0.5);
+  --backdrop-color: rgba(0, 0, 0, 0.5);
+  --backdrop-heavy: rgba(0, 0, 0, 0.8);
+  --scrollbar-thumb: rgba(255, 255, 255, 0.15);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+  --toast-warn-bg: #3a2a00;
+  --toast-warn-border: #7a5a00;
+  --toast-warn-text: #ffc107;
+}
+
+/* --- Anthropic theme (light) --- */
+[data-theme="anthropic"] {
+  --bg: #F5F0E8;
+  --bg-alt: #EDE7DD;
+  --text: #1A1816;
+  --text-secondary: #4A4540;
+  --text-muted: #7A756E;
+  --text-dimmer: #A09A92;
+  --accent: #DA7756;
+  --accent-hover: #C5684A;
+  --accent-bg: rgba(218, 119, 86, 0.10);
+  --code-bg: #E5DFD5;
+  --border: #D5CFC5;
+  --border-subtle: #DDD7CD;
+  --input-bg: #FFFFFF;
+  --user-bubble: #E8E0D4;
+  --error: #D93025;
+  --success: #34A853;
+  --sidebar-bg: #EBE5DB;
+  --sidebar-hover: #E2DCD2;
+  --sidebar-active: #D8D2C8;
+  --overlay-hover: rgba(0, 0, 0, 0.04);
+  --overlay-active: rgba(0, 0, 0, 0.06);
+  --overlay-strong: rgba(0, 0, 0, 0.1);
+  --overlay-subtle: rgba(0, 0, 0, 0.02);
+  --overlay-mid: rgba(0, 0, 0, 0.05);
+  --shadow-color: rgba(0, 0, 0, 0.08);
+  --shadow-heavy: rgba(0, 0, 0, 0.15);
+  --backdrop-color: rgba(0, 0, 0, 0.3);
+  --backdrop-heavy: rgba(0, 0, 0, 0.6);
+  --scrollbar-thumb: rgba(0, 0, 0, 0.15);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
+  --toast-warn-bg: #FFF3CD;
+  --toast-warn-border: #FFCA28;
+  --toast-warn-text: #856404;
+}
+
+/* --- Anthropic theme (dark) --- */
+[data-theme="anthropic-dark"] {
+  --bg: #2B2A27;
+  --bg-alt: #333230;
+  --text: #ECECEC;
+  --text-secondary: #B0AFAB;
+  --text-muted: #8A8884;
+  --text-dimmer: #5E5D5A;
+  --accent: #DA7756;
+  --accent-hover: #E5886A;
+  --accent-bg: rgba(218, 119, 86, 0.12);
+  --code-bg: #1C1B19;
+  --border: #3C3B38;
+  --border-subtle: #343331;
+  --input-bg: #3A3937;
+  --user-bubble: #3D3C39;
+  --error: #F85149;
+  --success: #57AB5A;
+  --sidebar-bg: #232220;
+  --sidebar-hover: #2E2D2A;
+  --sidebar-active: #383735;
+  --overlay-hover: rgba(255, 255, 255, 0.04);
+  --overlay-active: rgba(255, 255, 255, 0.06);
+  --overlay-strong: rgba(255, 255, 255, 0.1);
+  --overlay-subtle: rgba(255, 255, 255, 0.02);
+  --overlay-mid: rgba(255, 255, 255, 0.05);
+  --shadow-color: rgba(0, 0, 0, 0.3);
+  --shadow-heavy: rgba(0, 0, 0, 0.5);
+  --backdrop-color: rgba(0, 0, 0, 0.5);
+  --backdrop-heavy: rgba(0, 0, 0, 0.8);
+  --scrollbar-thumb: rgba(255, 255, 255, 0.15);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.25);
+  --toast-warn-bg: #3a2a00;
+  --toast-warn-border: #7a5a00;
+  --toast-warn-text: #ffc107;
 }
 
 html, body {
@@ -96,7 +186,7 @@ html, body {
   opacity: 0;
   transition: opacity 0.2s, transform 0.2s;
   pointer-events: none;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 20px var(--shadow-color);
 }
 
 .toast.visible {
@@ -104,8 +194,8 @@ html, body {
   transform: translateX(-50%) translateY(0);
 }
 .toast.toast-warn {
-  background: #3a2a00;
-  border-color: #7a5a00;
-  color: #ffc107;
+  background: var(--toast-warn-bg);
+  border-color: var(--toast-warn-border);
+  color: var(--toast-warn-text);
 }
 

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -461,7 +461,7 @@
 
 .terminal-tab:hover .terminal-tab-close,
 .terminal-tab.active .terminal-tab-close { display: flex; }
-.terminal-tab-close:hover { background: rgba(255,255,255,0.1); color: var(--text); }
+.terminal-tab-close:hover { background: var(--overlay-strong); color: var(--text); }
 
 .terminal-tab-label { cursor: default; }
 
@@ -606,7 +606,7 @@
   border-radius: 10px;
   padding: 4px 0;
   min-width: 160px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 500;
 }
 
@@ -626,7 +626,7 @@
 }
 
 .term-ctx-item .lucide { width: 14px; height: 14px; flex-shrink: 0; }
-.term-ctx-item:hover { background: rgba(255, 255, 255, 0.05); }
+.term-ctx-item:hover { background: var(--overlay-mid); }
 
 /* --- File Edit History --- */
 
@@ -727,7 +727,7 @@
 }
 
 .file-history-badge.badge-commit {
-  background: rgba(255,255,255,0.06);
+  background: var(--overlay-active);
   color: var(--text-muted);
 }
 
@@ -737,7 +737,7 @@
   color: var(--text-muted);
   margin-top: 4px;
   padding: 2px 6px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--overlay-hover);
   border-radius: 3px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -811,7 +811,7 @@
   padding: 10px 12px;
   margin-bottom: 8px;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--overlay-hover);
   border: 1px solid var(--border);
 }
 
@@ -846,11 +846,11 @@
   flex: 1;
   min-width: 0;
   padding: 7px 10px;
-  border: 1.5px dashed rgba(255, 255, 255, 0.15);
+  border: 1.5px dashed var(--overlay-strong);
   border-radius: 6px;
   font-size: 11px;
   color: var(--text-muted);
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--overlay-subtle);
   transition: border-color 0.15s, background 0.15s;
 }
 
@@ -871,7 +871,7 @@
   font-size: 10px;
   font-weight: 700;
   flex-shrink: 0;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--overlay-strong);
   color: var(--text-muted);
 }
 

--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -12,7 +12,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--overlay-active);
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 8px 12px;
@@ -23,7 +23,7 @@
 
 .bubble-paste:hover {
   border-color: var(--text-dimmer);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--overlay-strong);
 }
 
 .bubble-paste-preview {
@@ -90,7 +90,7 @@
 }
 
 .pasted-chip-remove .lucide { width: 12px; height: 12px; }
-.pasted-chip-remove:hover { color: var(--text); background: rgba(255, 255, 255, 0.1); }
+.pasted-chip-remove:hover { color: var(--text); background: var(--overlay-strong); }
 
 /* --- Paste viewer modal --- */
 #paste-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
@@ -133,7 +133,7 @@
   transition: color 0.15s, background 0.15s;
 }
 
-.paste-modal-close:hover { color: var(--text); background: rgba(255, 255, 255, 0.06); }
+.paste-modal-close:hover { color: var(--text); background: var(--overlay-active); }
 
 .paste-modal-body {
   margin: 0;
@@ -288,7 +288,7 @@
 }
 
 #attach-btn .lucide { width: 20px; height: 20px; }
-#attach-btn:hover { background: rgba(255, 255, 255, 0.06); color: var(--text); }
+#attach-btn:hover { background: var(--overlay-active); color: var(--text); }
 
 #attach-menu {
   position: absolute;
@@ -298,7 +298,7 @@
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 14px;
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 -4px 24px var(--shadow-color);
   z-index: 10;
   overflow: hidden;
 }
@@ -325,7 +325,7 @@
 }
 
 .attach-menu-item:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--overlay-mid);
   color: var(--text);
 }
 
@@ -381,7 +381,7 @@
   border: 1px solid var(--border);
   border-radius: 14px;
   margin-bottom: 8px;
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 -4px 24px var(--shadow-color);
   z-index: 10;
 }
 
@@ -400,7 +400,7 @@
 
 .slash-item:hover,
 .slash-item.active {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--overlay-mid);
 }
 
 .slash-item .slash-cmd {

--- a/lib/public/css/menus.css
+++ b/lib/public/css/menus.css
@@ -70,7 +70,7 @@
   border-radius: 10px;
   padding: 8px 0;
   min-width: 200px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 200;
 }
 
@@ -99,7 +99,7 @@
   transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 #terminal-toggle-btn .lucide { width: 15px; height: 15px; }
-#terminal-toggle-btn:hover { color: var(--text-secondary); background: rgba(255,255,255,0.04); border-color: var(--border); }
+#terminal-toggle-btn:hover { color: var(--text-secondary); background: var(--overlay-hover); border-color: var(--border); }
 #terminal-toggle-btn { position: relative; }
 #terminal-count {
   position: absolute;
@@ -134,13 +134,13 @@
   transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 #qr-btn .lucide { width: 15px; height: 15px; }
-#qr-btn:hover { color: var(--text-secondary); background: rgba(255,255,255,0.04); border-color: var(--border); }
-#qr-btn.active { color: var(--text); background: rgba(255,255,255,0.06); border-color: var(--border); }
+#qr-btn:hover { color: var(--text-secondary); background: var(--overlay-hover); border-color: var(--border); }
+#qr-btn.active { color: var(--text); background: var(--overlay-active); border-color: var(--border); }
 
 #qr-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--backdrop-color);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -156,7 +156,7 @@
   flex-direction: column;
   align-items: center;
   gap: 14px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 8px 32px var(--shadow-heavy);
 }
 
 #qr-canvas table { border-collapse: collapse; }
@@ -204,8 +204,8 @@
 }
 
 #notif-btn .lucide { width: 15px; height: 15px; }
-#notif-btn:hover { color: var(--text-secondary); background: rgba(255,255,255,0.04); border-color: var(--border); }
-#notif-btn.active { color: var(--text); background: rgba(255,255,255,0.06); border-color: var(--border); }
+#notif-btn:hover { color: var(--text-secondary); background: var(--overlay-hover); border-color: var(--border); }
+#notif-btn.active { color: var(--text); background: var(--overlay-active); border-color: var(--border); }
 
 #notif-menu {
   position: absolute;
@@ -216,7 +216,7 @@
   border-radius: 10px;
   padding: 8px 0;
   min-width: 200px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 200;
 }
 
@@ -245,7 +245,7 @@
   flex-shrink: 0;
 }
 
-.notif-option:hover { background: rgba(255, 255, 255, 0.03); }
+.notif-option:hover { background: var(--overlay-hover); }
 .notif-option input { display: none; }
 
 #notif-blocked-hint {
@@ -317,7 +317,7 @@
   transition: background 0.15s;
 }
 
-.notif-action:hover { background: rgba(255, 255, 255, 0.03); }
+.notif-action:hover { background: var(--overlay-hover); }
 .notif-action .lucide { flex-shrink: 0; }
 
 .notif-action.copied { color: var(--success); }
@@ -382,8 +382,8 @@
 }
 
 #model-btn .lucide { width: 10px; height: 10px; }
-#model-btn:hover { color: var(--text-secondary); background: rgba(255,255,255,0.06); }
-#model-btn.active { color: var(--text-secondary); background: rgba(255,255,255,0.06); }
+#model-btn:hover { color: var(--text-secondary); background: var(--overlay-active); }
+#model-btn.active { color: var(--text-secondary); background: var(--overlay-active); }
 
 #model-menu {
   position: absolute;
@@ -394,7 +394,7 @@
   border-radius: 12px;
   padding: 4px 0;
   min-width: 200px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 200;
 }
 
@@ -416,7 +416,7 @@
   white-space: nowrap;
 }
 
-.model-menu-item:hover { background: rgba(255,255,255,0.05); color: var(--text); }
+.model-menu-item:hover { background: var(--overlay-mid); color: var(--text); }
 .model-menu-item.active { color: var(--accent); font-weight: 600; }
 
 /* --- Info panels container --- */
@@ -441,7 +441,7 @@
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 12px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px var(--shadow-color);
   font-size: 12px;
   pointer-events: auto;
 }
@@ -476,7 +476,7 @@
   border-radius: 4px;
 }
 
-.usage-panel-header button:hover { color: var(--text); background: rgba(255,255,255,0.06); }
+.usage-panel-header button:hover { color: var(--text); background: var(--overlay-active); }
 .usage-panel-header button .lucide { width: 14px; height: 14px; }
 
 .usage-panel-body {

--- a/lib/public/css/messages.css
+++ b/lib/public/css/messages.css
@@ -26,7 +26,7 @@
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 12px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px var(--shadow-color);
   overflow: hidden;
 }
 
@@ -38,7 +38,7 @@
   cursor: pointer;
   user-select: none;
 }
-#todo-sticky .todo-sticky-header:hover { background: rgba(255, 255, 255, 0.03); }
+#todo-sticky .todo-sticky-header:hover { background: var(--overlay-hover); }
 #todo-sticky .todo-sticky-icon { display: inline-flex; color: var(--accent); }
 #todo-sticky .todo-sticky-icon .lucide { width: 14px; height: 14px; }
 #todo-sticky .todo-sticky-title { font-size: 12px; font-weight: 600; color: var(--text-secondary); flex: 1; }
@@ -101,7 +101,7 @@
   cursor: pointer;
   z-index: 10;
   transition: opacity 0.15s;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px var(--shadow-color);
 }
 #new-msg-btn:hover {
   background: var(--sidebar-hover);
@@ -144,11 +144,11 @@
 }
 
 .msg-assistant:hover {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--overlay-subtle);
 }
 
 .msg-assistant.copy-primed {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--overlay-hover);
   cursor: pointer;
 }
 
@@ -197,7 +197,7 @@
 .md-content h3 { font-size: 1.1em; }
 
 .md-content code {
-  background: rgba(255, 255, 255, 0.07);
+  background: var(--overlay-strong);
   padding: 2px 7px;
   border-radius: 6px;
   font-family: "SF Mono", "Fira Code", Menlo, Monaco, "Cascadia Code", monospace;
@@ -289,7 +289,7 @@ pre:hover .code-copy-btn { opacity: 1; }
   text-align: start;
 }
 .md-content th {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--overlay-hover);
   font-weight: 600;
 }
 
@@ -346,7 +346,7 @@ pre.mermaid-error {
 /* --- Mermaid Viewer Modal --- */
 #mermaid-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
 #mermaid-modal.hidden { display: none; }
-#mermaid-modal .confirm-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; background: rgba(0, 0, 0, 0.7); }
+#mermaid-modal .confirm-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; background: var(--backdrop-color); }
 
 .mermaid-modal-dialog {
   position: relative;
@@ -359,7 +359,7 @@ pre.mermaid-error {
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 16px;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 24px 80px var(--shadow-heavy);
 }
 
 .mermaid-modal-header {
@@ -395,7 +395,7 @@ pre.mermaid-error {
   transition: color 0.15s, background 0.15s;
 }
 
-.mermaid-modal-btn:hover { color: var(--text); background: rgba(255, 255, 255, 0.06); }
+.mermaid-modal-btn:hover { color: var(--text); background: var(--overlay-active); }
 
 .mermaid-modal-body {
   padding: 24px;
@@ -414,7 +414,7 @@ pre.mermaid-error {
 /* --- Image lightbox modal --- */
 #image-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
 #image-modal.hidden { display: none; }
-#image-modal .confirm-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; background: rgba(0, 0, 0, 0.8); }
+#image-modal .confirm-backdrop { backdrop-filter: none; -webkit-backdrop-filter: none; background: var(--backdrop-heavy); }
 
 .image-modal-dialog {
   position: relative;
@@ -429,7 +429,7 @@ pre.mermaid-error {
   max-height: 90vh;
   border-radius: 12px;
   object-fit: contain;
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 24px 80px var(--shadow-heavy);
 }
 
 .image-modal-close {
@@ -440,7 +440,7 @@ pre.mermaid-error {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--backdrop-color);
   border: none;
   color: #fff;
   cursor: pointer;
@@ -448,7 +448,7 @@ pre.mermaid-error {
   border-radius: 50%;
   transition: background 0.15s;
 }
-.image-modal-close:hover { background: rgba(255, 255, 255, 0.2); }
+.image-modal-close:hover { background: var(--overlay-strong); }
 
 /* ==========================================================================
    Thinking
@@ -467,13 +467,13 @@ pre.mermaid-error {
   cursor: pointer;
   padding: 6px 12px;
   user-select: none;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--overlay-hover);
   border-radius: 8px;
   transition: background 0.15s;
 }
 
 .thinking-header:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--overlay-active);
 }
 
 .thinking-chevron {
@@ -525,7 +525,7 @@ pre.mermaid-error {
   word-break: break-word;
   max-height: 300px;
   overflow-y: auto;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--overlay-subtle);
   border-radius: 8px;
 }
 
@@ -548,7 +548,7 @@ pre.mermaid-error {
   padding: 8px 12px;
   cursor: pointer;
   user-select: none;
-  background: rgba(255, 255, 255, 0.025);
+  background: var(--overlay-subtle);
   border-radius: 10px;
   transition: background 0.15s;
 }
@@ -570,7 +570,7 @@ pre.mermaid-error {
 }
 
 .tool-header:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--overlay-mid);
 }
 
 .tool-bullet {
@@ -739,7 +739,7 @@ pre.mermaid-error {
   font-size: 12px;
   font-family: "SF Mono", Menlo, Monaco, monospace;
   color: var(--text-muted);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--overlay-hover);
   border-bottom: 1px solid var(--border-subtle);
 }
 
@@ -900,7 +900,7 @@ pre.mermaid-error {
 
 .plan-card-body {
   padding: 16px 18px;
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--overlay-subtle);
   border: 1px solid var(--border);
   border-top: none;
   border-radius: 0 0 12px 12px;
@@ -918,7 +918,7 @@ pre.mermaid-error {
 .plan-card-body h1 { font-size: 1.3em; }
 .plan-card-body h2 { font-size: 1.15em; }
 .plan-card-body h3 { font-size: 1.05em; }
-.plan-card-body code { background: rgba(255,255,255,0.06); padding: 2px 6px; border-radius: 4px; font-family: "SF Mono", Menlo, Monaco, monospace; font-size: 0.88em; }
+.plan-card-body code { background: var(--overlay-active); padding: 2px 6px; border-radius: 4px; font-family: "SF Mono", Menlo, Monaco, monospace; font-size: 0.88em; }
 .plan-card-body pre { background: var(--code-bg); border: 1px solid var(--border); border-radius: 8px; margin: 8px 0; }
 .plan-card-body pre code { display: block; padding: 10px 12px; overflow-x: auto; font-size: 12px; line-height: 1.5; background: none; border-radius: 0; }
 .plan-card-body ul, .plan-card-body ol { padding-left: 22px; margin: 6px 0; }
@@ -949,7 +949,7 @@ pre.mermaid-error {
   align-items: center;
   gap: 8px;
   padding: 10px 16px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--overlay-hover);
   border: 1px solid var(--border);
   border-radius: 12px 12px 0 0;
 }

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -118,7 +118,7 @@
   border-radius: 10px;
   padding: 12px 16px;
   z-index: 200;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   white-space: nowrap;
 }
 
@@ -140,7 +140,7 @@
   font-family: "SF Mono", Menlo, Monaco, monospace;
   font-size: 13px;
   color: var(--text);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--overlay-active);
   padding: 6px 12px;
   border-radius: 6px;
   user-select: all;
@@ -211,7 +211,7 @@
 .confirm-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--backdrop-color);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
 }
@@ -224,7 +224,7 @@
   padding: 20px 24px;
   max-width: 320px;
   width: 90%;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 8px 32px var(--shadow-heavy);
 }
 
 .confirm-text {
@@ -341,13 +341,13 @@
   align-items: center;
   gap: 8px;
   padding: 8px 12px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--overlay-hover);
   cursor: pointer;
   user-select: none;
   transition: background 0.15s;
 }
 
-.rewind-file-header:hover { background: rgba(255, 255, 255, 0.06); }
+.rewind-file-header:hover { background: var(--overlay-active); }
 
 .rewind-file-chevron {
   display: inline-flex;
@@ -434,7 +434,7 @@
 }
 
 .resume-modal-hint code {
-  background: rgba(255, 255, 255, 0.07);
+  background: var(--overlay-hover);
   padding: 2px 6px;
   border-radius: 4px;
   font-family: "SF Mono", Menlo, Monaco, monospace;
@@ -488,7 +488,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--overlay-hover);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 8px 10px;

--- a/lib/public/css/rewind.css
+++ b/lib/public/css/rewind.css
@@ -60,7 +60,7 @@
   background: var(--bg-alt);
   border: 1px solid rgba(218, 119, 86, 0.25);
   border-radius: 20px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 10;
   white-space: nowrap;
 }
@@ -156,7 +156,7 @@
 
 .rewind-timeline-marker:hover {
   border-color: var(--accent);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px var(--shadow-color);
 }
 
 .rewind-timeline-marker:hover .lucide,
@@ -280,7 +280,7 @@
 }
 
 .ask-user-option:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--overlay-active);
   border-color: var(--accent);
 }
 
@@ -353,7 +353,7 @@
 }
 
 .ask-user-skip:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--overlay-hover);
   color: var(--text-secondary);
   border-color: var(--text-dimmer);
 }
@@ -382,7 +382,7 @@
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--overlay-hover);
   border: 1px solid var(--border);
   border-bottom: none;
   border-radius: 12px 12px 0 0;
@@ -398,7 +398,7 @@
   border: 1px solid var(--border);
   border-top: none;
   border-bottom: none;
-  background: rgba(255, 255, 255, 0.015);
+  background: var(--overlay-subtle);
 }
 
 .permission-summary {
@@ -464,7 +464,7 @@
   border: 1px solid var(--border);
   border-top: none;
   border-radius: 0 0 12px 12px;
-  background: rgba(255, 255, 255, 0.015);
+  background: var(--overlay-subtle);
 }
 
 .permission-btn {

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -148,7 +148,7 @@
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 4px 0;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 120;
   max-height: 320px;
   overflow-y: auto;
@@ -181,7 +181,7 @@
 }
 
 .project-dropdown-item:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--overlay-mid);
 }
 
 .project-dropdown-item.current {
@@ -246,7 +246,7 @@
 }
 
 .project-dropdown-footer button:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--overlay-mid);
   color: var(--text-secondary);
 }
 
@@ -508,7 +508,7 @@
 
 .session-more-btn .lucide { width: 14px; height: 14px; }
 .session-item:hover .session-more-btn { display: flex; }
-.session-more-btn:hover { color: var(--text); background: rgba(255, 255, 255, 0.06); }
+.session-more-btn:hover { color: var(--text); background: var(--overlay-active); }
 
 /* --- Session context menu --- */
 .session-ctx-menu {
@@ -521,7 +521,7 @@
   border-radius: 10px;
   padding: 4px 0;
   min-width: 140px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 110;
 }
 
@@ -541,7 +541,7 @@
 }
 
 .session-ctx-item .lucide { width: 14px; height: 14px; flex-shrink: 0; }
-.session-ctx-item:hover { background: rgba(255, 255, 255, 0.05); }
+.session-ctx-item:hover { background: var(--overlay-mid); }
 
 .session-ctx-item.session-ctx-delete { color: var(--error); }
 .session-ctx-item.session-ctx-delete:hover { background: rgba(229, 83, 75, 0.08); }
@@ -621,7 +621,7 @@
   border: 1px solid var(--border);
   border-radius: 10px;
   padding: 4px 0;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow-color);
   z-index: 110;
 }
 
@@ -644,7 +644,7 @@
 }
 
 .sidebar-menu-item .lucide { width: 14px; height: 14px; flex-shrink: 0; }
-.sidebar-menu-item:hover { background: rgba(255, 255, 255, 0.05); }
+.sidebar-menu-item:hover { background: var(--overlay-mid); }
 
 .sidebar-menu-item.has-badge { position: relative; }
 .sidebar-menu-item .menu-badge {
@@ -654,12 +654,26 @@
   color: var(--success);
 }
 
+/* --- Theme picker in sidebar menu --- */
+.sidebar-menu-theme {
+  justify-content: flex-start;
+}
+.sidebar-menu-value {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dimmer);
+  padding: 2px 8px;
+  background: var(--overlay-hover);
+  border-radius: 6px;
+}
+
 /* --- Sidebar overlay (mobile) --- */
 #sidebar-overlay {
   display: none;
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--backdrop-color);
   z-index: 99;
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -13,7 +13,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600&family=Styrene+A+Web:wght@400;500&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark-dimmed.min.css">
+<link id="hljs-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark-dimmed.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/file-icons-js@1/css/style.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/css/xterm.min.css">
 <link rel="stylesheet" href="style.css">
@@ -86,6 +86,10 @@
         </a>
         <button class="sidebar-menu-item" id="footer-status">
           <i data-lucide="activity"></i> <span>Status</span>
+        </button>
+        <button class="sidebar-menu-item sidebar-menu-theme" id="footer-theme">
+          <i data-lucide="palette"></i> <span>Theme</span>
+          <span id="footer-theme-value" class="sidebar-menu-value">Default</span>
         </button>
         <button class="sidebar-menu-item" id="footer-update-check">
           <i data-lucide="refresh-cw"></i> <span>Check for updates</span>

--- a/lib/public/modules/notifications.js
+++ b/lib/public/modules/notifications.js
@@ -1,5 +1,6 @@
 import { copyToClipboard } from './utils.js';
 import { iconHtml, refreshIcons } from './icons.js';
+import { cycleTheme, getThemeLabel } from './theme.js';
 
 var ctx;
 var basePath = "/";
@@ -202,6 +203,20 @@ export function initNotifications(_ctx) {
         e.stopPropagation();
         footerMenu.classList.add("hidden");
         if (ctx.toggleStatusPanel) ctx.toggleStatusPanel();
+      });
+    }
+
+    // --- Theme picker ---
+    var footerTheme = $("footer-theme");
+    var footerThemeValue = $("footer-theme-value");
+    if (footerTheme) {
+      // Set initial label
+      footerThemeValue.textContent = getThemeLabel();
+      footerTheme.addEventListener("click", function (e) {
+        e.stopPropagation();
+        cycleTheme();
+        footerThemeValue.textContent = getThemeLabel();
+        refreshIcons();
       });
     }
   })();

--- a/lib/public/modules/theme.js
+++ b/lib/public/modules/theme.js
@@ -1,0 +1,67 @@
+// --- Theme management ---
+
+var STORAGE_KEY = "claude-relay-theme";
+var THEMES = ["default", "anthropic"];
+var currentTheme = "default";
+var darkMq = window.matchMedia("(prefers-color-scheme: dark)");
+
+export function getTheme() {
+  return currentTheme;
+}
+
+export function getThemeLabel() {
+  return currentTheme === "default" ? "Default" : "Anthropic";
+}
+
+export function setTheme(name) {
+  if (THEMES.indexOf(name) === -1) name = "default";
+  currentTheme = name;
+  try { localStorage.setItem(STORAGE_KEY, name); } catch (e) {}
+  applyTheme();
+}
+
+export function cycleTheme() {
+  var idx = THEMES.indexOf(currentTheme);
+  var next = THEMES[(idx + 1) % THEMES.length];
+  setTheme(next);
+  return next;
+}
+
+function applyTheme() {
+  var html = document.documentElement;
+  var meta = document.querySelector('meta[name="theme-color"]');
+  var hljsLink = document.getElementById("hljs-theme");
+
+  if (currentTheme === "default") {
+    delete html.dataset.theme;
+    if (meta) meta.content = "#2F2E2B";
+    if (hljsLink) hljsLink.href = "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark-dimmed.min.css";
+  } else if (currentTheme === "anthropic") {
+    var prefersDark = darkMq.matches;
+    html.dataset.theme = prefersDark ? "anthropic-dark" : "anthropic";
+    if (meta) {
+      meta.content = prefersDark ? "#2B2A27" : "#F5F0E8";
+    }
+    if (hljsLink) {
+      hljsLink.href = prefersDark
+        ? "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark-dimmed.min.css"
+        : "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github.min.css";
+    }
+  }
+}
+
+export function initTheme() {
+  // Read saved preference
+  try {
+    var saved = localStorage.getItem(STORAGE_KEY);
+    if (saved && THEMES.indexOf(saved) !== -1) currentTheme = saved;
+  } catch (e) {}
+
+  // Apply immediately
+  applyTheme();
+
+  // Listen for OS dark/light changes (matters for anthropic theme)
+  darkMq.addEventListener("change", function () {
+    if (currentTheme === "anthropic") applyTheme();
+  });
+}


### PR DESCRIPTION
## Summary
- Add a theme system with two themes: **Default** (warm dark) and **Anthropic** (matching claude.ai's appearance)
- The Anthropic theme auto-switches between light and dark modes based on OS `prefers-color-scheme`
- Replace all hardcoded `rgba()` values across 8 CSS files with CSS custom properties for full theme compatibility

## Details
- New `theme.js` module handles persistence (localStorage), OS dark/light detection, and dynamic highlight.js stylesheet swapping
- Theme picker added to the sidebar footer menu — cycles between Default and Anthropic on click
- Three variable sets in `base.css`: `:root` (default dark), `[data-theme="anthropic"]` (light), `[data-theme="anthropic-dark"]` (dark)

## Test plan
- [ ] Verify Default theme looks unchanged
- [ ] Switch to Anthropic theme — confirm light mode appearance matches claude.ai
- [ ] Toggle OS to dark mode — confirm Anthropic dark mode activates automatically
- [ ] Refresh page — confirm theme preference persists
- [ ] Check all modals, menus, code blocks, and overlays render correctly in both themes