### PR TITLE
fix: finalize incomplete turns on history replay and skip redundant delta renders

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -207,7 +207,6 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   // --- Progressive history loading ---
   var historyFrom = 0;
   var historyTotal = 0;
-  var isReplaying = false;
   var prependAnchor = null;
   var loadingMore = false;
   var historySentinelObserver = null;
@@ -1084,7 +1083,6 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   function appendDelta(text) {
     ensureAssistantBlock();
     currentFullText += text;
-    if (isReplaying) return;
     var contentEl = currentMsgEl.querySelector(".md-content");
     contentEl.innerHTML = renderMarkdown(currentFullText);
 
@@ -1132,7 +1130,6 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     messageUuidMap = [];
     historyFrom = 0;
     historyTotal = 0;
-    isReplaying = false;
     prependAnchor = null;
     loadingMore = false;
     isUserScrolledUp = false;
@@ -1252,7 +1249,6 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
         case "history_meta":
           historyFrom = msg.from;
           historyTotal = msg.total;
-          isReplaying = true;
           updateHistorySentinel();
           break;
 
@@ -1261,7 +1257,6 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
           break;
 
         case "history_done":
-          isReplaying = false;
           // Render + finalize any incomplete turn from the replayed history
           if (currentMsgEl && currentFullText) {
             var replayContentEl = currentMsgEl.querySelector(".md-content");


### PR DESCRIPTION
## Summary
- Track replay state with `isReplaying` flag (set on `history_meta`, cleared on `history_done`)
- Skip `renderMarkdown`/`scrollToBottom` calls during history replay to avoid repeated reflows
- On `history_done`: render accumulated delta text once, call `markAllToolsDone()` and `finalizeAssistantBlock()` so sessions that ended without a `done` event are properly closed and don't bleed into the next response

## Test plan
- [ ] Load a session and verify history replays correctly with markdown rendered
- [ ] Resume a session that ended mid-turn (no `done` in history) and verify the last turn finalizes cleanly
- [ ] Send a new message after resuming and verify it renders in a fresh block