### PR TITLE
fix: prevent iOS Safari from URL-encoding copied text

### DIFF
--- a/lib/public/modules/tools.js
+++ b/lib/public/modules/tools.js
@@ -1,4 +1,4 @@
-import { escapeHtml } from './utils.js';
+import { escapeHtml, copyToClipboard } from './utils.js';
 import { iconHtml, refreshIcons, randomThinkingVerb } from './icons.js';
 import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks } from './markdown.js';
 import { renderUnifiedDiff, renderSplitDiff, renderPatchDiff } from './diff.js';
@@ -519,7 +519,7 @@ export function renderPlanCard(content) {
   if (copyBtn) {
     copyBtn.addEventListener("click", function (e) {
       e.stopPropagation();
-      navigator.clipboard.writeText(content).then(function () {
+      copyToClipboard(content).then(function () {
         copyBtn.innerHTML = iconHtml("check");
         refreshIcons();
         setTimeout(function () {

--- a/lib/public/modules/utils.js
+++ b/lib/public/modules/utils.js
@@ -18,18 +18,34 @@ export function showToast(message, level, detail) {
   }, duration);
 }
 
+var isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+
 export function copyToClipboard(text) {
   var p;
-  if (navigator.clipboard && navigator.clipboard.writeText) {
-    p = navigator.clipboard.writeText(text);
-  } else {
+  if (isIOS) {
+    // iOS Safari URL-encodes clipboard text that contains colons via the
+    // Clipboard API. Use textarea + execCommand to copy raw text instead.
     var ta = document.createElement("textarea");
     ta.value = text;
-    ta.style.cssText = "position:fixed;opacity:0";
+    ta.style.cssText = "position:fixed;left:-9999px;opacity:0";
     document.body.appendChild(ta);
-    ta.select();
+    ta.focus();
+    ta.setSelectionRange(0, ta.value.length);
     document.execCommand("copy");
     document.body.removeChild(ta);
+    p = Promise.resolve();
+  } else if (navigator.clipboard && navigator.clipboard.writeText) {
+    p = navigator.clipboard.writeText(text);
+  } else {
+    var ta2 = document.createElement("textarea");
+    ta2.value = text;
+    ta2.style.cssText = "position:fixed;left:-9999px;opacity:0";
+    document.body.appendChild(ta2);
+    ta2.focus();
+    ta2.setSelectionRange(0, ta2.value.length);
+    document.execCommand("copy");
+    document.body.removeChild(ta2);
     p = Promise.resolve();
   }
   return p.then(function () { showToast("Copied to clipboard"); });


### PR DESCRIPTION
## Summary
- iOS Safari interprets clipboard text containing colons (e.g. `SomeException: message`) as URL schemes and percent-encodes it
- Bypass the Clipboard API on iOS and use textarea + `execCommand("copy")` to copy raw text without URL normalization
- Also route the plan card copy button through the shared `copyToClipboard` utility

## Test plan
- [ ] On iOS Safari, copy a code block containing text with colons (e.g. `EpicCareLoginException: failed to find...`)
- [ ] Verify the pasted text is not URL-encoded (no `%20` replacing spaces, no lowercasing)
- [ ] Verify copy still works on desktop browsers (Chrome, Firefox, Safari)
- [ ] Verify "Copied to clipboard" toast still appears on all platforms