### PR TITLE
fix: refresh session history from CLI on reconnect and session switch

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -247,36 +247,49 @@ function createProjectContext(opts) {
       }),
     });
 
-    // Restore active session for this client
+    // Restore active session for this client, refreshing from CLI history first if idle
     var active = sm.getActiveSession();
     if (active) {
-      sendTo(ws, { type: "session_switched", id: active.localId, cliSessionId: active.cliSessionId || null });
-
-      var total = active.history.length;
-      var fromIndex = 0;
-      if (total > sm.HISTORY_PAGE_SIZE) {
-        fromIndex = sm.findTurnBoundary(active.history, Math.max(0, total - sm.HISTORY_PAGE_SIZE));
+      function doSendActiveSession(sess) {
+        sendTo(ws, { type: "session_switched", id: sess.localId, cliSessionId: sess.cliSessionId || null });
+        var total = sess.history.length;
+        var fromIndex = 0;
+        if (total > sm.HISTORY_PAGE_SIZE) {
+          fromIndex = sm.findTurnBoundary(sess.history, Math.max(0, total - sm.HISTORY_PAGE_SIZE));
+        }
+        sendTo(ws, { type: "history_meta", total: total, from: fromIndex });
+        for (var i = fromIndex; i < total; i++) {
+          sendTo(ws, sess.history[i]);
+        }
+        sendTo(ws, { type: "history_done" });
+        if (sess.isProcessing) {
+          sendTo(ws, { type: "status", status: "processing" });
+        }
+        var pendingIds = Object.keys(sess.pendingPermissions);
+        for (var pi = 0; pi < pendingIds.length; pi++) {
+          var p = sess.pendingPermissions[pendingIds[pi]];
+          sendTo(ws, {
+            type: "permission_request_pending",
+            requestId: p.requestId,
+            toolName: p.toolName,
+            toolInput: p.toolInput,
+            toolUseId: p.toolUseId,
+            decisionReason: p.decisionReason,
+          });
+        }
       }
-      sendTo(ws, { type: "history_meta", total: total, from: fromIndex });
-      for (var i = fromIndex; i < total; i++) {
-        sendTo(ws, active.history[i]);
-      }
-      sendTo(ws, { type: "history_done" });
-
-      if (active.isProcessing) {
-        sendTo(ws, { type: "status", status: "processing" });
-      }
-      var pendingIds = Object.keys(active.pendingPermissions);
-      for (var pi = 0; pi < pendingIds.length; pi++) {
-        var p = active.pendingPermissions[pendingIds[pi]];
-        sendTo(ws, {
-          type: "permission_request_pending",
-          requestId: p.requestId,
-          toolName: p.toolName,
-          toolInput: p.toolInput,
-          toolUseId: p.toolUseId,
-          decisionReason: p.decisionReason,
+      if (active.cliSessionId && !active.isProcessing) {
+        require("./cli-sessions").readCliSessionHistory(cwd, active.cliSessionId).then(function (history) {
+          if (history && history.length > active.history.length) {
+            active.history = history;
+            sm.saveSessionFile(active);
+          }
+          if (clients.has(ws)) doSendActiveSession(active);
+        }).catch(function () {
+          if (clients.has(ws)) doSendActiveSession(active);
         });
+      } else {
+        doSendActiveSession(active);
       }
     }
 
@@ -326,7 +339,20 @@ function createProjectContext(opts) {
 
     if (msg.type === "switch_session") {
       if (msg.id && sm.sessions.has(msg.id)) {
-        sm.switchSession(msg.id);
+        var switchTarget = sm.sessions.get(msg.id);
+        if (switchTarget.cliSessionId && !switchTarget.isProcessing) {
+          require("./cli-sessions").readCliSessionHistory(cwd, switchTarget.cliSessionId).then(function (history) {
+            if (history && history.length > switchTarget.history.length) {
+              switchTarget.history = history;
+              sm.saveSessionFile(switchTarget);
+            }
+            sm.switchSession(msg.id);
+          }).catch(function () {
+            sm.switchSession(msg.id);
+          });
+        } else {
+          sm.switchSession(msg.id);
+        }
       }
       return;
     }


### PR DESCRIPTION
## Summary

When a session is continued externally (e.g. via the CLI), the relay's in-memory history stays at whatever point it was when the relay last saw activity. Coming back to the web UI after that shows stale content — the conversation appears frozen at an earlier point even though work has continued.

Three places needed fixing:

- **`handleConnection`** — on WebSocket reconnect, refresh history from the CLI session file before replaying to the client
- **`switch_session`** — when switching to a session, refresh its history from the CLI session file before switching
- **`resumeSession`** — when resuming an existing session, update its history if the fresh history from the CLI file is longer

All three refreshes are guarded by `!isProcessing` so we don't stomp on an in-flight query.

## Test plan

- [ ] Start a session via the web UI, continue it from the CLI externally, then reconnect in the browser — history should be up to date
- [ ] Do the same but switch to the session (not a fresh reconnect) — history should refresh before the switch
- [ ] Resume a CLI session that was continued externally — history should reflect the full CLI state
- [ ] Verify that history does **not** refresh mid-query (while `isProcessing` is true)