### PR TITLE
fix: prevent auto-scroll from hijacking viewport while reading

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -910,6 +910,12 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   var newMsgBtnDefault = "\u2193 Latest";
   var newMsgBtnActivity = "\u2193 New activity";
 
+  var userScrolledAt = 0;
+  var USER_SCROLL_LOCK_MS = 2000;
+
+  messagesEl.addEventListener("wheel", function () { userScrolledAt = Date.now(); }, { passive: true });
+  messagesEl.addEventListener("touchstart", function () { userScrolledAt = Date.now(); }, { passive: true });
+
   messagesEl.addEventListener("scroll", function () {
     var distFromBottom = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight;
     isUserScrolledUp = distFromBottom > scrollThreshold;
@@ -918,7 +924,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
         newMsgBtn.textContent = newMsgBtnDefault;
       }
       newMsgBtn.classList.remove("hidden");
-    } else {
+    } else if (Date.now() - userScrolledAt > USER_SCROLL_LOCK_MS) {
       newMsgBtn.classList.add("hidden");
       newMsgBtn.textContent = newMsgBtnDefault;
     }
@@ -928,14 +934,19 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     forceScrollToBottom();
   });
 
+  var scrollRafPending = false;
   function scrollToBottom() {
     if (prependAnchor) return;
-    if (isUserScrolledUp) {
+    if (isUserScrolledUp || Date.now() - userScrolledAt < USER_SCROLL_LOCK_MS) {
       newMsgBtn.textContent = newMsgBtnActivity;
       newMsgBtn.classList.remove("hidden");
       return;
     }
+    if (scrollRafPending) return;
+    scrollRafPending = true;
     requestAnimationFrame(function () {
+      scrollRafPending = false;
+      if (isUserScrolledUp || Date.now() - userScrolledAt < USER_SCROLL_LOCK_MS) return;
       messagesEl.scrollTop = messagesEl.scrollHeight;
     });
   }
@@ -943,6 +954,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   function forceScrollToBottom() {
     if (prependAnchor) return;
     isUserScrolledUp = false;
+    userScrolledAt = 0;
     newMsgBtn.classList.add("hidden");
     newMsgBtn.textContent = newMsgBtnDefault;
     requestAnimationFrame(function () {

--- a/lib/public/css/messages.css
+++ b/lib/public/css/messages.css
@@ -5,6 +5,7 @@
 #messages {
   flex: 1;
   overflow-y: auto;
+  overflow-anchor: none;
   -webkit-overflow-scrolling: touch;
   padding: 20px 0 12px;
 }


### PR DESCRIPTION
## Summary
- Disables browser scroll anchoring (`overflow-anchor: none`) on the messages container
- Adds a 2-second scroll lock after `wheel`/`touchstart` input so streaming content never yanks the viewport away while the user is reading
- Deduplicates `requestAnimationFrame` scroll calls and re-checks the lock inside the rAF callback

## Problem
When Claude is streaming a long response, the browser's auto-scroll behavior fights with the user trying to read earlier content — the viewport jumps back to the bottom even after the user has scrolled up.

## Changes
- **`lib/public/app.js`** — track last user scroll timestamp, gate `scrollToBottom()` on a 2s cooldown, coalesce rAF calls
- **`lib/public/css/messages.css`** — add `overflow-anchor: none` to `#messages`

## Test plan
- [x] Start a long streaming response and scroll up mid-stream — viewport should stay put
- [x] After 2s of no scroll input, auto-scroll resumes if user is at the bottom
- [x] "↓ New activity" button appears correctly when locked and scrolled up
- [x] `forceScrollToBottom()` (clicking the button) still works immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)