### PR TITLE
fix: exclude output tokens from context window calculation

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -783,8 +783,8 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
 
   function updateContextPanel() {
     if (!contextUsedEl) return;
-    // Context window usage = input tokens (includes cache read/write) + output tokens
-    var used = contextData.input + contextData.output;
+    // Context window usage = input tokens only (output tokens don't count toward context limit)
+    var used = contextData.input;
     var win = contextData.contextWindow;
     var pct = win > 0 ? Math.min(100, (used / win) * 100) : 0;
     var cls = contextPctClass(pct);


### PR DESCRIPTION
## Summary
Fixes #137 - The `/context` token count calculation was inaccurate.

## Problem
The context window usage was incorrectly calculated as:
```javascript
var used = contextData.input + contextData.output;
```

This included output tokens in the context window calculation, which is incorrect.

## Solution
Changed to only count input tokens:
```javascript
var used = contextData.input;
```

**Why this is correct:**
- The context window represents what's **sent to** the model (input tokens)
- Output tokens are what the model **generates** in response
- Output tokens don't consume context window space - they're separate from the context limit

This aligns with how Claude's API reports context window limits - they apply to input only.