### PR TITLE
fix: show iOS Safari PWA guidance for push notifications

### DIFF
--- a/lib/public/css/menus.css
+++ b/lib/public/css/menus.css
@@ -302,6 +302,30 @@
   display: none;
 }
 
+/* iOS Safari notification info */
+.notif-ios-info { cursor: default; }
+.notif-ios-info-btn {
+  background: none;
+  border: none;
+  color: var(--text-dimmer);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+.notif-ios-info-btn:hover { color: var(--text-secondary); }
+
+#notif-ios-hint {
+  padding: 6px 14px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+#notif-ios-hint .lucide { flex-shrink: 0; }
+#notif-ios-hint strong { color: var(--text-secondary); }
+#notif-ios-hint.hidden { display: none; }
+
 .notif-action {
   display: flex;
   align-items: center;

--- a/lib/public/modules/notifications.js
+++ b/lib/public/modules/notifications.js
@@ -262,6 +262,15 @@ export function initNotifications(_ctx) {
     }
   });
 
+  // --- iOS Safari detection ---
+  var isIOSSafari = (function () {
+    var ua = navigator.userAgent;
+    var isIOS = /iPad|iPhone|iPod/.test(ua) || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+    var isSafari = isIOS && /Safari/.test(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(ua);
+    return isSafari;
+  })();
+  var isStandalone = window.matchMedia("(display-mode:standalone)").matches || navigator.standalone;
+
   // --- Browser notifications ---
   notifPermission = ("Notification" in window) ? Notification.permission : "denied";
   notifAlertEnabled = localStorage.getItem("notif-alert") !== "0";
@@ -334,6 +343,7 @@ export function initNotifications(_ctx) {
     if (ua.indexOf("Firefox") !== -1) url = "about:preferences#privacy";
     else if (ua.indexOf("Edg/") !== -1) url = "edge://settings/content/notifications";
     else if (ua.indexOf("Arc") !== -1) url = "arc://settings/content/notifications";
+    else if (isIOSSafari) url = "Settings > Safari > Notifications";
     notifSettingsUrl.textContent = url;
   })();
 
@@ -375,7 +385,34 @@ export function initNotifications(_ctx) {
   var pushAvailable = ("serviceWorker" in navigator) &&
     (location.protocol === "https:" || location.hostname === "localhost");
 
-  if (pushAvailable) {
+  // On iOS Safari (not in PWA mode), replace the push toggle with an info hint
+  if (isIOSSafari && !isStandalone) {
+    var infoRow = document.createElement("div");
+    infoRow.className = "notif-option notif-ios-info";
+    infoRow.style.display = "flex";
+    infoRow.innerHTML =
+      '<span><i data-lucide="smartphone" style="width:14px;height:14px"></i> Push notifications</span>' +
+      '<button class="notif-ios-info-btn" title="Info"><i data-lucide="info" style="width:14px;height:14px"></i></button>';
+    notifPushRow.parentNode.replaceChild(infoRow, notifPushRow);
+
+    var iosHint = document.createElement("div");
+    iosHint.id = "notif-ios-hint";
+    iosHint.className = "hidden";
+    iosHint.innerHTML =
+      'To enable push notifications on iOS, tap <strong>Share</strong> ' +
+      '<i data-lucide="share" style="width:12px;height:12px;vertical-align:-2px"></i> ' +
+      'then <strong>Add to Home Screen</strong>. ' +
+      'Push notifications work inside the installed app.';
+    infoRow.parentNode.insertBefore(iosHint, infoRow.nextSibling);
+
+    infoRow.querySelector(".notif-ios-info-btn").addEventListener("click", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      iosHint.classList.toggle("hidden");
+      refreshIcons();
+    });
+    refreshIcons();
+  } else if (pushAvailable) {
     notifPushRow.style.display = "flex";
   }
 


### PR DESCRIPTION
## Summary
- On iOS Safari (non-PWA), the push notification toggle doesn't work since Web Push requires installation as a PWA
- Replace the non-functional toggle with an info icon and guidance explaining how to add the app to Home Screen
- Add Safari fallback for the notification settings URL
- Only affects iOS Safari; other browsers retain the standard push notification toggle

## Test plan
- [ ] Open notification settings on iOS Safari and verify the push row shows PWA installation guidance
- [ ] Verify the browser alerts toggle still works normally on iOS Safari
- [ ] Verify push notification toggle works as expected on non-iOS browsers
- [ ] Test on Chrome/Firefox to confirm no regressions