### PR TITLE
fix: detect daemon when pid is absent (launchd / external start)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -53,10 +53,11 @@ function isPidAlive(pid) {
 }
 
 function isDaemonAlive(config) {
-  if (!config || !config.pid) return false;
-  if (!isPidAlive(config.pid)) return false;
-  // Named pipes on Windows can't be stat'd, just check PID
-  if (process.platform === "win32") return true;
+  if (!config) return false;
+  // If pid is known and process is dead, daemon is definitely not running
+  if (config.pid && !isPidAlive(config.pid)) return false;
+  // Named pipes on Windows can't be stat'd; require a live pid on Windows
+  if (process.platform === "win32") return !!(config.pid && isPidAlive(config.pid));
   try {
     fs.statSync(socketPath());
     return true;
@@ -67,8 +68,9 @@ function isDaemonAlive(config) {
 
 function isDaemonAliveAsync(config) {
   return new Promise(function (resolve) {
-    if (!config || !config.pid) return resolve(false);
-    if (!isPidAlive(config.pid)) return resolve(false);
+    if (!config) return resolve(false);
+    // If pid is known and process is dead, daemon is definitely not running
+    if (config.pid && !isPidAlive(config.pid)) return resolve(false);
 
     var sock = socketPath();
     var client = net.connect(sock);


### PR DESCRIPTION
## Problem

`isDaemonAlive` and `isDaemonAliveAsync` both bail immediately when `config.pid` is null or falsy:

```js
if (!config || !config.pid) return resolve(false);
```

This means if the daemon was started by an external process manager (e.g. a macOS LaunchAgent running `daemon.js` directly), the CLI sees no pid in `daemon.json` and thinks no daemon is running — even though one is. The CLI then tries to fork a new daemon, hits "Port already in use", and fails.

## Fix

Only short-circuit on a pid that is **known to be dead**. If no pid is recorded, fall through to the socket connection attempt, which is the real source of truth.

```js
// before
if (!config || !config.pid) return resolve(false);
if (!isPidAlive(config.pid)) return resolve(false);

// after
if (!config) return resolve(false);
if (config.pid && !isPidAlive(config.pid)) return resolve(false);
```

Same change applied to both the sync (`isDaemonAlive`) and async (`isDaemonAliveAsync`) variants.

## Testing

- Start daemon via launchd / external process, then run `claude-relay` → correctly detects running daemon
- Kill daemon, run `claude-relay` → correctly starts a new daemon (dead pid short-circuits as before)
- Normal `claude-relay` start/stop cycle unchanged