### PR TITLE
feat: CLI session picker for resuming conversations

### DIFF
--- a/lib/cli-sessions.js
+++ b/lib/cli-sessions.js
@@ -1,0 +1,270 @@
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+var readline = require("readline");
+
+/**
+ * Compute the encoded project directory name used by the Claude CLI.
+ * Replaces all "/" with "-", e.g. "/Users/foo/project" -> "-Users-foo-project"
+ */
+function encodeCwd(cwd) {
+  return cwd.replace(/\//g, "-");
+}
+
+/**
+ * Parse the first ~20 lines of a CLI session JSONL file to extract metadata.
+ * Returns null if the file can't be parsed or has no user messages.
+ */
+function parseSessionFile(filePath, maxLines) {
+  if (maxLines == null) maxLines = 20;
+  return new Promise(function (resolve) {
+    var sessionId = path.basename(filePath, ".jsonl");
+    var result = {
+      sessionId: sessionId,
+      firstPrompt: "",
+      model: null,
+      gitBranch: null,
+      startTime: null,
+      lastActivity: null,
+    };
+
+    var lineCount = 0;
+    var foundUser = false;
+    var stream;
+    try {
+      stream = fs.createReadStream(filePath, { encoding: "utf8" });
+    } catch (e) {
+      return resolve(null);
+    }
+
+    var rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    rl.on("line", function (line) {
+      lineCount++;
+      if (lineCount > maxLines) {
+        rl.close();
+        stream.destroy();
+        return;
+      }
+
+      var obj;
+      try { obj = JSON.parse(line); } catch (e) { return; }
+
+      // Skip file-history-snapshot, queue-operation, and other non-message records
+      if (obj.type === "user" && obj.message && obj.message.role === "user") {
+        if (!foundUser) {
+          foundUser = true;
+          result.sessionId = obj.sessionId || sessionId;
+          result.gitBranch = obj.gitBranch || null;
+          if (obj.timestamp) result.startTime = obj.timestamp;
+          var content = obj.message.content || "";
+          if (typeof content === "string") {
+            result.firstPrompt = content.substring(0, 100);
+          } else if (Array.isArray(content)) {
+            for (var i = 0; i < content.length; i++) {
+              if (content[i].type === "text" && content[i].text) {
+                result.firstPrompt = content[i].text.substring(0, 100);
+                break;
+              }
+            }
+          }
+        }
+        // Track latest user timestamp for lastActivity
+        if (obj.timestamp) result.lastActivity = obj.timestamp;
+      }
+
+      // Extract model from first assistant message
+      if (!result.model && obj.message && obj.message.role === "assistant" && obj.message.model) {
+        result.model = obj.message.model;
+      }
+    });
+
+    rl.on("close", function () {
+      if (!foundUser) return resolve(null);
+
+      // Use file mtime as fallback for lastActivity, or as a better proxy
+      // since we only read the first ~20 lines
+      try {
+        var stat = fs.statSync(filePath);
+        var mtime = stat.mtime.toISOString();
+        // File mtime is always more accurate for "last activity" since we
+        // don't read the entire file
+        result.lastActivity = mtime;
+      } catch (e) {}
+
+      resolve(result);
+    });
+
+    rl.on("error", function () {
+      resolve(null);
+    });
+
+    stream.on("error", function () {
+      rl.close();
+      resolve(null);
+    });
+  });
+}
+
+/**
+ * List CLI sessions for a given project directory.
+ * Reads ~/.claude/projects/{encoded-cwd}/ and parses JSONL metadata.
+ * Returns array sorted by lastActivity descending (most recent first).
+ */
+function listCliSessions(cwd) {
+  var encoded = encodeCwd(cwd);
+  var projectDir = path.join(os.homedir(), ".claude", "projects", encoded);
+
+  return new Promise(function (resolve) {
+    fs.readdir(projectDir, { withFileTypes: true }, function (err, entries) {
+      if (err) return resolve([]);
+
+      var jsonlFiles = [];
+      for (var i = 0; i < entries.length; i++) {
+        if (entries[i].isFile() && entries[i].name.endsWith(".jsonl")) {
+          jsonlFiles.push(path.join(projectDir, entries[i].name));
+        }
+      }
+
+      if (jsonlFiles.length === 0) return resolve([]);
+
+      var pending = jsonlFiles.length;
+      var results = [];
+
+      for (var j = 0; j < jsonlFiles.length; j++) {
+        parseSessionFile(jsonlFiles[j]).then(function (session) {
+          if (session) results.push(session);
+          pending--;
+          if (pending === 0) {
+            results.sort(function (a, b) {
+              var ta = a.lastActivity || "";
+              var tb = b.lastActivity || "";
+              return ta < tb ? 1 : ta > tb ? -1 : 0;
+            });
+            resolve(results);
+          }
+        });
+      }
+    });
+  });
+}
+
+/**
+ * Get the most recent CLI session for a given project directory.
+ * Returns the session object or null if none found.
+ */
+function getMostRecentCliSession(cwd) {
+  return listCliSessions(cwd).then(function (sessions) {
+    return sessions.length > 0 ? sessions[0] : null;
+  });
+}
+
+/**
+ * Extract user message text from a CLI JSONL content field.
+ * Content can be a string or an array of content blocks.
+ */
+function extractText(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  var parts = [];
+  for (var i = 0; i < content.length; i++) {
+    if (content[i].type === "text" && content[i].text) {
+      parts.push(content[i].text);
+    }
+  }
+  return parts.join("");
+}
+
+/**
+ * Read a full CLI session JSONL file and convert it to relay-compatible
+ * history entries (user_message, delta, tool_start, tool_executing, tool_result).
+ * Returns a Promise that resolves to an array of history entries.
+ */
+function readCliSessionHistory(cwd, sessionId) {
+  var encoded = encodeCwd(cwd);
+  var filePath = path.join(os.homedir(), ".claude", "projects", encoded, sessionId + ".jsonl");
+
+  return new Promise(function (resolve) {
+    var history = [];
+    var stream;
+    try {
+      stream = fs.createReadStream(filePath, { encoding: "utf8" });
+    } catch (e) {
+      return resolve([]);
+    }
+
+    var rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    var toolCounter = 0;
+
+    rl.on("line", function (line) {
+      var obj;
+      try { obj = JSON.parse(line); } catch (e) { return; }
+
+      if (!obj.message) return;
+
+      // User prompt
+      if (obj.type === "user" && obj.message.role === "user") {
+        // Skip tool_result records (they have type "user" but content is tool results)
+        var content = obj.message.content;
+        if (Array.isArray(content) && content.length > 0 && content[0].type === "tool_result") {
+          return;
+        }
+        var text = extractText(content);
+        if (text) {
+          history.push({ type: "user_message", text: text });
+        }
+        return;
+      }
+
+      // Assistant message
+      if (obj.message.role === "assistant" && Array.isArray(obj.message.content)) {
+        for (var i = 0; i < obj.message.content.length; i++) {
+          var block = obj.message.content[i];
+
+          if (block.type === "text" && block.text) {
+            history.push({ type: "delta", text: block.text });
+          }
+
+          if (block.type === "tool_use") {
+            var toolId = "cli-tool-" + (++toolCounter);
+            var toolName = block.name || "Tool";
+            history.push({ type: "tool_start", id: toolId, name: toolName });
+            history.push({
+              type: "tool_executing",
+              id: toolId,
+              name: toolName,
+              input: block.input || {},
+            });
+            // Emit ask_user_answered so the client re-enables input after replaying AskUserQuestion
+            if (toolName === "AskUserQuestion") {
+              history.push({ type: "ask_user_answered", toolId: toolId });
+            }
+            history.push({ type: "tool_result", id: toolId, content: "" });
+          }
+        }
+      }
+    });
+
+    rl.on("close", function () {
+      resolve(history);
+    });
+
+    rl.on("error", function () {
+      resolve([]);
+    });
+
+    stream.on("error", function () {
+      rl.close();
+      resolve([]);
+    });
+  });
+}
+
+module.exports = {
+  listCliSessions: listCliSessions,
+  getMostRecentCliSession: getMostRecentCliSession,
+  readCliSessionHistory: readCliSessionHistory,
+  parseSessionFile: parseSessionFile,
+  encodeCwd: encodeCwd,
+  extractText: extractText,
+};

--- a/lib/project.js
+++ b/lib/project.js
@@ -320,9 +320,51 @@ function createProjectContext(opts) {
 
     if (msg.type === "resume_session") {
       if (!msg.cliSessionId) return;
-      sm.resumeSession(msg.cliSessionId);
+      var cliSess = require("./cli-sessions");
+      cliSess.readCliSessionHistory(cwd, msg.cliSessionId).then(function (history) {
+        var title = "Resumed session";
+        for (var i = 0; i < history.length; i++) {
+          if (history[i].type === "user_message" && history[i].text) {
+            title = history[i].text.substring(0, 50);
+            break;
+          }
+        }
+        sm.resumeSession(msg.cliSessionId, { history: history, title: title });
+      }).catch(function () {
+        sm.resumeSession(msg.cliSessionId);
+      });
       return;
     }
+
+    if (msg.type === "list_cli_sessions") {
+      var cliSessions = require("./cli-sessions");
+      var _fs = require("fs");
+      var _path = require("path");
+      // Collect session IDs already in relay (in-memory + persisted on disk)
+      var relayIds = {};
+      sm.sessions.forEach(function (s) {
+        if (s.cliSessionId) relayIds[s.cliSessionId] = true;
+      });
+      try {
+        var sessDir = _path.join(cwd, ".claude-relay", "sessions");
+        var diskFiles = _fs.readdirSync(sessDir);
+        for (var fi = 0; fi < diskFiles.length; fi++) {
+          if (diskFiles[fi].endsWith(".jsonl")) {
+            relayIds[diskFiles[fi].replace(".jsonl", "")] = true;
+          }
+        }
+      } catch (e) {}
+      cliSessions.listCliSessions(cwd).then(function (sessions) {
+        var filtered = sessions.filter(function (s) {
+          return !relayIds[s.sessionId];
+        });
+        sendTo(ws, { type: "cli_session_list", sessions: filtered });
+      }).catch(function () {
+        sendTo(ws, { type: "cli_session_list", sessions: [] });
+      });
+      return;
+    }
+
 
     if (msg.type === "switch_session") {
       if (msg.id && sm.sessions.has(msg.id)) {

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1,7 +1,7 @@
 import { showToast, copyToClipboard, escapeHtml } from './modules/utils.js';
 import { refreshIcons, iconHtml, randomThinkingVerb } from './modules/icons.js';
 import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, closeMermaidModal } from './modules/markdown.js';
-import { initSidebar, renderSessionList, handleSearchResults, updatePageTitle, getActiveSearchQuery, buildSearchTimeline, removeSearchTimeline } from './modules/sidebar.js';
+import { initSidebar, renderSessionList, handleSearchResults, updatePageTitle, getActiveSearchQuery, buildSearchTimeline, removeSearchTimeline, populateCliSessionList } from './modules/sidebar.js';
 import { initRewind, setRewindMode, showRewindModal, clearPendingRewindUuid } from './modules/rewind.js';
 import { initNotifications, showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './modules/notifications.js';
 import { initInput, clearPendingImages, handleInputSync, autoResize, builtinCommands } from './modules/input.js';
@@ -1388,6 +1388,10 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
 
         case "search_results":
           handleSearchResults(msg);
+          break;
+
+        case "cli_session_list":
+          populateCliSessionList(msg.sessions || []);
           break;
 
         case "session_switched":

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -407,7 +407,7 @@
   font-style: italic;
 }
 
-/* --- Resume modal --- */
+/* --- Resume / Session Picker modal --- */
 #resume-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
 #resume-modal.hidden { display: none; }
 
@@ -418,44 +418,68 @@
   margin-bottom: 12px;
 }
 
-.resume-modal-body {
-  font-size: 13px;
-  color: var(--text-secondary);
-  line-height: 1.6;
-  margin-bottom: 16px;
+.resume-picker-dialog { min-width: 380px; max-width: 480px; }
+.resume-picker-body { margin-bottom: 12px; }
+
+.resume-picker-loading {
+  display: flex; align-items: center; gap: 10px;
+  padding: 24px 0; justify-content: center;
+  font-size: 13px; color: var(--text-muted);
+}
+.resume-picker-loading.hidden { display: none; }
+.resume-picker-empty.hidden { display: none; }
+.resume-picker-list.hidden { display: none; }
+
+.resume-picker-spinner {
+  width: 16px; height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--text-secondary);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
 }
 
-.resume-modal-body p { margin: 0 0 10px; }
+@keyframes spin { to { transform: rotate(360deg); } }
 
-.resume-modal-hint {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-bottom: 12px;
+.resume-picker-empty {
+  padding: 24px 0; text-align: center;
+  font-size: 13px; color: var(--text-muted);
 }
 
-.resume-modal-hint code {
+.resume-picker-list {
+  max-height: 400px; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 2px;
+}
+
+.cli-session-item {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 10px 12px; border-radius: 8px;
+  cursor: pointer; transition: background 0.15s;
+  border: 1px solid transparent;
+}
+
+.cli-session-item:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--border-subtle);
+}
+
+.cli-session-title {
+  font-size: 13px; color: var(--text);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  line-height: 1.4;
+}
+
+.cli-session-meta {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 11px; color: var(--text-muted);
+  flex-wrap: wrap;
+}
+
+.cli-session-meta .badge {
   background: rgba(255, 255, 255, 0.07);
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: 1px 6px; border-radius: 4px;
   font-family: "SF Mono", Menlo, Monaco, monospace;
-  font-size: 0.92em;
+  font-size: 10px;
 }
-
-#resume-session-input {
-  width: 100%;
-  background: var(--input-bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  color: var(--text);
-  font-size: 13px;
-  font-family: "SF Mono", Menlo, Monaco, monospace;
-  padding: 10px 12px;
-  outline: none;
-  transition: border-color 0.2s;
-}
-
-#resume-session-input:focus { border-color: var(--text-dimmer); }
-#resume-session-input::placeholder { color: var(--text-muted); font-family: "Inter", system-ui, sans-serif; }
 
 /* --- Notification help modal --- */
 #notif-help-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -55,7 +55,7 @@
     <div id="sidebar-panel-sessions" class="sidebar-panel">
       <div id="session-actions">
         <button id="new-session-btn"><i data-lucide="plus"></i> <span>New session</span></button>
-        <button id="resume-session-btn"><i data-lucide="link"></i> <span>Resume with ID</span></button>
+        <button id="resume-session-btn" title="Resume a CLI session"><i data-lucide="terminal"></i> <span>Resume CLI</span></button>
         <button id="file-browser-btn"><i data-lucide="folder-tree"></i> <span>File browser</span></button>
         <button id="terminal-sidebar-btn"><i data-lucide="square-terminal"></i> <span>Terminal</span></button>
       </div>
@@ -369,16 +369,20 @@
 
 <div id="resume-modal" class="hidden">
   <div class="confirm-backdrop"></div>
-  <div class="confirm-dialog">
+  <div class="confirm-dialog resume-picker-dialog">
     <div class="resume-modal-title">Resume CLI session</div>
-    <div class="resume-modal-body">
-      <p>Paste a session ID to continue a CLI conversation here.</p>
-      <div class="resume-modal-hint">Run <code>claude conversation list</code> in your terminal to find session IDs.</div>
-      <input type="text" id="resume-session-input" placeholder="Session ID" autocomplete="off" spellcheck="false">
+    <div class="resume-picker-body">
+      <div id="resume-picker-loading" class="resume-picker-loading">
+        <div class="resume-picker-spinner"></div>
+        <span>Loading sessions...</span>
+      </div>
+      <div id="resume-picker-empty" class="resume-picker-empty hidden">
+        No CLI sessions found for this project.
+      </div>
+      <div id="resume-picker-list" class="resume-picker-list hidden"></div>
     </div>
     <div class="confirm-actions">
       <button class="confirm-btn confirm-cancel" id="resume-cancel">Cancel</button>
-      <button class="confirm-btn confirm-ok" id="resume-ok">Resume</button>
     </div>
   </div>
 </div>

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -349,48 +349,31 @@ export function initSidebar(_ctx) {
     }
   });
 
