### PR TITLE
feat: resolve per-project API keys via direnv

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -230,6 +230,9 @@ function createProjectContext(opts) {
     if (sm.currentModel) {
       sendTo(ws, { type: "model_info", model: sm.currentModel, models: sm.availableModels || [] });
     }
+    if (sdk.hasProjectApiKey()) {
+      sendTo(ws, { type: "api_key_override", active: true });
+    }
     sendTo(ws, { type: "term_list", terminals: tm.list() });
 
     // Session list

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1300,6 +1300,14 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
           updateProjectSwitcher(msg);
           break;
 
+        case "api_key_override":
+          var akBanner = $("api-key-banner");
+          if (akBanner) {
+            if (msg.active) akBanner.classList.remove("hidden");
+            else akBanner.classList.add("hidden");
+          }
+          break;
+
         case "update_available":
           var updateBanner = $("update-banner");
           var updateVersion = $("update-version");

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -196,6 +196,22 @@
 #skip-perms-banner.hidden { display: none; }
 #skip-perms-banner .lucide { width: 14px; height: 14px; flex-shrink: 0; }
 
+#api-key-banner {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 7px 16px;
+  background: rgba(210, 153, 34, 0.12);
+  border-bottom: 1px solid rgba(210, 153, 34, 0.25);
+  font-size: 12px;
+  font-weight: 500;
+  color: #D29922;
+}
+#api-key-banner.hidden { display: none; }
+#api-key-banner .lucide { width: 14px; height: 14px; flex-shrink: 0; }
+
 /* --- Confirm modal --- */
 #confirm-modal {
   position: fixed;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -108,6 +108,10 @@
       <i data-lucide="shield-off"></i>
       <span>Skip permissions mode is active. All tool executions are auto-approved.</span>
     </div>
+    <div id="api-key-banner" class="hidden">
+      <i data-lucide="key-round"></i>
+      <span>Using project API key (via direnv)</span>
+    </div>
     <div id="header">
       <div id="header-left">
         <button id="sidebar-expand-btn" title="Open sidebar"><i data-lucide="panel-left-open"></i></button>

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1,4 +1,37 @@
 const crypto = require("crypto");
+var { execFile } = require("child_process");
+
+// --- Per-project API key resolution via direnv ---
+var apiKeyCache = {}; // cwd → key (cached for process lifetime)
+
+function resolveApiKey(cwd) {
+  if (cwd in apiKeyCache) return Promise.resolve(apiKeyCache[cwd]);
+  return new Promise(function (resolve) {
+    execFile("direnv", ["export", "json"], { cwd: cwd, timeout: 5000, env: Object.assign({}, process.env, { DIRENV_LOG_FORMAT: "" }) }, function (err, stdout) {
+      if (err || !stdout || !stdout.trim()) {
+        apiKeyCache[cwd] = null;
+        resolve(null);
+        return;
+      }
+      try {
+        var env = JSON.parse(stdout);
+        var key = env.ANTHROPIC_API_KEY || null;
+        apiKeyCache[cwd] = key;
+        resolve(key);
+      } catch (e) {
+        apiKeyCache[cwd] = null;
+        resolve(null);
+      }
+    });
+  });
+}
+
+function buildEnv(apiKey) {
+  if (!apiKey) return undefined;
+  var env = Object.assign({}, process.env);
+  env.ANTHROPIC_API_KEY = apiKey;
+  return env;
+}
 
 // Async message queue for streaming input to SDK
 function createMessageQueue() {
@@ -49,6 +82,7 @@ function createSDKBridge(opts) {
   var pushModule = opts.pushModule;
   var getSDK = opts.getSDK;
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
+  var hasProjectApiKey = false;
 
   function sendAndRecord(session, obj) {
     sm.sendAndRecord(session, obj);
@@ -366,11 +400,13 @@ function createSDKBridge(opts) {
       throw e;
     }
     var mq = createMessageQueue();
+    var apiKey = await resolveApiKey(cwd);
 
     var tempQuery = sdk.query({
       prompt: mq,
       options: {
         cwd: cwd,
+        env: buildEnv(apiKey),
         settingSources: ["user", "project", "local"],
         enableFileCheckpointing: true,
         resume: session.cliSessionId,
@@ -427,9 +463,11 @@ function createSDKBridge(opts) {
     });
 
     session.abortController = new AbortController();
+    var apiKey = await resolveApiKey(cwd);
 
     var queryOptions = {
       cwd: cwd,
+      env: buildEnv(apiKey),
       settingSources: ["user", "project", "local"],
       includePartialMessages: true,
       enableFileCheckpointing: true,
@@ -543,7 +581,12 @@ function createSDKBridge(opts) {
       var mq = createMessageQueue();
       mq.push({ type: "user", message: { role: "user", content: [{ type: "text", text: "hi" }] } });
       mq.end();
-      var warmupOptions = { cwd: cwd, settingSources: ["user", "project", "local"], abortController: ac };
+      var apiKey = await resolveApiKey(cwd);
+      if (apiKey) {
+        hasProjectApiKey = true;
+        send({ type: "api_key_override", active: true });
+      }
+      var warmupOptions = { cwd: cwd, env: buildEnv(apiKey), settingSources: ["user", "project", "local"], abortController: ac };
       if (dangerouslySkipPermissions) {
         warmupOptions.permissionMode = "bypassPermissions";
         warmupOptions.allowDangerouslySkipPermissions = true;
@@ -606,6 +649,7 @@ function createSDKBridge(opts) {
     permissionPushTitle: permissionPushTitle,
     permissionPushBody: permissionPushBody,
     warmup: warmup,
+    hasProjectApiKey: function () { return hasProjectApiKey; },
   };
 }
 


### PR DESCRIPTION
## Summary
- Use `direnv export json` to resolve `ANTHROPIC_API_KEY` for each project directory before SDK queries, so users with per-directory `.envrc` API key setups get the correct key used automatically
- Keys are cached for the lifetime of the process; falls back gracefully to `process.env` when direnv is unavailable, `.envrc` doesn't exist, or `direnv allow` hasn't been run
- Display a yellow warning banner in the UI when a project is using a direnv-resolved API key, mirroring the "Auth conflict" warning shown by the CLI

## Test plan
- [ ] Configure a project directory with `.envrc` that exports `ANTHROPIC_API_KEY` and run `direnv allow`
- [ ] Add that directory as a project in relay — verify SDK queries use the per-project key
- [ ] Verify the yellow "Using project API key (via direnv)" banner appears in the UI
- [ ] Add a project directory without `.envrc` — verify no banner appears and default credentials are used
- [ ] Test with direnv not installed — verify graceful fallback (no errors, default credentials used)