### PR TITLE
feat: add/remove projects from web UI

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -73,6 +73,46 @@ var relay = createServer({
   debug: config.debug || false,
   dangerouslySkipPermissions: config.dangerouslySkipPermissions || false,
   lanHost: lanIp ? lanIp + ":" + config.port : null,
+  onAddProject: function (absPath) {
+    // Check if already registered
+    for (var j = 0; j < config.projects.length; j++) {
+      if (config.projects[j].path === absPath) {
+        return { ok: true, slug: config.projects[j].slug, existing: true };
+      }
+    }
+    var slugs = config.projects.map(function (p) { return p.slug; });
+    var slug = generateSlug(absPath, slugs);
+    relay.addProject(absPath, slug);
+    config.projects.push({ path: absPath, slug: slug, addedAt: Date.now() });
+    saveConfig(config);
+    try { syncClayrc(config.projects); } catch (e) {}
+    console.log("[daemon] Added project (web):", slug, "→", absPath);
+    // Broadcast updated project list to all clients
+    relay.broadcastAll({
+      type: "projects_updated",
+      projects: relay.getProjects(),
+      projectCount: config.projects.length,
+    });
+    return { ok: true, slug: slug };
+  },
+  onRemoveProject: function (slug) {
+    var found = false;
+    for (var j = 0; j < config.projects.length; j++) {
+      if (config.projects[j].slug === slug) { found = true; break; }
+    }
+    if (!found) return { ok: false, error: "Project not found" };
+    relay.removeProject(slug);
+    config.projects = config.projects.filter(function (p) { return p.slug !== slug; });
+    saveConfig(config);
+    try { syncClayrc(config.projects); } catch (e) {}
+    console.log("[daemon] Removed project (web):", slug);
+    relay.broadcastAll({
+      type: "projects_updated",
+      projects: relay.getProjects(),
+      projectCount: config.projects.length,
+    });
+    return { ok: true };
+  },
 });
 
 // --- Register projects ---

--- a/lib/project.js
+++ b/lib/project.js
@@ -550,6 +550,84 @@ function createProjectContext(opts) {
       return;
     }
 