-  // --- Resume session modal ---
+  // --- Resume session picker ---
   var resumeModal = ctx.$("resume-modal");
-  var resumeInput = ctx.$("resume-session-input");
-  var resumeOk = ctx.$("resume-ok");
   var resumeCancel = ctx.$("resume-cancel");
+  var pickerLoading = ctx.$("resume-picker-loading");
+  var pickerEmpty = ctx.$("resume-picker-empty");
+  var pickerList = ctx.$("resume-picker-list");
 
   function openResumeModal() {
     resumeModal.classList.remove("hidden");
-    resumeInput.value = "";
-    setTimeout(function () { resumeInput.focus(); }, 50);
+    pickerLoading.classList.remove("hidden");
+    pickerEmpty.classList.add("hidden");
+    pickerList.classList.add("hidden");
+    pickerList.innerHTML = "";
+    if (ctx.ws && ctx.connected) {
+      ctx.ws.send(JSON.stringify({ type: "list_cli_sessions" }));
+    }
   }
 
   function closeResumeModal() {
     resumeModal.classList.add("hidden");
-    resumeInput.value = "";
-  }
-
-  function submitResume() {
-    var val = resumeInput.value.trim();
-    if (!val) return;
-    if (ctx.ws && ctx.connected) {
-      ctx.ws.send(JSON.stringify({ type: "resume_session", cliSessionId: val }));
-    }
-    closeResumeModal();
-    closeSidebar();
   }
 
   ctx.resumeSessionBtn.addEventListener("click", openResumeModal);
