### PR TITLE
fix: handle snake_case field names in context token calculation

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -836,8 +836,11 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
         var m = models[0];
         var mu = modelUsage[m];
         contextData.model = m;
-        if (mu.contextWindow) contextData.contextWindow = mu.contextWindow;
-        if (mu.maxOutputTokens) contextData.maxOutputTokens = mu.maxOutputTokens;
+        // Handle both camelCase and snake_case field names from SDK
+        var ctxWin = mu.contextWindow || mu.context_window;
+        var maxOut = mu.maxOutputTokens || mu.max_output_tokens;
+        if (ctxWin) contextData.contextWindow = ctxWin;
+        if (maxOut) contextData.maxOutputTokens = maxOut;
       }
     }
     updateContextPanel();

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -222,7 +222,7 @@ function createSDKBridge(opts) {
         cost: parsed.total_cost_usd,
         duration: parsed.duration_ms,
         usage: parsed.usage || null,
-        modelUsage: parsed.modelUsage || null,
+        modelUsage: parsed.modelUsage || parsed.model_usage || null,
         sessionId: parsed.session_id,
       });
       sendAndRecord(session, { type: "done", code: 0 });


### PR DESCRIPTION
## Problem

The `/context` command displays inaccurate token counts because the code only checks for camelCase field names (`modelUsage`, `contextWindow`, `maxOutputTokens`) but the Claude Agent SDK may send these fields using snake_case (`model_usage`, `context_window`, `max_output_tokens`).

When `modelUsage` is not found (because it was sent as `model_usage`), the `contextWindow` value remains at 0, causing the percentage calculation to be incorrect.

## Solution

Added fallback checks for snake_case field names, consistent with how token fields are already handled elsewhere in the codebase (e.g., `input_tokens || inputTokens`).

### Changes
1. `lib/sdk-bridge.js`: Check for both `parsed.modelUsage` and `parsed.model_usage`
2. `lib/public/app.js`: Check for both camelCase and snake_case variants of `contextWindow` and `maxOutputTokens`

## Testing

The fix follows the same pattern already used for token fields, which has been working correctly.

Fixes #137