+    // --- Browse directories (for add-project autocomplete) ---
+    if (msg.type === "browse_dir") {
+      var rawPath = (msg.path || "").replace(/^~/, process.env.HOME || "/");
+      var absTarget = path.resolve(rawPath);
+      var parentDir, prefix;
+      try {
+        var stat = fs.statSync(absTarget);
+        if (stat.isDirectory()) {
+          // Input is an existing directory — list its children
+          parentDir = absTarget;
+          prefix = "";
+        } else {
+          parentDir = path.dirname(absTarget);
+          prefix = path.basename(absTarget).toLowerCase();
+        }
+      } catch (e) {
+        // Path doesn't exist — list parent and filter by typed prefix
+        parentDir = path.dirname(absTarget);
+        prefix = path.basename(absTarget).toLowerCase();
+      }
+      try {
+        var dirItems = fs.readdirSync(parentDir, { withFileTypes: true });
+        var dirEntries = [];
+        for (var di = 0; di < dirItems.length; di++) {
+          var d = dirItems[di];
+          if (!d.isDirectory()) continue;
+          if (d.name.charAt(0) === ".") continue;
+          if (IGNORED_DIRS.has(d.name)) continue;
+          if (prefix && !d.name.toLowerCase().startsWith(prefix)) continue;
+          dirEntries.push({ name: d.name, path: path.join(parentDir, d.name) });
+        }
+        dirEntries.sort(function (a, b) { return a.name.localeCompare(b.name); });
+        sendTo(ws, { type: "browse_dir_result", path: msg.path, entries: dirEntries });
+      } catch (e) {
+        sendTo(ws, { type: "browse_dir_result", path: msg.path, entries: [], error: e.message });
+      }
+      return;
+    }
+
+    // --- Add project from web UI ---
+    if (msg.type === "add_project") {
+      var addPath = (msg.path || "").replace(/^~/, process.env.HOME || "/");
+      var addAbs = path.resolve(addPath);
+      try {
+        var addStat = fs.statSync(addAbs);
+        if (!addStat.isDirectory()) {
+          sendTo(ws, { type: "add_project_result", ok: false, error: "Not a directory" });
+          return;
+        }
+      } catch (e) {
+        sendTo(ws, { type: "add_project_result", ok: false, error: "Directory not found" });
+        return;
+      }
+      if (typeof opts.onAddProject === "function") {
+        var result = opts.onAddProject(addAbs);
+        sendTo(ws, { type: "add_project_result", ok: result.ok, slug: result.slug, error: result.error, existing: result.existing });
+      } else {
+        sendTo(ws, { type: "add_project_result", ok: false, error: "Not supported" });
+      }
+      return;
+    }
+
+    // --- Remove project from web UI ---
+    if (msg.type === "remove_project") {
+      var removeSlug = msg.slug;
+      if (!removeSlug) {
+        sendTo(ws, { type: "remove_project_result", ok: false, error: "Missing slug" });
+        return;
+      }
+      if (typeof opts.onRemoveProject === "function") {
+        var removeResult = opts.onRemoveProject(removeSlug);
+        sendTo(ws, { type: "remove_project_result", ok: removeResult.ok, slug: removeSlug, error: removeResult.error });
+      } else {
+        sendTo(ws, { type: "remove_project_result", ok: false, error: "Not supported" });
+      }
+      return;
+    }
+
     // --- File browser ---
     if (msg.type === "fs_list") {
       var fsDir = safePath(cwd, msg.path || ".");

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -90,6 +90,24 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
       count.textContent = p.sessions;
       item.appendChild(count);
 
+      if (!isCurrent) {
+        var removeBtn = document.createElement("button");
+        removeBtn.className = "pd-remove";
+        removeBtn.type = "button";
+        removeBtn.title = "Remove project";
+        removeBtn.innerHTML = '<i data-lucide="x"></i>';
+        removeBtn.dataset.slug = p.slug;
+        removeBtn.dataset.name = displayName;
+        removeBtn.addEventListener("click", function (e) {
+          e.preventDefault();
+          e.stopPropagation();
+          var s = this.dataset.slug;
+          var n = this.dataset.name;
+          confirmRemoveProject(s, n);
+        });
+        item.appendChild(removeBtn);
+      }
+
       projectDropdownList.appendChild(item);
     }
 
@@ -98,11 +116,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     if (addBtn) {
       addBtn.onclick = function () {
         closeProjectDropdown();
-        var hint = document.getElementById("project-hint");
-        if (hint) {
-          hint.classList.remove("hidden");
-          try { localStorage.removeItem("claude-relay-project-hint-dismissed"); } catch (e) {}
-        }
+        openAddProjectModal();
       };
     }
     refreshIcons();
@@ -1660,6 +1674,23 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
         case "process_stats":
           updateStatusPanel(msg);
           break;
+
+        case "browse_dir_result":
+          handleBrowseDirResult(msg);
+          break;
+
+        case "add_project_result":
+          handleAddProjectResult(msg);
+          break;
+
+        case "remove_project_result":
+          handleRemoveProjectResult(msg);
+          break;
+
+        case "projects_updated":
+          updateProjectSwitcher(msg);
+          renderProjectDropdown();
+          break;
       }
   }
 
@@ -1830,6 +1861,217 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     terminalContainerEl: $("terminal-container"),
     terminalBodyEl: $("terminal-body"),
     fileViewerEl: $("file-viewer"),