-  resumeOk.addEventListener("click", submitResume);
   resumeCancel.addEventListener("click", closeResumeModal);
   resumeModal.querySelector(".confirm-backdrop").addEventListener("click", closeResumeModal);
-
-  resumeInput.addEventListener("keydown", function (e) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      submitResume();
-    }
-    if (e.key === "Escape") {
-      e.preventDefault();
-      closeResumeModal();
-    }
-  });
 
   // --- File browser panel switch ---
   var fileBrowserBtn = ctx.$("file-browser-btn");
@@ -414,6 +397,85 @@ export function initSidebar(_ctx) {
   }
   if (filePanelBack) {
     filePanelBack.addEventListener("click", showSessionsPanel);
+  }
+}
+
+// --- CLI session picker ---
+function relativeTime(isoString) {
+  if (!isoString) return "";
+  var ms = Date.now() - new Date(isoString).getTime();
+  var sec = Math.floor(ms / 1000);
+  if (sec < 60) return "just now";
+  var min = Math.floor(sec / 60);
+  if (min < 60) return min + "m ago";
+  var hr = Math.floor(min / 60);
+  if (hr < 24) return hr + "h ago";
+  var days = Math.floor(hr / 24);
+  if (days < 30) return days + "d ago";
+  return new Date(isoString).toLocaleDateString();
+}
+
+export function populateCliSessionList(sessions) {
+  var pickerLoading = ctx.$("resume-picker-loading");
+  var pickerEmpty = ctx.$("resume-picker-empty");
+  var pickerList = ctx.$("resume-picker-list");
+  if (!pickerLoading || !pickerList) return;
+
+  pickerLoading.classList.add("hidden");
+
+  if (!sessions || sessions.length === 0) {
+    pickerEmpty.classList.remove("hidden");
+    pickerList.classList.add("hidden");
+    return;
+  }
+
+  pickerEmpty.classList.add("hidden");
+  pickerList.classList.remove("hidden");
+  pickerList.innerHTML = "";
+
+  for (var i = 0; i < sessions.length; i++) {
+    var s = sessions[i];
+    var item = document.createElement("div");
+    item.className = "cli-session-item";
+
+    var title = document.createElement("div");
+    title.className = "cli-session-title";
+    title.textContent = s.firstPrompt || "Untitled session";
+    item.appendChild(title);
+
+    var meta = document.createElement("div");
+    meta.className = "cli-session-meta";
+    if (s.lastActivity) {
+      var time = document.createElement("span");
+      time.textContent = relativeTime(s.lastActivity);
+      meta.appendChild(time);
+    }
+    if (s.model) {
+      var model = document.createElement("span");
+      model.className = "badge";
+      model.textContent = s.model;
+      meta.appendChild(model);
+    }
+    if (s.gitBranch) {
+      var branch = document.createElement("span");
+      branch.className = "badge";
+      branch.textContent = s.gitBranch;
+      meta.appendChild(branch);
+    }
+    item.appendChild(meta);
+
+    (function (sessionId) {
+      item.addEventListener("click", function () {
+        if (ctx.ws && ctx.connected) {
+          ctx.ws.send(JSON.stringify({ type: "resume_session", cliSessionId: sessionId }));
+        }
+        var modal = ctx.$("resume-modal");
+        if (modal) modal.classList.add("hidden");
+        closeSidebar();
+      });
+    })(s.sessionId);
+
+    pickerList.appendChild(item);
   }
 }
 

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -253,7 +253,20 @@ function createSessionManager(opts) {
     }
   }
 
