### PR TITLE
feat: add project from web UI via modal dialog

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -73,6 +73,7 @@ var relay = createServer({
   debug: config.debug || false,
   dangerouslySkipPermissions: config.dangerouslySkipPermissions || false,
   lanHost: lanIp ? lanIp + ":" + config.port : null,
+  addProjectCallback: function (p) { return handleAddProject(p); },
 });
 
 // --- Register projects ---
@@ -90,26 +91,34 @@ for (var i = 0; i < projects.length; i++) {
 // Sync ~/.clayrc on startup
 try { syncClayrc(config.projects); } catch (e) {}
 
+// --- Shared add-project logic (used by IPC + WebSocket) ---
+function handleAddProject(absPath) {
+  if (!absPath) return { ok: false, error: "missing path" };
+  absPath = path.resolve(absPath);
+  if (!fs.existsSync(absPath)) return { ok: false, error: "path does not exist" };
+  try { if (!fs.statSync(absPath).isDirectory()) return { ok: false, error: "path is not a directory" }; } catch(e) { return { ok: false, error: "cannot read path" }; }
+  for (var j = 0; j < config.projects.length; j++) {
+    if (config.projects[j].path === absPath) {
+      return { ok: true, slug: config.projects[j].slug, existing: true };
+    }
+  }
+  var slugs = config.projects.map(function (p) { return p.slug; });
+  var slug = generateSlug(absPath, slugs);
+  relay.addProject(absPath, slug);
+  config.projects.push({ path: absPath, slug: slug, addedAt: Date.now() });
+  saveConfig(config);
+  try { syncClayrc(config.projects); } catch (e) {}
+  console.log("[daemon] Added project:", slug, "→", absPath);
+  relay.broadcastAll({ type: "projects_updated", projectCount: relay.getProjects().length, projects: relay.getProjects() });
+  return { ok: true, slug: slug };
+}
+
 // --- IPC server ---
 var ipc = createIPCServer(socketPath(), function (msg) {
   switch (msg.cmd) {
     case "add_project": {
       if (!msg.path) return { ok: false, error: "missing path" };
-      var absPath = path.resolve(msg.path);
-      // Check if already registered
-      for (var j = 0; j < config.projects.length; j++) {
-        if (config.projects[j].path === absPath) {
-          return { ok: true, slug: config.projects[j].slug, existing: true };
-        }
-      }
-      var slugs = config.projects.map(function (p) { return p.slug; });
-      var slug = generateSlug(absPath, slugs);
-      relay.addProject(absPath, slug);
-      config.projects.push({ path: absPath, slug: slug, addedAt: Date.now() });
-      saveConfig(config);
-      try { syncClayrc(config.projects); } catch (e) {}
-      console.log("[daemon] Added project:", slug, "→", absPath);
-      return { ok: true, slug: slug };
+      return handleAddProject(msg.path);
     }
 
     case "remove_project": {

--- a/lib/project.js
+++ b/lib/project.js
@@ -67,6 +67,7 @@ function createProjectContext(opts) {
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
   var currentVersion = opts.currentVersion;
   var lanHost = opts.lanHost || null;
+  var addProject = opts.addProject || null;
   var getProjectCount = opts.getProjectCount || function () { return 1; };
   var getProjectList = opts.getProjectList || function () { return []; };
   var latestVersion = null;
@@ -293,6 +294,24 @@ function createProjectContext(opts) {
 
   // --- WS message handler ---
   function handleMessage(ws, msg) {
+    if (msg.type === "add_project") {
+      if (!addProject) {
+        sendTo(ws, { type: "toast", level: "error", message: "Adding projects not supported in this mode." });
+        return;
+      }
+      if (!msg.path) {
+        sendTo(ws, { type: "toast", level: "error", message: "No path provided." });
+        return;
+      }
+      var result = addProject(msg.path);
+      if (result.ok) {
+        sendTo(ws, { type: "project_added", slug: result.slug, path: msg.path, existing: !!result.existing });
+      } else {
+        sendTo(ws, { type: "toast", level: "error", message: result.error || "Failed to add project." });
+      }
+      return;
+    }
+
     if (msg.type === "push_subscribe") {
       if (pushModule && msg.subscription) pushModule.addSubscription(msg.subscription, msg.replaceEndpoint);
       return;

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -98,10 +98,12 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     if (addBtn) {
       addBtn.onclick = function () {
         closeProjectDropdown();
-        var hint = document.getElementById("project-hint");
-        if (hint) {
-          hint.classList.remove("hidden");
-          try { localStorage.removeItem("claude-relay-project-hint-dismissed"); } catch (e) {}
+        var modal = document.getElementById("add-project-modal");
+        var input = document.getElementById("add-project-path");
+        if (modal && input) {
+          input.value = "";
+          modal.classList.remove("hidden");
+          input.focus();
         }
       };
     }
@@ -149,6 +151,33 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
       try { localStorage.setItem("claude-relay-project-hint-dismissed", "1"); } catch (e) {}
     });
   }
+
+  // --- Add project modal ---
+  (function () {
+    var addModal = $("add-project-modal");
+    var addInput = $("add-project-path");
+    var addSubmit = $("add-project-submit");
+    var addCancel = $("add-project-cancel");
+    if (!addModal) return;
+
+    function closeAddModal() { addModal.classList.add("hidden"); }
+
+    function submitAddProject() {
+      var val = addInput.value.trim();
+      if (!val) return;
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: "add_project", path: val }));
+      }
+      closeAddModal();
+    }
+
+    addSubmit.addEventListener("click", submitAddProject);
+    addCancel.addEventListener("click", closeAddModal);
+    addModal.querySelector(".confirm-backdrop").addEventListener("click", closeAddModal);
+    addInput.addEventListener("keydown", function (e) {
+      if (e.key === "Enter") { e.preventDefault(); submitAddProject(); }
+    });
+  })();
 
   // Modal close handlers (replaces inline onclick)
   $("paste-modal").querySelector(".confirm-backdrop").addEventListener("click", function() {
@@ -1352,6 +1381,14 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
 
         case "toast":
           showToast(msg.message, msg.level, msg.detail);
+          break;
+
+        case "project_added":
+          window.location.href = "/p/" + msg.slug + "/";
+          break;
+
+        case "projects_updated":
+          updateProjectSwitcher(msg);
           break;
 
         case "input_sync":

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -196,6 +196,41 @@
 #skip-perms-banner.hidden { display: none; }
 #skip-perms-banner .lucide { width: 14px; height: 14px; flex-shrink: 0; }
 
+/* --- Add project modal --- */
+#add-project-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
+#add-project-modal.hidden { display: none; }
+
+.confirm-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.confirm-body {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 16px;
+}
+
+.confirm-body p { margin: 0 0 10px; }
+
+#add-project-path {
+  width: 100%;
+  padding: 8px 10px;
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  font-size: 13px;
+  color: var(--text);
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  outline: none;
+  box-sizing: border-box;
+}
+
+#add-project-path:focus { border-color: var(--accent); }
+
 /* --- Confirm modal --- */
 #confirm-modal {
   position: fixed;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -403,6 +403,21 @@
   </div>
 </div>
 
+<div id="add-project-modal" class="hidden">
+  <div class="confirm-backdrop"></div>
+  <div class="confirm-dialog">
+    <div class="confirm-title">Add Project</div>
+    <div class="confirm-body">
+      <p>Enter the absolute path to a project directory:</p>
+      <input type="text" id="add-project-path" placeholder="/path/to/project" autocomplete="off" spellcheck="false" />
+    </div>
+    <div class="confirm-actions">
+      <button class="confirm-btn confirm-cancel" id="add-project-cancel">Cancel</button>
+      <button class="confirm-btn confirm-ok" id="add-project-submit">Add</button>
+    </div>
+  </div>
+</div>
+
 <div id="confirm-modal" class="hidden">
   <div class="confirm-backdrop"></div>
   <div class="confirm-dialog">

--- a/lib/server.js
+++ b/lib/server.js
@@ -124,6 +124,7 @@ function createServer(opts) {
   var debug = opts.debug || false;
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
   var lanHost = opts.lanHost || null;
+  var addProjectCallback = opts.addProjectCallback || null;
 
   var authToken = pinHash || null;
   var realVersion = require("../package.json").version;
@@ -466,6 +467,7 @@ function createServer(opts) {
       dangerouslySkipPermissions: dangerouslySkipPermissions,
       currentVersion: currentVersion,
       lanHost: lanHost,
+      addProject: addProjectCallback,
       getProjectCount: function () { return projects.size; },
       getProjectList: function () {
         var list = [];


### PR DESCRIPTION
## Summary
- Replace the "Add project" button hint with an interactive modal dialog
- Accepts an absolute directory path and registers it as a new project
- Reuses the same validation and registration logic as the CLI/IPC path
- After adding, broadcast `projects_updated` to all connected clients so the project dropdown updates immediately (no refresh needed)

## Test plan
- [ ] Open the sidebar and click the "Add Project" button
- [ ] Verify the modal dialog appears with a path input field
- [ ] Enter a valid project path and confirm it gets added
- [ ] Verify the browser navigates to the new project
- [ ] Open a second browser tab on a different project — verify its project dropdown updates immediately after adding
- [ ] Test with invalid paths and verify error toasts appear