+  });
+
+  // --- Remove project ---
+  function confirmRemoveProject(slug, name) {
+    closeProjectDropdown();
+    showConfirm("Remove project \"" + name + "\"?", function () {
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: "remove_project", slug: slug }));
+      }
+    });
+  }
+
+  function handleRemoveProjectResult(msg) {
+    if (msg.ok) {
+      showToast("Project removed", "success");
+      // If we removed the current project, navigate to first available
+      if (msg.slug === currentSlug) {
+        window.location.href = "/";
+      }
+    } else {
+      showToast(msg.error || "Failed to remove project", "error");
+    }
+  }
+
+  // --- Add project modal ---
+  var addProjectModal = document.getElementById("add-project-modal");
+  var addProjectInput = document.getElementById("add-project-input");
+  var addProjectSuggestions = document.getElementById("add-project-suggestions");
+  var addProjectError = document.getElementById("add-project-error");
+  var addProjectOk = document.getElementById("add-project-ok");
+  var addProjectCancel = document.getElementById("add-project-cancel");
+  var addProjectDebounce = null;
+  var addProjectActiveIdx = -1;
+
+  function openAddProjectModal() {
+    addProjectModal.classList.remove("hidden");
+    addProjectInput.value = "/";
+    addProjectError.classList.add("hidden");
+    addProjectError.textContent = "";
+    addProjectSuggestions.classList.add("hidden");
+    addProjectSuggestions.innerHTML = "";
+    addProjectActiveIdx = -1;
+    addProjectOk.disabled = false;
+    setTimeout(function () {
+      addProjectInput.focus();
+      addProjectInput.setSelectionRange(1, 1);
+      requestBrowseDir("/");
+    }, 50);
+  }
+
+  function closeAddProjectModal() {
+    addProjectModal.classList.add("hidden");
+    addProjectInput.value = "";
+    addProjectSuggestions.classList.add("hidden");
+    addProjectSuggestions.innerHTML = "";
+    addProjectError.classList.add("hidden");
+    addProjectActiveIdx = -1;
+    if (addProjectDebounce) { clearTimeout(addProjectDebounce); addProjectDebounce = null; }
+  }
+
+  function requestBrowseDir(val) {
+    if (!ws || ws.readyState !== 1) return;
+    ws.send(JSON.stringify({ type: "browse_dir", path: val }));
+  }
+
+  function handleBrowseDirResult(msg) {
+    addProjectSuggestions.innerHTML = "";
+    addProjectActiveIdx = -1;
+    if (msg.error) {
+      addProjectSuggestions.classList.add("hidden");
+      return;
+    }
+    var entries = msg.entries || [];
+    if (entries.length === 0) {
+      addProjectSuggestions.classList.add("hidden");
+      return;
+    }
+    for (var si = 0; si < entries.length; si++) {
+      var entry = entries[si];
+      var item = document.createElement("div");
+      item.className = "add-project-suggestion-item";
+      item.dataset.path = entry.path;
+      item.innerHTML = '<i data-lucide="folder"></i><span class="add-project-suggestion-name">' +
+        escapeHtml(entry.name) + '</span>';
+      item.addEventListener("click", function (e) {
+        var p = this.dataset.path + "/";
+        addProjectInput.value = p;
+        addProjectInput.focus();
+        addProjectError.classList.add("hidden");
+        requestBrowseDir(p);
+      });
+      addProjectSuggestions.appendChild(item);
+    }
+    addProjectSuggestions.classList.remove("hidden");
+    refreshIcons();
+  }
+
+  function handleAddProjectResult(msg) {
+    if (msg.ok) {
+      closeAddProjectModal();
+      if (msg.existing) {
+        showToast("Project already registered", "info");
+      } else {
+        showToast("Project added", "success");
+        // Navigate to the new project
+        if (msg.slug) {
+          window.location.href = "/p/" + msg.slug + "/";
+        }
+      }
+    } else {
+      addProjectError.textContent = msg.error || "Failed to add project";
+      addProjectError.classList.remove("hidden");
+      addProjectOk.disabled = false;
+    }
+  }
+
+  function setActiveIdx(idx) {
+    var items = addProjectSuggestions.querySelectorAll(".add-project-suggestion-item");
+    addProjectActiveIdx = idx;
+    for (var ai = 0; ai < items.length; ai++) {
+      if (ai === idx) {
+        items[ai].classList.add("active");
+        items[ai].scrollIntoView({ block: "nearest" });
+      } else {
+        items[ai].classList.remove("active");
+      }
+    }
+  }
+
+  addProjectInput.addEventListener("input", function () {
+    var val = addProjectInput.value;
+    addProjectError.classList.add("hidden");
+    if (addProjectDebounce) clearTimeout(addProjectDebounce);
+    addProjectDebounce = setTimeout(function () {
+      requestBrowseDir(val);
+    }, 200);
+  });
+
+  addProjectInput.addEventListener("keydown", function (e) {
+    var items = addProjectSuggestions.querySelectorAll(".add-project-suggestion-item");
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (items.length > 0) {
+        var next = addProjectActiveIdx < items.length - 1 ? addProjectActiveIdx + 1 : 0;
+        setActiveIdx(next);
+      }
+      return;
+    }
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (items.length > 0) {
+        var prev = addProjectActiveIdx > 0 ? addProjectActiveIdx - 1 : items.length - 1;
+        setActiveIdx(prev);
+      }
+      return;
+    }
+
+    if (e.key === "Tab") {
+      e.preventDefault();
+      var target = addProjectActiveIdx >= 0 && addProjectActiveIdx < items.length
+        ? items[addProjectActiveIdx]
+        : items.length > 0 ? items[0] : null;
+      if (target) {
+        var p = target.dataset.path + "/";
+        addProjectInput.value = p;
+        addProjectError.classList.add("hidden");
+        requestBrowseDir(p);
+      }
+      return;
+    }
+
+    if (e.key === "Enter") {
+      e.preventDefault();
+      // If a suggestion is highlighted, pick it first
+      if (addProjectActiveIdx >= 0 && addProjectActiveIdx < items.length) {
+        var picked = items[addProjectActiveIdx].dataset.path + "/";
+        addProjectInput.value = picked;
+        addProjectError.classList.add("hidden");
+        requestBrowseDir(picked);
+        return;
+      }
+      // Otherwise submit
+      submitAddProject();
+      return;
+    }
+
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeAddProjectModal();
+      return;
+    }
+  });
+
+  function submitAddProject() {
+    var val = addProjectInput.value.replace(/\/+$/, "");
+    if (!val) return;
+    addProjectOk.disabled = true;
+    addProjectError.classList.add("hidden");
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "add_project", path: val }));
+    }
+  }
+
+  addProjectOk.addEventListener("click", function () { submitAddProject(); });
+  addProjectCancel.addEventListener("click", function () { closeAddProjectModal(); });
+
+  // Close on backdrop click
+  addProjectModal.querySelector(".confirm-backdrop").addEventListener("click", function () {
+    closeAddProjectModal();
   });
 
   // --- Init ---

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -520,6 +520,98 @@
 .notif-help-url .popover-copy:hover { color: var(--text); border-color: var(--text-dimmer); }
 .notif-help-url .popover-copy.copied { color: var(--success); border-color: var(--success); }
 