-  function resumeSession(cliSessionId) {
+  function resumeSession(cliSessionId, opts) {
+    // If a session with this cliSessionId already exists, just switch to it
+    var existing = null;
+    sessions.forEach(function (s) {
+      if (s.cliSessionId === cliSessionId) existing = s;
+    });
+    if (existing) {
+      existing.lastActivity = Date.now();
+      switchSession(existing.localId);
+      return existing;
+    }
+
+    var cliHistory = (opts && opts.history) || [];
+    var title = (opts && opts.title) || "Resumed session";
     var localId = nextLocalId++;
     var session = {
       localId: localId,
@@ -266,9 +279,9 @@ function createSessionManager(opts) {
       pendingAskUser: {},
       allowedTools: {},
       isProcessing: false,
-      title: "Resumed session",
+      title: title,
       createdAt: Date.now(),
-      history: [],
+      history: cliHistory,
       messageUUIDs: [],
     };
     sessions.set(localId, session);


### PR DESCRIPTION
## Summary
- Replace text-input resume modal with a session picker that reads CLI session JSONL files from `~/.claude/projects/`
- Each session shows first prompt, relative time, model badge, and git branch badge
- Filter out sessions already open in relay (in-memory + persisted on disk)
- Load full CLI conversation history when resuming, with deduplication (same cliSessionId → switch instead of creating duplicate)
- "Resume CLI" button with terminal icon in sidebar

## Changes
- **New:** `lib/cli-sessions.js` — parses CLI JSONL files (metadata extraction + full history conversion)
- **Modified:** `lib/sessions.js` — `resumeSession(id, opts)` accepts history/title, deduplicates by cliSessionId
- **Modified:** `lib/project.js` — `resume_session` loads CLI history, new `list_cli_sessions` handler with relay session filtering
- **Modified:** `lib/public/index.html` — session picker modal UI, "Resume CLI" button
- **Modified:** `lib/public/modules/sidebar.js` — picker population logic, relative time display
- **Modified:** `lib/public/app.js` — `cli_session_list` WS handler
- **Modified:** `lib/public/css/overlays.css` — session picker styles

Closes #107

## Test plan
- [ ] Click "Resume CLI" → modal shows CLI sessions with first prompt, time, model, branch
- [ ] Click a session → history loads, conversation displayed
- [ ] Sessions already in relay sidebar are not shown in picker
- [ ] Resume same session twice → switches to existing instead of duplicating
- [ ] Project with no CLI sessions → "No CLI sessions found" message