### PR TITLE
feat: per-client session tracking and URL-addressable sessions

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -72,11 +72,11 @@ function createProjectContext(opts) {
   var latestVersion = null;
 
   // --- Per-project clients ---
-  var clients = new Set();
+  var clients = new Map();  // ws -> { sessionId: number }
 
   function send(obj) {
     var data = JSON.stringify(obj);
-    for (var ws of clients) {
+    for (var [ws] of clients) {
       if (ws.readyState === 1) ws.send(data);
     }
   }
@@ -91,8 +91,26 @@ function createProjectContext(opts) {
 
   function sendToOthers(sender, obj) {
     var data = JSON.stringify(obj);
-    for (var ws of clients) {
+    for (var [ws] of clients) {
       if (ws !== sender && ws.readyState === 1) ws.send(data);
+    }
+  }
+
+  function sendToSessionViewers(sessionId, obj) {
+    var data = JSON.stringify(obj);
+    for (var [ws, state] of clients) {
+      if (state.sessionId === sessionId && ws.readyState === 1) {
+        ws.send(data);
+      }
+    }
+  }
+
+  function sendToSessionViewersExcept(sessionId, sender, obj) {
+    var data = JSON.stringify(obj);
+    for (var [ws, state] of clients) {
+      if (ws !== sender && state.sessionId === sessionId && ws.readyState === 1) {
+        ws.send(data);
+      }
     }
   }
 
@@ -191,6 +209,7 @@ function createProjectContext(opts) {
 
   // --- Session manager ---
   var sm = createSessionManager({ cwd: cwd, send: send });
+  sm.setSendToViewers(sendToSessionViewers);
 
   // --- SDK bridge ---
   var sdk = createSDKBridge({
@@ -198,6 +217,7 @@ function createProjectContext(opts) {
     slug: slug,
     sessionManager: sm,
     send: send,
+    sendToViewers: sendToSessionViewers,
     pushModule: pushModule,
     getSDK: getSDK,
     dangerouslySkipPermissions: dangerouslySkipPermissions,
@@ -216,7 +236,7 @@ function createProjectContext(opts) {
 
   // --- WS connection handler ---
   function handleConnection(ws) {
-    clients.add(ws);
+    clients.set(ws, { sessionId: null });
     broadcastClientCount();
 
     // Send cached state
@@ -232,7 +252,7 @@ function createProjectContext(opts) {
     }
     sendTo(ws, { type: "term_list", terminals: tm.list() });
 
-    // Session list
+    // Session list (no active flag — client determines its own)
     sendTo(ws, {
       type: "session_list",
       sessions: [].concat(Array.from(sm.sessions.values())).map(function (s) {
@@ -240,44 +260,30 @@ function createProjectContext(opts) {
           id: s.localId,
           cliSessionId: s.cliSessionId || null,
           title: s.title || "New Session",
-          active: s.localId === sm.activeSessionId,
           isProcessing: s.isProcessing,
           lastActivity: s.lastActivity || s.createdAt || 0,
         };
       }),
     });
 
-    // Restore active session for this client
-    var active = sm.getActiveSession();
-    if (active) {
-      sendTo(ws, { type: "session_switched", id: active.localId, cliSessionId: active.cliSessionId || null });
+    // Determine which session this client should view
+    var requestedSessionId = null;
+    try {
+      var urlParams = new URLSearchParams(ws._relayQuery || "");
+      var sParam = urlParams.get("s");
+      if (sParam) requestedSessionId = parseInt(sParam, 10);
+    } catch(e) {}
 
-      var total = active.history.length;
-      var fromIndex = 0;
-      if (total > sm.HISTORY_PAGE_SIZE) {
-        fromIndex = sm.findTurnBoundary(active.history, Math.max(0, total - sm.HISTORY_PAGE_SIZE));
-      }
-      sendTo(ws, { type: "history_meta", total: total, from: fromIndex });
-      for (var i = fromIndex; i < total; i++) {
-        sendTo(ws, active.history[i]);
-      }
-      sendTo(ws, { type: "history_done" });
+    var targetSession = null;
+    if (requestedSessionId && sm.sessions.has(requestedSessionId)) {
+      targetSession = sm.sessions.get(requestedSessionId);
+    } else {
+      targetSession = sm.getDefaultSession();
+    }
 
-      if (active.isProcessing) {
-        sendTo(ws, { type: "status", status: "processing" });
-      }
-      var pendingIds = Object.keys(active.pendingPermissions);
-      for (var pi = 0; pi < pendingIds.length; pi++) {
-        var p = active.pendingPermissions[pendingIds[pi]];
-        sendTo(ws, {
-          type: "permission_request_pending",
-          requestId: p.requestId,
-          toolName: p.toolName,
-          toolInput: p.toolInput,
-          toolUseId: p.toolUseId,
-          decisionReason: p.decisionReason,
-        });
-      }
+    if (targetSession) {
+      clients.get(ws).sessionId = targetSession.localId;
+      sm.switchSessionForClient(ws, targetSession.localId, sendTo);
     }
 
     ws.on("message", function (raw) {
@@ -291,6 +297,12 @@ function createProjectContext(opts) {
     });
   }
 
+  // --- Per-client session lookup helper ---
+  function getClientSession(ws) {
+    var state = clients.get(ws);
+    return state ? sm.sessions.get(state.sessionId) : null;
+  }
+
   // --- WS message handler ---
   function handleMessage(ws, msg) {
     if (msg.type === "push_subscribe") {
@@ -299,7 +311,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "load_more_history") {
-      var session = sm.getActiveSession();
+      var session = getClientSession(ws);
       if (!session || typeof msg.before !== "number") return;
       var before = msg.before;
       var from = sm.findTurnBoundary(session.history, Math.max(0, before - sm.HISTORY_PAGE_SIZE));
@@ -314,26 +326,30 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "new_session") {
-      sm.createSession();
+      var newSession = sm.createSession(ws, sendTo);
+      clients.get(ws).sessionId = newSession.localId;
       return;
     }
 
     if (msg.type === "resume_session") {
       if (!msg.cliSessionId) return;
-      sm.resumeSession(msg.cliSessionId);
+      var resumed = sm.resumeSession(msg.cliSessionId, ws, sendTo);
+      clients.get(ws).sessionId = resumed.localId;
       return;
     }
 
     if (msg.type === "switch_session") {
       if (msg.id && sm.sessions.has(msg.id)) {
-        sm.switchSession(msg.id);
+        clients.get(ws).sessionId = msg.id;
+        sm.switchSessionForClient(ws, msg.id, sendTo);
+        sm.broadcastSessionList();
       }
       return;
     }
 
     if (msg.type === "delete_session") {
       if (msg.id && sm.sessions.has(msg.id)) {
-        sm.deleteSession(msg.id);
+        sm.deleteSession(msg.id, clients, sendTo);
       }
       return;
     }
@@ -390,16 +406,15 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "stop") {
-      var session = sm.getActiveSession();
+      var session = getClientSession(ws);
       if (session && session.abortController && session.isProcessing) {
         session.abortController.abort();
       }
       return;
     }
 
-
     if (msg.type === "set_model" && msg.model) {
-      var session = sm.getActiveSession();
+      var session = getClientSession(ws);
       if (session) {
         sdk.setModel(session, msg.model);
       }
@@ -407,7 +422,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "rewind_preview") {
-      var session = sm.getActiveSession();
+      var session = getClientSession(ws);
       if (!session || !session.cliSessionId || !msg.uuid) return;
 
       (async function () {
@@ -436,7 +451,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "rewind_execute") {
-      var session = sm.getActiveSession();
+      var session = getClientSession(ws);
       if (!session || !session.cliSessionId || !msg.uuid) return;
       var mode = msg.mode || "both";
 
@@ -490,11 +505,16 @@ function createProjectContext(opts) {
           session.isProcessing = false;
 
           sm.saveSessionFile(session);
-          sm.switchSession(session.localId);
+          // Replay to all clients viewing this session
+          for (var [clientWs, state] of clients) {
+            if (state.sessionId === session.localId) {
+              sm.switchSessionForClient(clientWs, session.localId, sendTo);
+            }
+          }
           sm.sendAndRecord(session, { type: "rewind_complete", mode: mode });
           sm.broadcastSessionList();
         } catch (err) {
-          send({ type: "rewind_error", text: "Rewind failed: " + err.message });
+          sendToSessionViewers(session.localId, { type: "rewind_error", text: "Rewind failed: " + err.message });
         } finally {
           if (result && result.isTemp) result.cleanup();
         }
@@ -503,7 +523,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "ask_user_response") {
-      var session = sm.getActiveSession();
+      var session = getClientSession(ws);
       if (!session) return;
       var toolId = msg.toolId;
       var answers = msg.answers || {};
@@ -519,12 +539,15 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "input_sync") {
-      sendToOthers(ws, msg);
+      var clientState = clients.get(ws);
+      if (clientState) {
+        sendToSessionViewersExcept(clientState.sessionId, ws, msg);
+      }
       return;
     }
 
     if (msg.type === "permission_response") {
-      var session = sm.getActiveSession();
+      var session = getClientSession(ws);
       if (!session) return;
       var requestId = msg.requestId;
       var decision = msg.decision;
@@ -861,7 +884,7 @@ function createProjectContext(opts) {
     if (msg.type !== "message") return;
     if (!msg.text && (!msg.images || msg.images.length === 0) && (!msg.pastes || msg.pastes.length === 0)) return;
 
-    var session = sm.getActiveSession();
+    var session = getClientSession(ws);
     if (!session) return;
 
     var userMsg = { type: "user_message", text: msg.text || "" };
@@ -873,7 +896,7 @@ function createProjectContext(opts) {
     }
     session.history.push(userMsg);
     sm.appendToSessionFile(session, userMsg);
-    sendToOthers(ws, userMsg);
+    sendToSessionViewersExcept(session.localId, ws, userMsg);
 
     if (!session.title) {
       session.title = (msg.text || "Image").substring(0, 50);
@@ -892,7 +915,7 @@ function createProjectContext(opts) {
     if (!session.isProcessing) {
       session.isProcessing = true;
       session.sentToolResults = {};
-      send({ type: "status", status: "processing" });
+      sendToSessionViewers(session.localId, { type: "status", status: "processing" });
       if (!session.queryInstance) {
         sdk.startQuery(session, fullText, msg.images);
       } else {
@@ -1033,7 +1056,7 @@ function createProjectContext(opts) {
     });
     // Kill all terminals
     tm.destroyAll();
-    for (var ws of clients) {
+    for (var [ws] of clients) {
       try { ws.close(); } catch (e) {}
     }
     clients.clear();

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -15,6 +15,16 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   var basePath = slugMatch ? "/p/" + slugMatch[1] + "/" : "/";
   var wsPath = slugMatch ? "/p/" + slugMatch[1] + "/ws" : "/ws";
 
+  // --- Session hash routing ---
+  function getSessionFromHash() {
+    var match = location.hash.match(/^#s=(\d+)$/);
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  function isNewSessionHash() {
+    return location.hash === "#s=new";
+  }
+
 // --- DOM refs ---
   var $ = function (id) { return document.getElementById(id); };
   var messagesEl = $("messages");
@@ -1151,7 +1161,10 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     if (connectTimeoutId) { clearTimeout(connectTimeoutId); connectTimeoutId = null; }
 
     var protocol = location.protocol === "https:" ? "wss:" : "ws:";
-    ws = new WebSocket(protocol + "//" + location.host + wsPath);
+    var wsUrl = protocol + "//" + location.host + wsPath;
+    var hashSession = getSessionFromHash();
+    if (hashSession) wsUrl += "?s=" + hashSession;
+    ws = new WebSocket(wsUrl);
 
     connectStatusEl.textContent = "Connecting...";
 
@@ -1198,6 +1211,11 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
             subscription: window._pushSubscription.toJSON(),
           }));
         } catch(e) {}
+      }
+
+      // If hash says #s=new, request a new session after connecting
+      if (isNewSessionHash()) {
+        ws.send(JSON.stringify({ type: "new_session" }));
       }
     };
 
@@ -1369,7 +1387,12 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
           break;
 
         case "session_list":
-          renderSessionList(msg.sessions || []);
+          // Inject active flag client-side (server no longer sends it)
+          var sessionsList = (msg.sessions || []).map(function(s) {
+            s.active = s.id === activeSessionId;
+            return s;
+          });
+          renderSessionList(sessionsList);
           break;
 
         case "search_results":
@@ -1385,7 +1408,11 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
           }
           activeSessionId = msg.id;
           cliSessionId = msg.cliSessionId || null;
+          // Update URL hash so this session is bookmarkable/refreshable
+          try { history.replaceState(null, "", location.pathname + location.search + "#s=" + msg.id); } catch(e) {}
           resetClientState();
+          // Re-render sidebar so the active session is highlighted
+          renderSessionList(null);
           // Restore draft for incoming session
           var draft = sessionDrafts[activeSessionId] || "";
           inputEl.value = draft;
@@ -1830,6 +1857,14 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     terminalContainerEl: $("terminal-container"),
     terminalBodyEl: $("terminal-body"),
     fileViewerEl: $("file-viewer"),
+  });
+
+  // --- Session hash navigation ---
+  window.addEventListener("hashchange", function() {
+    var sid = getSessionFromHash();
+    if (sid && sid !== activeSessionId && ws && connected) {
+      ws.send(JSON.stringify({ type: "switch_session", id: sid }));
+    }
   });
 
   // --- Init ---

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -459,6 +459,7 @@
   color: var(--text-secondary);
   margin-bottom: 0;
   transition: background 0.15s, color 0.15s;
+  text-decoration: none;
 }
 
 .session-item-text {

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -148,11 +148,12 @@ function highlightMatch(text, query) {
 }
 
 function renderSessionItem(s) {
-  var el = document.createElement("div");
+  var el = document.createElement("a");
   var isMatch = searchMatchIds !== null && searchMatchIds.has(s.id);
   var dimmed = searchMatchIds !== null && !isMatch;
   el.className = "session-item" + (s.active ? " active" : "") + (isMatch ? " search-match" : "") + (dimmed ? " search-dimmed" : "");
   el.dataset.sessionId = s.id;
+  el.href = location.pathname + location.search + "#s=" + s.id;
 
   var textSpan = document.createElement("span");
   textSpan.className = "session-item-text";
@@ -171,19 +172,31 @@ function renderSessionItem(s) {
   moreBtn.addEventListener("click", (function(id, title, cliSid, btn) {
     return function(e) {
       e.stopPropagation();
+      e.preventDefault();
       showSessionCtxMenu(btn, id, title, cliSid);
     };
   })(s.id, s.title, s.cliSessionId, moreBtn));
   el.appendChild(moreBtn);
 
   el.addEventListener("click", (function (id) {
-    return function () {
+    return function (e) {
+      // Let modifier clicks (ctrl/cmd/middle) open in new tab natively
+      if (e.ctrlKey || e.metaKey || e.shiftKey || e.button === 1) return;
+      e.preventDefault();
       if (ctx.ws && ctx.connected) {
         ctx.ws.send(JSON.stringify({ type: "switch_session", id: id }));
         closeSidebar();
       }
     };
   })(s.id));
+
+  // Middle-click support
+  el.addEventListener("auxclick", function (e) {
+    if (e.button === 1) {
+      // Let browser handle natively — <a> tag will open in new tab
+      return;
+    }
+  });
 
   return el;
 }
@@ -287,7 +300,17 @@ export function initSidebar(_ctx) {
     }
   } catch (e) {}
 
-  ctx.newSessionBtn.addEventListener("click", function () {
+  ctx.newSessionBtn.addEventListener("click", function (e) {
+    // Modifier click → open new session in a new tab
+    if (e.ctrlKey || e.metaKey || e.shiftKey) {
+      var newTabUrl = location.pathname + location.search + "#s=new";
+      if (e.shiftKey) {
+        window.open(newTabUrl, "_blank");
+      } else {
+        window.open(newTabUrl);
+      }
+      return;
+    }
     if (ctx.ws && ctx.connected) {
       ctx.ws.send(JSON.stringify({ type: "new_session" }));
       closeSidebar();

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -46,6 +46,7 @@ function createSDKBridge(opts) {
   var slug = opts.slug || "";
   var sm = opts.sessionManager;   // session manager instance
   var send = opts.send;           // broadcast to all clients
+  var sendToViewers = opts.sendToViewers || send;  // function(sessionId, obj) - send to session viewers
   var pushModule = opts.pushModule;
   var getSDK = opts.getSDK;
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
@@ -59,9 +60,7 @@ function createSDKBridge(opts) {
     if (parsed.session_id && !session.cliSessionId) {
       session.cliSessionId = parsed.session_id;
       sm.saveSessionFile(session);
-      if (session.localId === sm.activeSessionId) {
-        send({ type: "session_id", cliSessionId: session.cliSessionId });
-      }
+      sendToViewers(session.localId, { type: "session_id", cliSessionId: session.cliSessionId });
     } else if (parsed.session_id) {
       session.cliSessionId = parsed.session_id;
     }
@@ -395,7 +394,7 @@ function createSDKBridge(opts) {
       sdk = await getSDK();
     } catch (e) {
       session.isProcessing = false;
-      send({ type: "error", text: "Failed to load Claude SDK: " + (e.message || e) });
+      sendToViewers(session.localId, { type: "error", text: "Failed to load Claude SDK: " + (e.message || e) });
       sendAndRecord(session, { type: "done", code: 1 });
       sm.broadcastSessionList();
       return;
@@ -463,7 +462,7 @@ function createSDKBridge(opts) {
       session.queryInstance = null;
       session.messageQueue = null;
       session.abortController = null;
-      send({ type: "error", text: "Failed to start query: " + (e.message || e) });
+      sendToViewers(session.localId, { type: "error", text: "Failed to start query: " + (e.message || e) });
       sendAndRecord(session, { type: "done", code: 1 });
       sm.broadcastSessionList();
       return;
@@ -590,7 +589,7 @@ function createSDKBridge(opts) {
       sm.currentModel = model;
       send({ type: "model_info", model: model, models: sm.availableModels || [] });
     } catch (e) {
-      send({ type: "error", text: "Failed to switch model: " + (e.message || e) });
+      sendToViewers(session.localId, { type: "error", text: "Failed to switch model: " + (e.message || e) });
     }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -450,6 +450,9 @@ function createServer(opts) {
     }
 
     wss.handleUpgrade(req, socket, head, function (ws) {
+      // Pass URL query string for session routing (e.g. ?s=3)
+      var qIdx = req.url.indexOf("?");
+      ws._relayQuery = qIdx >= 0 ? req.url.substring(qIdx + 1) : "";
       ctx.handleConnection(ws);
     });
   });

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -4,12 +4,12 @@ const path = require("path");
 function createSessionManager(opts) {
   var cwd = opts.cwd;
   var send = opts.send;          // function(obj) - broadcast to all clients
-  var sendAndRecord = null;      // set after init via setSendAndRecord
+  var sendToViewers = opts.sendToViewers || send;  // function(sessionId, obj) - send to session viewers
 
   // --- Multi-session state ---
   var nextLocalId = 1;
   var sessions = new Map();     // localId -> session object
-  var activeSessionId = null;   // currently active local ID
+  var defaultSessionId = null;  // default session for new connections
   var slashCommands = null;     // shared across sessions
   var skillNames = null;        // Claude-only skills to filter from slash menu
 
@@ -116,8 +116,8 @@ function createSessionManager(opts) {
   // Load persisted sessions from disk
   loadSessions();
 
-  function getActiveSession() {
-    return sessions.get(activeSessionId) || null;
+  function getDefaultSession() {
+    return sessions.get(defaultSessionId) || null;
   }
 
   function broadcastSessionList() {
@@ -128,7 +128,6 @@ function createSessionManager(opts) {
           id: s.localId,
           cliSessionId: s.cliSessionId || null,
           title: s.title || "New Session",
-          active: s.localId === activeSessionId,
           isProcessing: s.isProcessing,
           lastActivity: s.lastActivity || s.createdAt || 0,
         };
@@ -136,7 +135,7 @@ function createSessionManager(opts) {
     });
   }
 
-  function createSession() {
+  function makeSessionObj() {
     var localId = nextLocalId++;
     var session = {
       localId: localId,
@@ -156,7 +155,16 @@ function createSessionManager(opts) {
       messageUUIDs: [],
     };
     sessions.set(localId, session);
-    switchSession(localId);
+    return session;
+  }
+
+  function createSession(ws, sendToFn) {
+    var session = makeSessionObj();
+    if (ws && sendToFn) {
+      switchSessionForClient(ws, session.localId, sendToFn);
+    }
+    defaultSessionId = session.localId;
+    broadcastSessionList();
     return session;
   }
 
@@ -169,7 +177,7 @@ function createSessionManager(opts) {
     return 0;
   }
 
-  function replayHistory(session, fromIndex) {
+  function replayHistoryTo(session, fromIndex, sendToFn, ws) {
     var total = session.history.length;
     if (typeof fromIndex !== "number") {
       if (total <= HISTORY_PAGE_SIZE) {
@@ -179,33 +187,31 @@ function createSessionManager(opts) {
       }
     }
 
-    send({ type: "history_meta", total: total, from: fromIndex });
+    sendToFn(ws, { type: "history_meta", total: total, from: fromIndex });
 
     for (var i = fromIndex; i < total; i++) {
-      send(session.history[i]);
+      sendToFn(ws, session.history[i]);
     }
 
-    send({ type: "history_done" });
+    sendToFn(ws, { type: "history_done" });
   }
 
-  function switchSession(localId) {
+  function switchSessionForClient(ws, localId, sendToFn) {
     var session = sessions.get(localId);
     if (!session) return;
 
-    activeSessionId = localId;
-    send({ type: "session_switched", id: localId, cliSessionId: session.cliSessionId || null });
-    broadcastSessionList();
-    replayHistory(session);
+    sendToFn(ws, { type: "session_switched", id: localId, cliSessionId: session.cliSessionId || null });
+    replayHistoryTo(session, undefined, sendToFn, ws);
 
     if (session.isProcessing) {
-      send({ type: "status", status: "processing" });
+      sendToFn(ws, { type: "status", status: "processing" });
     }
 
     // Re-send any pending permission requests
     var pendingIds = Object.keys(session.pendingPermissions);
     for (var i = 0; i < pendingIds.length; i++) {
       var p = session.pendingPermissions[pendingIds[i]];
-      send({
+      sendToFn(ws, {
         type: "permission_request_pending",
         requestId: p.requestId,
         toolName: p.toolName,
@@ -216,7 +222,7 @@ function createSessionManager(opts) {
     }
   }
 
-  function deleteSession(localId) {
+  function deleteSession(localId, clientsMap, sendToFn) {
     var session = sessions.get(localId);
     if (!session) return;
 
@@ -233,27 +239,43 @@ function createSessionManager(opts) {
 
     sessions.delete(localId);
 
-    if (activeSessionId === localId) {
-      var remaining = [...sessions.keys()];
-      if (remaining.length > 0) {
-        switchSession(remaining[remaining.length - 1]);
-      } else {
-        createSession();
+    // Find a fallback session for displaced clients
+    var remaining = [...sessions.keys()];
+    var fallbackId = remaining.length > 0 ? remaining[remaining.length - 1] : null;
+
+    // Move all clients that were viewing the deleted session
+    if (clientsMap) {
+      for (var [ws, state] of clientsMap) {
+        if (state.sessionId === localId) {
+          if (fallbackId) {
+            state.sessionId = fallbackId;
+            switchSessionForClient(ws, fallbackId, sendToFn);
+          } else {
+            // No sessions left, create a new one
+            var newSession = makeSessionObj();
+            defaultSessionId = newSession.localId;
+            state.sessionId = newSession.localId;
+            switchSessionForClient(ws, newSession.localId, sendToFn);
+            fallbackId = newSession.localId; // reuse for other displaced clients
+          }
+        }
       }
-    } else {
-      broadcastSessionList();
     }
+
+    if (defaultSessionId === localId) {
+      defaultSessionId = fallbackId;
+    }
+
+    broadcastSessionList();
   }
 
   function doSendAndRecord(session, obj) {
     session.history.push(obj);
     appendToSessionFile(session, obj);
-    if (session.localId === activeSessionId) {
-      send(obj);
-    }
+    sendToViewers(session.localId, obj);
   }
 
-  function resumeSession(cliSessionId) {
+  function resumeSession(cliSessionId, ws, sendToFn) {
     var localId = nextLocalId++;
     var session = {
       localId: localId,
@@ -273,15 +295,20 @@ function createSessionManager(opts) {
     };
     sessions.set(localId, session);
     saveSessionFile(session);
-    switchSession(localId);
+    if (ws && sendToFn) {
+      switchSessionForClient(ws, localId, sendToFn);
+    }
+    defaultSessionId = localId;
+    broadcastSessionList();
     return session;
   }
 
   // --- Spawn initial session only if no persisted sessions ---
   if (sessions.size === 0) {
-    createSession();
+    var initSession = makeSessionObj();
+    defaultSessionId = initSession.localId;
   } else {
-    // Activate the most recently used session
+    // Set default to the most recently used session
     var allSessions = [...sessions.values()];
     var mostRecent = allSessions[0];
     for (var i = 1; i < allSessions.length; i++) {
@@ -289,7 +316,7 @@ function createSessionManager(opts) {
         mostRecent = allSessions[i];
       }
     }
-    activeSessionId = mostRecent.localId;
+    defaultSessionId = mostRecent.localId;
   }
 
   function searchSessions(query) {
@@ -313,7 +340,6 @@ function createSessionManager(opts) {
           id: session.localId,
           cliSessionId: session.cliSessionId || null,
           title: session.title || "New Session",
-          active: session.localId === activeSessionId,
           isProcessing: session.isProcessing,
           lastActivity: session.lastActivity || session.createdAt || 0,
           matchType: titleMatch && contentMatch ? "both" : titleMatch ? "title" : "content",
@@ -323,8 +349,14 @@ function createSessionManager(opts) {
     return results;
   }
 
+  function setSendToViewers(fn) {
+    sendToViewers = fn;
+  }
+
   return {
-    get activeSessionId() { return activeSessionId; },
+    get defaultSessionId() { return defaultSessionId; },
+    // Backward compat alias
+    get activeSessionId() { return defaultSessionId; },
     get nextLocalId() { return nextLocalId; },
     get slashCommands() { return slashCommands; },
     set slashCommands(v) { slashCommands = v; },
@@ -332,9 +364,9 @@ function createSessionManager(opts) {
     set skillNames(v) { skillNames = v; },
     sessions: sessions,
     HISTORY_PAGE_SIZE: HISTORY_PAGE_SIZE,
-    getActiveSession: getActiveSession,
+    getDefaultSession: getDefaultSession,
     createSession: createSession,
-    switchSession: switchSession,
+    switchSessionForClient: switchSessionForClient,
     deleteSession: deleteSession,
     resumeSession: resumeSession,
     broadcastSessionList: broadcastSessionList,
@@ -342,8 +374,9 @@ function createSessionManager(opts) {
     appendToSessionFile: appendToSessionFile,
     sendAndRecord: doSendAndRecord,
     findTurnBoundary: findTurnBoundary,
-    replayHistory: replayHistory,
+    replayHistoryTo: replayHistoryTo,
     searchSessions: searchSessions,
+    setSendToViewers: setSendToViewers,
   };
 }
 


### PR DESCRIPTION
## Summary
- **Per-client session tracking**: Each browser tab independently tracks which session it's viewing. Switching sessions in one window no longer causes every other window to jump — the root cause was a single global `activeSessionId` shared by all clients.
- **URL-addressable sessions**: Sessions get a `#s=N` URL hash, making them bookmarkable, shareable, and restorable on reconnect. `#s=new` opens a fresh session in a new tab.
- **Native new-tab support**: Sidebar session items are now `<a>` tags with proper `href`, enabling Ctrl/Cmd+click, middle-click, and right-click → "Open in New Tab" natively.

## Changes
| File | What changed |
|------|-------------|
| `lib/sessions.js` | `activeSessionId` → `defaultSessionId`, new `switchSessionForClient()`, `replayHistoryTo()`, `makeSessionObj()`, `setSendToViewers()`; `deleteSession` handles displaced clients; `doSendAndRecord` uses per-session send |
| `lib/project.js` | `clients` Set → Map for per-client state, added `sendToSessionViewers()`/`sendToSessionViewersExcept()`, rewired all 8 message handlers to use `getClientSession(ws)` |
| `lib/sdk-bridge.js` | Uses `sendToViewers(sessionId, obj)` instead of gating on global `activeSessionId` |
| `lib/server.js` | Passes URL query string via `ws._relayQuery` for session routing on connect |
| `lib/public/app.js` | Hash routing (`#s=N`), client-side `active` flag injection, `hashchange` listener, `#s=new` support |
| `lib/public/modules/sidebar.js` | Session items are `<a href="#s=N">` links; modifier-key + New Session opens in new tab |
| `lib/public/css/sidebar.css` | `text-decoration: none` on session items |

## Test plan
- [ ] Single window: switching sessions works as before
- [ ] Two windows, different sessions: each stays on its own session independently
- [ ] Two windows, same session: both receive live updates
- [ ] URL `#s=N`: opening a URL with hash loads the correct session
- [ ] Ctrl/Cmd+click on sidebar session: opens in new tab
- [ ] Middle-click on sidebar session: opens in new tab
- [ ] New Session + Ctrl/Cmd: opens new session in new tab (`#s=new`)
- [ ] Delete session with multiple viewers: displaced clients move to fallback
- [ ] Reconnect: session restores from URL hash
- [ ] Sidebar highlights correct active session on page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)