+/* --- Add project modal --- */
+#add-project-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
+#add-project-modal.hidden { display: none; }
+
+.add-project-dialog { max-width: 420px; }
+
+.add-project-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 14px;
+}
+
+.add-project-body { margin-bottom: 16px; }
+
+.add-project-input-wrap { position: relative; }
+
+#add-project-input {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 13px;
+  font-family: "SF Mono", Menlo, Monaco, monospace;
+  padding: 10px 12px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+#add-project-input:focus { border-color: var(--text-dimmer); }
+#add-project-input::placeholder { color: var(--text-muted); font-family: "Inter", system-ui, sans-serif; }
+
+#add-project-suggestions {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 10;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+#add-project-suggestions.hidden { display: none; }
+
+.add-project-suggestion-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.add-project-suggestion-item:first-child { border-radius: 8px 8px 0 0; }
+.add-project-suggestion-item:last-child { border-radius: 0 0 8px 8px; }
+.add-project-suggestion-item:only-child { border-radius: 8px; }
+.add-project-suggestion-item:hover,
+.add-project-suggestion-item.active { background: var(--sidebar-hover); }
+
+.add-project-suggestion-item .lucide { width: 14px; height: 14px; color: var(--text-muted); flex-shrink: 0; }
+
+.add-project-suggestion-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.add-project-suggestion-path {
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
+}
+
+#add-project-error {
+  font-size: 12px;
+  color: var(--error);
+  margin-top: 8px;
+}
+
+#add-project-error.hidden { display: none; }
+
 /* --- Connect overlay --- */
 #connect-overlay {
   position: absolute;

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -225,6 +225,23 @@
   opacity: 0.4;
 }
 
