### PR TITLE
feat: group consecutive tool calls with collapsed summary header

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -9,7 +9,7 @@ import { initQrCode } from './modules/qrcode.js';
 import { initFileBrowser, loadRootDirectory, refreshTree, handleFsList, handleFsRead, handleDirChanged, refreshIfOpen, handleFileChanged, handleFileHistory, handleGitDiff, handleFileAt, getPendingNavigate, closeFileViewer } from './modules/filebrowser.js';
 import { initTerminal, openTerminal, closeTerminal, resetTerminals, handleTermList, handleTermCreated, handleTermOutput, handleTermExited, handleTermClosed } from './modules/terminal.js';
 import { initTheme, getThemeColor, getComputedVar, onThemeChange } from './modules/theme.js';
-import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionResolved, markPermissionCancelled, renderPlanBanner, renderPlanCard, handleTodoWrite, handleTaskCreate, handleTaskUpdate, startThinking, appendThinking, stopThinking, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, addTurnMeta, enableMainInput, getTools, getPlanContent, setPlanContent, isPlanFilePath, getTodoTools, updateSubagentActivity, addSubagentToolEntry, markSubagentDone } from './modules/tools.js';
+import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionResolved, markPermissionCancelled, renderPlanBanner, renderPlanCard, handleTodoWrite, handleTaskCreate, handleTaskUpdate, startThinking, appendThinking, stopThinking, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, addTurnMeta, enableMainInput, getTools, getPlanContent, setPlanContent, isPlanFilePath, getTodoTools, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, closeToolGroup, removeToolFromGroup } from './modules/tools.js';
 
 // --- Base path for multi-project routing ---
   var slugMatch = location.pathname.match(/^\/p\/([a-z0-9_-]+)/);
@@ -1132,6 +1132,8 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
       if (currentFullText) {
         addCopyHandler(currentMsgEl, currentFullText);
       }
+      // Assistant text appeared, so break the current tool group
+      closeToolGroup();
     }
     currentMsgEl = null;
     currentFullText = "";
