### PR TITLE
feat: dev mode with foreground daemon and auto-restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "claude-relay-dev": "./bin/cli.js"
   },
   "scripts": {
+    "dev": "node bin/cli.js --dev",
     "prepack": "npm pkg delete bin.claude-relay-dev",
     "postpack": "npm pkg set bin.claude-relay-dev=./bin/cli.js"
   },


### PR DESCRIPTION
## Summary
- Adds `npm run dev` for development — daemon runs in the foreground with live logs and auto-restarts on `lib/*.js` file changes
- Unifies `--dev` flag with existing `claude-relay-dev` binary detection
- Debug panel auto-enabled, update check skipped, separate config/port

## How it works
```
$ npm run dev
[dev] Starting relay on port 2635...
[dev] https://100.x.x.x:2635
[dev] Watching lib/ for changes (excluding lib/public/)

[daemon] Listening on port 2635
[daemon] Added project: claude-relay → /Users/chad/projects/claude-relay

  ... edit lib/server.js ...

[dev] File changed: lib/server.js
[dev] Restarting...

[daemon] Listening on port 2635
```

## Details
- **Foreground execution**: `stdio: ["ignore", "inherit", "inherit"]` — no detach, logs go straight to terminal
- **File watching**: `fs.watch(lib/, { recursive: true })` with 300ms debounce, `lib/public/` excluded (static files served from disk)
- **Auto-restart**: On file change, kills daemon with SIGTERM, respawns after 300ms
- **Crash recovery**: If daemon exits unexpectedly (not from file change), auto-restarts after 500ms
- **Clean shutdown**: Ctrl+C kills child, closes watcher, clears stale config
- **Existing daemon**: Auto-shuts down any running dev daemon before starting
- **Config isolation**: `~/.claude-relay-dev/` directory, port 2635

## Test plan
- [ ] `npm run dev` → daemon starts, logs visible in terminal
- [ ] Edit `lib/server.js` → "[dev] Restarting..." and daemon restarts
- [ ] Edit `lib/public/app.js` → no restart (client-side file)
- [ ] Ctrl+C → clean shutdown
- [ ] Run `npm run dev` while dev daemon already running → shuts down old, starts new
- [ ] Web UI → debug panel visible

Resolves #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)