+.pd-remove {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  line-height: 0;
+  transition: color 0.15s, background 0.15s;
+}
+
+.pd-remove .lucide { width: 14px; height: 14px; }
+.project-dropdown-item:hover .pd-remove { display: block; }
+.pd-remove:hover { color: var(--error); background: rgba(255, 255, 255, 0.06); }
+
 .project-dropdown-footer {
   border-top: 1px solid var(--border-subtle);
   padding: 4px 0;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -414,6 +414,24 @@
   </div>
 </div>
 
+<div id="add-project-modal" class="hidden">
+  <div class="confirm-backdrop"></div>
+  <div class="confirm-dialog add-project-dialog">
+    <div class="add-project-title">Add project</div>
+    <div class="add-project-body">
+      <div class="add-project-input-wrap">
+        <input type="text" id="add-project-input" placeholder="/" autocomplete="off" spellcheck="false">
+        <div id="add-project-suggestions" class="hidden"></div>
+      </div>
+      <div id="add-project-error" class="hidden"></div>
+    </div>
+    <div class="confirm-actions">
+      <button class="confirm-btn confirm-cancel" id="add-project-cancel">Cancel</button>
+      <button class="confirm-btn confirm-ok" id="add-project-ok">Add</button>
+    </div>
+  </div>
+</div>
+
 <script src="https://cdn.jsdelivr.net/npm/marked@14/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>

--- a/lib/server.js
+++ b/lib/server.js
@@ -124,6 +124,8 @@ function createServer(opts) {
   var debug = opts.debug || false;
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
   var lanHost = opts.lanHost || null;
+  var onAddProject = opts.onAddProject || null;
+  var onRemoveProject = opts.onRemoveProject || null;
 
   var authToken = pinHash || null;
   var realVersion = require("../package.json").version;
@@ -472,6 +474,8 @@ function createServer(opts) {
         projects.forEach(function (ctx) { list.push(ctx.getStatus()); });
         return list;
       },
+      onAddProject: onAddProject,
+      onRemoveProject: onRemoveProject,
     });
     projects.set(slug, ctx);
     ctx.warmup();


### PR DESCRIPTION
## Summary
- **Add project**: "Add project" button opens a modal with a path input and server-side directory autocomplete (VS Code Remote style)
  - Type a path → server returns matching directories → dropdown suggestions
  - Arrow keys to navigate, Tab to autocomplete, Enter on a highlighted item to drill in, Enter on empty selection to submit
  - `~` expansion, hidden/ignored dirs filtered out
- **Remove project**: X button on each project in the dropdown (hidden until hover, not shown on current project)
  - Confirmation dialog before removal
- Both operations use `broadcastAll` to update all connected clients immediately

## Architecture
```
[Browser]                    [project.js]              [daemon.js]
   │                              │                         │
   │─── browse_dir ──────────────>│                         │
   │<── browse_dir_result ────────│                         │
   │                              │                         │
   │─── add_project ─────────────>│                         │
   │                              │── onAddProject() ──────>│
   │<── add_project_result ───────│                         │
   │<── projects_updated ─────────│<── broadcastAll() ──────│
   │                              │                         │
   │─── remove_project ──────────>│                         │
   │                              │── onRemoveProject() ───>│
   │<── remove_project_result ────│                         │
   │<── projects_updated ─────────│<── broadcastAll() ──────│
```

## Files changed
- `lib/project.js` — `browse_dir`, `add_project`, `remove_project` WS handlers
- `lib/daemon.js` — `onAddProject`/`onRemoveProject` callbacks with broadcast
- `lib/server.js` — Pass callbacks through to project contexts
- `lib/public/index.html` — Add project modal HTML
- `lib/public/css/overlays.css` — Modal + autocomplete dropdown styles
- `lib/public/css/sidebar.css` — Remove button styles
- `lib/public/app.js` — Modal logic, autocomplete, keyboard nav, WS handling

## Test plan
- [ ] Click "Add project" → modal opens with `/` and directory suggestions
- [ ] Type path → suggestions update with 200ms debounce
- [ ] Arrow keys navigate suggestions, Tab autocompletes
- [ ] Enter submits, project appears in sidebar immediately
- [ ] Already registered path → "Project already registered" toast
- [ ] Invalid path → error message in modal
- [ ] Hover project in dropdown → X button appears
- [ ] Click X → confirmation dialog → project removed
- [ ] Remove current project → redirects to `/`
- [ ] Multiple browser tabs → all update when project added/removed

Resolves #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)