@@ -1309,6 +1311,9 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
                 target = messagesEl.querySelector('[data-uuid="' + nav.assistantUuid + '"]');
               }
               if (target) {
+                // Auto-expand parent tool group if collapsed
+                var parentGroup = target.closest(".tool-group");
+                if (parentGroup) parentGroup.classList.remove("collapsed");
                 target.scrollIntoView({ behavior: "smooth", block: "center" });
                 target.classList.add("message-blink");
                 setTimeout(function() { target.classList.remove("message-blink"); }, 2000);
@@ -1510,6 +1515,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
             if (askTool) {
               if (askTool.el) askTool.el.style.display = "none";
               askTool.done = true;
+              removeToolFromGroup(msg.id);
             }
             renderAskUserQuestion(msg.id, msg.input);
             startUrgentBlink();
@@ -1601,6 +1607,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
           setActivity(null);
           stopThinking();
           markAllToolsDone();
+          closeToolGroup();
           finalizeAssistantBlock();
           addTurnMeta(msg.cost, msg.duration);
           accumulateUsage(msg.cost, msg.usage);
@@ -1611,6 +1618,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
           setActivity(null);
           stopThinking();
           markAllToolsDone();
+          closeToolGroup();
           finalizeAssistantBlock();
           processing = false;
           setStatus("connected");

--- a/lib/public/css/messages.css
+++ b/lib/public/css/messages.css
@@ -889,6 +889,103 @@ pre.mermaid-error {
 }
 
 /* ==========================================================================
+   Tool Groups
+   ========================================================================== */
+
+.tool-group {
+  max-width: var(--content-width);
+  margin: 4px auto;
+  padding: 0 20px;
+}
+
+.tool-group-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 6px 12px;
+  user-select: none;
+  background: rgba(var(--overlay-rgb), 0.03);
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+
+.tool-group-header:hover {
+  background: rgba(var(--overlay-rgb), 0.06);
+}
+
+.tool-group-chevron {
+  color: var(--text-dimmer);
+  transition: transform 0.2s;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.tool-group-chevron .lucide {
+  width: 14px;
+  height: 14px;
+}
+
+.tool-group:not(.collapsed) .tool-group-chevron {
+  transform: rotate(90deg);
+}
+
+.tool-group-bullet {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  flex-shrink: 0;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+.tool-group.done .tool-group-bullet {
+  background: var(--text-dimmer);
+  animation: none;
+}
+
+.tool-group.done .tool-group-bullet.error {
+  background: var(--error);
+}
+
+.tool-group-label {
+  font-size: 13px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.tool-group.done .tool-group-label {
+  color: var(--text-dimmer);
+}
+
+.tool-group-status-icon {
+  flex-shrink: 0;
+  width: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tool-group-status-icon .lucide { width: 14px; height: 14px; }
+.tool-group-status-icon .icon-spin .lucide { width: 14px; height: 14px; color: var(--text-muted); }
+.tool-group-status-icon .check { color: var(--text-dimmer); }
+.tool-group-status-icon .err-icon { color: var(--error); }
+
+.tool-group.done .tool-group-status-icon .icon-spin { display: none; }
+
+/* Collapsed state: hide individual tool items */
+.tool-group.collapsed .tool-group-items {
+  display: none;
+}
+
+/* Inside a group, tool-items defer layout to the group container */
+.tool-group .tool-item {
+  max-width: none;
+  margin: 2px 0;
+  padding: 0;
+}
+
+/* ==========================================================================
    Plan Mode
    ========================================================================== */
 

--- a/lib/public/modules/tools.js
+++ b/lib/public/modules/tools.js
@@ -21,10 +21,109 @@ var tools = {};
 var currentThinking = null;
 var pendingPermissions = {};
 
+// --- Tool group tracking ---
+var currentToolGroup = null;
+var toolGroupCounter = 0;
+var toolGroups = {};
+
 // --- Tool helpers ---
 var PLAN_MODE_TOOLS = { EnterPlanMode: 1, ExitPlanMode: 1 };
 var TODO_TOOLS = { TodoWrite: 1, TaskCreate: 1, TaskUpdate: 1, TaskList: 1, TaskGet: 1 };
 var HIDDEN_RESULT_TOOLS = { EnterPlanMode: 1, ExitPlanMode: 1, TaskCreate: 1, TaskUpdate: 1, TaskList: 1, TaskGet: 1, TodoWrite: 1 };
+
+// --- Tool group helpers ---
+function closeToolGroup() {
+  if (currentToolGroup) {
+    currentToolGroup.closed = true;
+  }
+  currentToolGroup = null;
+}
+
+function findToolGroup(groupId) {
+  return toolGroups[groupId] || null;
+}
+
+function toolGroupSummary(group) {
+  var names = group.toolNames;
+  var count = names.length;
+  var allDone = group.doneCount >= count;
+
+  // Count by tool name
+  var counts = {};
+  for (var i = 0; i < names.length; i++) {
+    counts[names[i]] = (counts[names[i]] || 0) + 1;
+  }
+  var uniqueNames = Object.keys(counts);
+
+  if (uniqueNames.length === 1) {
+    var name = uniqueNames[0];
+    var n = counts[name];
+    if (allDone) {
+      switch (name) {
+        case "Read": return "Read " + n + " file" + (n > 1 ? "s" : "");
+        case "Edit": return "Edited " + n + " file" + (n > 1 ? "s" : "");
+        case "Write": return "Wrote " + n + " file" + (n > 1 ? "s" : "");
+        case "Bash": return "Ran " + n + " command" + (n > 1 ? "s" : "");
+        case "Grep": return "Searched " + n + " pattern" + (n > 1 ? "s" : "");
+        case "Glob": return "Found " + n + " pattern" + (n > 1 ? "s" : "");
+        case "Task": return "Ran " + n + " task" + (n > 1 ? "s" : "");
+        case "WebSearch": return "Searched " + n + " quer" + (n > 1 ? "ies" : "y");
+        case "WebFetch": return "Fetched " + n + " URL" + (n > 1 ? "s" : "");
+        default: return "Ran " + n + " tool" + (n > 1 ? "s" : "");
+      }
+    }
+    switch (name) {
+      case "Read": return "Reading " + n + " file" + (n > 1 ? "s" : "") + "...";
+      case "Edit": return "Editing " + n + " file" + (n > 1 ? "s" : "") + "...";
+      case "Write": return "Writing " + n + " file" + (n > 1 ? "s" : "") + "...";
+      case "Bash": return "Running " + n + " command" + (n > 1 ? "s" : "") + "...";
+      case "Grep": return "Searching " + n + " pattern" + (n > 1 ? "s" : "") + "...";
+      case "Glob": return "Finding " + n + " pattern" + (n > 1 ? "s" : "") + "...";
+      case "Task": return "Running " + n + " task" + (n > 1 ? "s" : "") + "...";
+      case "WebSearch": return "Searching " + n + " quer" + (n > 1 ? "ies" : "y") + "...";
+      case "WebFetch": return "Fetching " + n + " URL" + (n > 1 ? "s" : "") + "...";
+      default: return "Running " + n + " tool" + (n > 1 ? "s" : "") + "...";
+    }
+  }
+
+  // Mixed tools
+  if (allDone) return "Ran " + count + " tools";
+  return "Running " + count + " tools...";
+}
+
+function updateToolGroupHeader(group) {
+  if (!group || !group.el) return;
+  var label = group.el.querySelector(".tool-group-label");
+  if (label) label.textContent = toolGroupSummary(group);
+
+  var allDone = group.doneCount >= group.toolCount;
+  var statusIcon = group.el.querySelector(".tool-group-status-icon");
+  var bullet = group.el.querySelector(".tool-group-bullet");
+
+  if (allDone) {
+    group.el.classList.add("done");
+    if (group.errorCount > 0) {
+      statusIcon.innerHTML = '<span class="err-icon">' + iconHtml("alert-triangle") + '</span>';
+      if (bullet) bullet.classList.add("error");
+    } else {
+      statusIcon.innerHTML = '<span class="check">' + iconHtml("check") + '</span>';
+    }
+    refreshIcons();
+  }
+
+  // Show group header only when 2+ visible tools
+  var header = group.el.querySelector(".tool-group-header");
+  if (group.toolCount >= 2) {
+    header.style.display = "";
+    // When 2+ tools, ensure collapsed by default (unless user already toggled)
+    if (!group.userToggled && !group.el.classList.contains("expanded-by-user")) {
+      group.el.classList.add("collapsed");
+    }
+  } else {
+    header.style.display = "none";
+    group.el.classList.remove("collapsed");
+  }
+}
 
 function isPlanFile(filePath) {
   return filePath && filePath.indexOf(".claude/plans/") !== -1;
@@ -73,6 +172,7 @@ function shortPath(p) {
 export function renderAskUserQuestion(toolId, input) {
   ctx.finalizeAssistantBlock();
   stopThinking();
+  closeToolGroup();
 
   var questions = input.questions || [];
   if (questions.length === 0) return;
@@ -261,6 +361,7 @@ export function renderPermissionRequest(requestId, toolName, toolInput, decision
   if (pendingPermissions[requestId]) return;
   ctx.finalizeAssistantBlock();
   stopThinking();
+  closeToolGroup();
 
   // ExitPlanMode: render as plan confirmation instead of generic permission
   if (toolName === "ExitPlanMode") {
@@ -469,6 +570,7 @@ export function markPermissionCancelled(requestId) {
 export function renderPlanBanner(type) {
   ctx.finalizeAssistantBlock();
   stopThinking();
+  closeToolGroup();
 
   var el = document.createElement("div");
   el.className = "plan-banner";
@@ -497,6 +599,7 @@ export function renderPlanBanner(type) {
 
 export function renderPlanCard(content) {
   ctx.finalizeAssistantBlock();
+  closeToolGroup();
 
   var el = document.createElement("div");
   el.className = "plan-card";
@@ -785,6 +888,40 @@ export function createToolItem(id, name) {
   ctx.finalizeAssistantBlock();
   stopThinking();
 
+  // Group management: create new group or reuse existing open group
+  if (!currentToolGroup || currentToolGroup.closed) {
+    toolGroupCounter++;
+    var groupEl = document.createElement("div");
+    groupEl.className = "tool-group";
+    groupEl.dataset.groupId = "g" + toolGroupCounter;
+    groupEl.innerHTML =
+      '<div class="tool-group-header" style="display:none">' +
+      '<span class="tool-group-chevron">' + iconHtml("chevron-right") + '</span>' +
+      '<span class="tool-group-bullet"></span>' +
+      '<span class="tool-group-label">Running...</span>' +
+      '<span class="tool-group-status-icon">' + iconHtml("loader", "icon-spin") + '</span>' +
+      '</div>' +
+      '<div class="tool-group-items"></div>';
+
+    groupEl.querySelector(".tool-group-header").addEventListener("click", function () {
+      groupEl.classList.toggle("collapsed");
+    });
+
+    ctx.addToMessages(groupEl);
+    refreshIcons();
+
+    currentToolGroup = {
+      el: groupEl,
+      id: "g" + toolGroupCounter,
+      toolNames: [],
+      toolCount: 0,
+      doneCount: 0,
+      errorCount: 0,
+      closed: false,
+    };
+    toolGroups[currentToolGroup.id] = currentToolGroup;
+  }
+
   var el = document.createElement("div");
   el.className = "tool-item";
   el.dataset.toolId = id;
@@ -803,11 +940,16 @@ export function createToolItem(id, name) {
 
   el.querySelector(".tool-name").textContent = name;
 
-  ctx.addToMessages(el);
+  // Append to group instead of messages directly
+  currentToolGroup.el.querySelector(".tool-group-items").appendChild(el);
+  currentToolGroup.toolNames.push(name);
+  currentToolGroup.toolCount++;
+  updateToolGroupHeader(currentToolGroup);
+
   refreshIcons();
   ctx.scrollToBottom();
 
-  tools[id] = { el: el, name: name, input: null, done: false };
+  tools[id] = { el: el, name: name, input: null, done: false, groupId: currentToolGroup.id };
   ctx.setActivity("Running " + name + "...");
 }
 
@@ -1095,6 +1237,16 @@ export function markToolDone(id, isError) {
     icon.innerHTML = '<span class="check">' + iconHtml("check") + '</span>';
   }
   refreshIcons();
+
+  // Update group state
+  if (tool.groupId) {
+    var group = findToolGroup(tool.groupId);
+    if (group) {
+      group.doneCount++;
+      if (isError) group.errorCount++;
+      updateToolGroupHeader(group);
+    }
+  }
 }
 
 export function markAllToolsDone() {
@@ -1169,6 +1321,7 @@ export function markSubagentDone(parentToolId) {
 }
 
 export function addTurnMeta(cost, duration) {
+  closeToolGroup();
   var div = document.createElement("div");
   div.className = "turn-meta";
   div.dataset.turn = ctx.turnCounter;
@@ -1180,6 +1333,22 @@ export function addTurnMeta(cost, duration) {
     ctx.addToMessages(div);
     ctx.scrollToBottom();
   }
+}
+
+// --- Tool group exports ---
+export { closeToolGroup };
+
+export function removeToolFromGroup(toolId) {
+  var tool = tools[toolId];
+  if (!tool || !tool.groupId) return;
+  var group = findToolGroup(tool.groupId);
+  if (!group) return;
+  group.toolCount--;
+  // Remove tool name from the names array (remove first occurrence)
+  var idx = group.toolNames.indexOf(tool.name);
+  if (idx !== -1) group.toolNames.splice(idx, 1);
+  if (tool.done) group.doneCount--;
+  updateToolGroupHeader(group);
 }
 
 // Expose state getters and reset
@@ -1199,6 +1368,9 @@ export function saveToolState() {
     todoWidgetEl: todoWidgetEl,
     inPlanMode: inPlanMode,
     planContent: planContent,
+    currentToolGroup: currentToolGroup,
+    toolGroupCounter: toolGroupCounter,
+    toolGroups: toolGroups,
   };
 }
 
@@ -1208,6 +1380,9 @@ export function restoreToolState(saved) {
   todoWidgetEl = saved.todoWidgetEl;
   inPlanMode = saved.inPlanMode;
   planContent = saved.planContent;
+  currentToolGroup = saved.currentToolGroup;
+  toolGroupCounter = saved.toolGroupCounter;
+  toolGroups = saved.toolGroups;
   if (todoWidgetEl) {
     setupTodoObserver();
   }
@@ -1223,6 +1398,9 @@ export function resetToolState() {
   todoWidgetVisible = true;
   if (todoObserver) { todoObserver.disconnect(); todoObserver = null; }
   pendingPermissions = {};
+  currentToolGroup = null;
+  toolGroupCounter = 0;
+  toolGroups = {};
   var stickyEl = document.getElementById("todo-sticky");
   if (stickyEl) { stickyEl.classList.add("hidden"); stickyEl.innerHTML = ""; }
 }


### PR DESCRIPTION
## Summary
- Consecutive tool calls are grouped under a collapsible summary header for a cleaner UI
- Reduces visual noise when Claude runs many tools in sequence

## Test plan
- [x] Multiple consecutive tool calls render as a collapsed group
- [x] Clicking the header expands/collapses the group
- [x] Single tool calls render normally without grouping