### PR TITLE
Redesign sidebar with inline projects, pinned sections, and UI polish

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -22,7 +22,8 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   var inputEl = $("input");
   var sendBtn = $("send-btn");
   var statusDot = $("status-dot");
-  var projectNameEl = $("project-name");
+  var headerTitleEl = $("header-title");
+  var headerRenameBtn = $("header-rename-btn");
   var slashMenu = $("slash-menu");
   var sidebar = $("sidebar");
   var sidebarOverlay = $("sidebar-overlay");
@@ -37,25 +38,21 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
   var connectVerbEl = $("connect-verb");
   var connectStatusEl = $("connect-status");
 
-  // --- Project Switcher ---
-  var projectSwitcher = $("project-switcher");
-  var projectSwitcherBtn = $("project-switcher-btn");
-  var projectDropdown = $("project-dropdown");
-  var projectDropdownList = $("project-dropdown-list");
-  var projectSwitcherName = $("project-switcher-name");
-  var projectSwitcherCount = $("project-switcher-count");
+  // --- Project List ---
+  var projectListSection = $("project-list-section");
+  var projectListEl = $("project-list");
+  var projectListAddBtn = $("project-list-add");
   var projectHint = $("project-hint");
   var projectHintDismiss = $("project-hint-dismiss");
   var cachedProjects = [];
   var cachedProjectCount = 0;
   var currentSlug = slugMatch ? slugMatch[1] : null;
 
-  function updateProjectSwitcher(msg) {
+  function updateProjectList(msg) {
     if (typeof msg.projectCount === "number") cachedProjectCount = msg.projectCount;
     if (msg.projects) cachedProjects = msg.projects;
     var count = cachedProjectCount || 0;
-    projectSwitcherName.textContent = projectName || "Project";
-    projectSwitcherCount.textContent = count ? count + (count === 1 ? " project" : " projects") : "";
+    renderProjectList();
     if (count === 1 && projectHint) {
       try {
         if (!localStorage.getItem("claude-relay-project-hint-dismissed")) {
@@ -67,14 +64,15 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     }
   }
 
-  function renderProjectDropdown() {
-    projectDropdownList.innerHTML = "";
+  function renderProjectList() {
+    if (!projectListEl) return;
+    projectListEl.innerHTML = "";
     for (var i = 0; i < cachedProjects.length; i++) {
       var p = cachedProjects[i];
       var isCurrent = p.slug === currentSlug;
       var displayName = p.title || p.project;
       var item = document.createElement("a");
-      item.className = "project-dropdown-item" + (isCurrent ? " current" : "");
+      item.className = "project-list-item" + (isCurrent ? " current" : "");
       item.href = "/p/" + p.slug + "/";
 
       var indicator = document.createElement("span");
@@ -102,51 +100,19 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
       });
       item.appendChild(removeBtn);
 
-      projectDropdownList.appendChild(item);
-    }
-
-    // Add project button logic
-    var addBtn = document.getElementById("project-dropdown-add");
-    if (addBtn) {
-      addBtn.onclick = function () {
-        closeProjectDropdown();
-        openAddProjectModal();
-      };
+      projectListEl.appendChild(item);
     }
     refreshIcons();
   }
 
-  function toggleProjectDropdown() {
-    if (projectDropdown.classList.contains("hidden")) {
-      renderProjectDropdown();
-      projectDropdown.classList.remove("hidden");
-      projectSwitcher.classList.add("open");
-    } else {
-      closeProjectDropdown();
-    }
-  }
-
-  function closeProjectDropdown() {
-    projectDropdown.classList.add("hidden");
-    projectSwitcher.classList.remove("open");
-  }
-
-  if (projectSwitcherBtn) {
-    projectSwitcherBtn.addEventListener("click", function (e) {
-      e.stopPropagation();
-      toggleProjectDropdown();
+  if (projectListAddBtn) {
+    projectListAddBtn.addEventListener("click", function () {
+      openAddProjectModal();
     });
   }
 
-  document.addEventListener("click", function (e) {
-    if (projectSwitcher && !projectSwitcher.contains(e.target)) {
-      closeProjectDropdown();
-    }
-  });
-
   document.addEventListener("keydown", function (e) {
     if (e.key === "Escape") {
-      closeProjectDropdown();
       closeImageModal();
     }
   });
@@ -225,6 +191,45 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
 
   // builtinCommands -> modules/input.js
 
+  // --- Header session rename ---
+  if (headerRenameBtn) {
+    headerRenameBtn.addEventListener("click", function () {
+      if (!activeSessionId) return;
+      var currentText = headerTitleEl.textContent;
+      var input = document.createElement("input");
+      input.type = "text";
+      input.className = "header-rename-input";
+      input.value = currentText;
+      headerTitleEl.style.display = "none";
+      headerRenameBtn.style.display = "none";
+      headerTitleEl.parentNode.insertBefore(input, headerTitleEl.nextSibling);
+      input.focus();
+      input.select();
+
+      function commit() {
+        var newTitle = input.value.trim();
+        if (newTitle && newTitle !== currentText && ws && ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: "rename_session", id: activeSessionId, title: newTitle }));
+          headerTitleEl.textContent = newTitle;
+        }
+        input.remove();
+        headerTitleEl.style.display = "";
+        headerRenameBtn.style.display = "";
+      }
+
+      input.addEventListener("keydown", function (e) {
+        if (e.key === "Enter") { e.preventDefault(); commit(); }
+        if (e.key === "Escape") {
+          e.preventDefault();
+          input.remove();
+          headerTitleEl.style.display = "";
+          headerRenameBtn.style.display = "";
+        }
+      });
+      input.addEventListener("blur", commit);
+    });
+  }
+
   // --- Confirm modal ---
   var confirmModal = $("confirm-modal");
   var confirmText = $("confirm-text");
@@ -293,6 +298,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
     hamburgerBtn: hamburgerBtn,
     newSessionBtn: newSessionBtn,
     resumeSessionBtn: resumeSessionBtn,
+    headerTitleEl: headerTitleEl,
     showConfirm: showConfirm,
     onFilesTabOpen: function () { loadRootDirectory(); },
   });
@@ -1325,7 +1331,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
         case "info":
           projectName = msg.project || msg.cwd;
           if (msg.slug) currentSlug = msg.slug;
-          projectNameEl.textContent = projectName;
+          headerTitleEl.textContent = projectName;
           updatePageTitle();
           if (msg.version) {
             var vEl = $("footer-version");
@@ -1340,7 +1346,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
             var spBanner = $("skip-perms-banner");
             if (spBanner) spBanner.classList.remove("hidden");
           }
-          updateProjectSwitcher(msg);
+          updateProjectList(msg);
           break;
 
         case "update_available":
@@ -1726,8 +1732,7 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
           break;
 
         case "projects_updated":
-          updateProjectSwitcher(msg);
-          renderProjectDropdown();
+          updateProjectList(msg);
           break;
       }
   }
@@ -1903,7 +1908,6 @@ import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUs
 
   // --- Remove project ---
   function confirmRemoveProject(slug, name) {
-    closeProjectDropdown();
     showConfirm("Remove project \"" + name + "\"?", function () {
       if (ws && ws.readyState === 1) {
         ws.send(JSON.stringify({ type: "remove_project", slug: slug }));

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -32,50 +32,12 @@
 .sidebar-panel { flex: 1; overflow-y: auto; min-height: 0; }
 .sidebar-panel.hidden { display: none; }
 
-/* --- File panel header --- */
-#file-panel-header {
-  display: flex;
-  align-items: center;
-  padding: 4px 8px;
+/* --- File browser header --- */
+#sessions-header-content.hidden,
+#files-header-content.hidden {
+  display: none;
 }
 
-#file-panel-back {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: 10px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  font-family: inherit;
-  font-size: 14px;
-  font-weight: 400;
-  cursor: pointer;
-  flex: 1;
-  transition: background 0.15s, color 0.15s;
-}
-
-#file-panel-back .lucide { width: 16px; height: 16px; flex-shrink: 0; }
-#file-panel-back:hover { background: var(--sidebar-hover); color: var(--text); }
-
-#file-panel-refresh {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: background 0.15s, color 0.15s, transform 0.3s;
-}
-
-#file-panel-refresh .lucide { width: 14px; height: 14px; }
-#file-panel-refresh:hover { background: var(--sidebar-hover); color: var(--text); }
 #file-panel-refresh.spinning { animation: spin-once 0.5s ease; }
 @keyframes spin-once { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
 
@@ -536,7 +498,6 @@
 
 #terminal-body {
   flex: 1;
-  background: #1a1a1a;
   min-height: 0;
   overflow: hidden;
   position: relative;
@@ -545,7 +506,7 @@
 .terminal-tab-body {
   position: absolute;
   inset: 0;
-  padding: 4px;
+  padding: 4px 0 0 4px;
 }
 
 .terminal-tab-body .xterm {

--- a/lib/public/css/menus.css
+++ b/lib/public/css/menus.css
@@ -18,13 +18,48 @@
   min-width: 0;
 }
 
-.project-name {
+.header-title {
   font-weight: 600;
   font-size: 15px;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+#header-rename-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: var(--text-dimmer);
+  cursor: pointer;
+  border-radius: 6px;
+  flex-shrink: 0;
+  padding: 0;
+  margin-left: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+#header-left:hover #header-rename-btn { display: flex; }
+#header-rename-btn:hover { color: var(--text); background: rgba(var(--overlay-rgb), 0.06); }
+#header-rename-btn .lucide { width: 13px; height: 13px; }
+
+.header-rename-input {
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--text);
+  background: var(--input-bg);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-family: inherit;
+  outline: none;
+  min-width: 0;
+  flex: 1;
 }
 
 .status {

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -49,148 +49,86 @@
   display: flex;
   flex-direction: column;
   padding: 4px 8px;
+  flex-shrink: 0;
 }
 
-/* --- Project Switcher --- */
-#project-switcher {
-  position: relative;
+/* --- Project List --- */
+#project-list-section {
   padding: 0 4px;
-  margin-bottom: 12px;
+  margin-bottom: 4px;
   border-bottom: 1px solid var(--border-subtle);
 }
 
-#project-switcher-btn {
+#project-list-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
-  padding: 10px 8px;
+  padding: 8px 8px 6px;
+}
+
+.project-list-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dimmer);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+#project-list-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
   border: none;
   background: transparent;
-  color: var(--text);
-  font-size: 14px;
-  font-weight: 600;
-  font-family: inherit;
+  color: var(--text-dimmer);
   cursor: pointer;
-  border-radius: 8px;
+  border-radius: 6px;
   transition: background 0.15s, color 0.15s;
 }
 
-#project-switcher-btn:hover {
+#project-list-add:hover {
   background: var(--sidebar-hover);
   color: var(--text);
 }
 
-#project-switcher-label {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  min-width: 0;
-  overflow: hidden;
-}
-
-.ps-title {
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-dimmer);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.ps-current {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-#project-switcher-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.ps-chevron {
+#project-list-add .lucide {
   width: 14px;
   height: 14px;
-  transition: transform 0.2s ease;
-  flex-shrink: 0;
-  color: var(--text-dimmer);
 }
 
-#project-switcher.open .ps-chevron {
-  transform: rotate(180deg);
-}
-
-.ps-count {
-  font-size: 11px;
-  font-weight: 700;
-  background: var(--accent-15);
-  color: var(--accent);
-  border-radius: 10px;
-  padding: 2px 8px;
-  margin-left: 4px;
-}
-
-.ps-count:empty {
-  display: none;
-}
-
-/* --- Project Dropdown --- */
-#project-dropdown {
-  position: absolute;
-  top: calc(100% + 2px);
-  left: 4px;
-  right: 4px;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 4px 0;
-  box-shadow: 0 4px 16px rgba(var(--shadow-rgb), 0.4);
-  z-index: 120;
-  max-height: 320px;
+#project-list {
+  padding: 0 0 6px;
   overflow-y: auto;
+  max-height: 200px;
 }
 
-#project-dropdown.hidden {
-  display: none;
-}
-
-.project-dropdown-header {
-  padding: 8px 12px 6px;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-dimmer);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.project-dropdown-item {
+.project-list-item {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 12px;
+  padding: 7px 8px 7px 10px;
   cursor: pointer;
   font-size: 13px;
   color: var(--text-secondary);
   text-decoration: none;
   transition: background 0.15s;
   border-left: 3px solid transparent;
+  border-radius: 0 6px 6px 0;
 }
 
-.project-dropdown-item:hover {
+.project-list-item:hover {
   background: rgba(var(--overlay-rgb), 0.05);
 }
 
-.project-dropdown-item.current {
+.project-list-item.current {
   background: var(--accent-8);
   border-left-color: var(--accent);
   color: var(--text);
 }
 
-.project-dropdown-item.current .pd-name {
+.project-list-item.current .pd-name {
   font-weight: 600;
 }
 
@@ -239,38 +177,8 @@
 }
 
 .pd-remove .lucide { width: 14px; height: 14px; }
-.project-dropdown-item:hover .pd-remove { display: block; }
+.project-list-item:hover .pd-remove { display: block; }
 .pd-remove:hover { color: var(--error); background: rgba(var(--overlay-rgb), 0.06); }
-
-.project-dropdown-footer {
-  border-top: 1px solid var(--border-subtle);
-  padding: 4px 0;
-}
-
-.project-dropdown-footer button {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 12px;
-  font-size: 12px;
-  font-family: inherit;
-  color: var(--text-muted);
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-.project-dropdown-footer button:hover {
-  background: rgba(var(--overlay-rgb), 0.05);
-  color: var(--text-secondary);
-}
-
-.project-dropdown-footer .lucide {
-  width: 13px;
-  height: 13px;
-}
 
 /* --- Project Hint (single-project onboarding) --- */
 #project-hint {
@@ -351,11 +259,12 @@
   height: 18px;
 }
 
-.session-list-header {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 24px 12px 4px 20px;
+/* --- Sidebar section headers --- */
+.sidebar-section-header {
+  padding: 8px 12px 4px;
+}
+
+.sidebar-section-title {
   font-size: 11px;
   font-weight: 600;
   color: var(--text-dimmer);
@@ -363,12 +272,42 @@
   letter-spacing: 0.5px;
 }
 
-#search-session-btn {
+/* --- Tools section --- */
+#sidebar-tools {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 4px;
+}
+
+/* --- Sessions header (pinned above scroll) --- */
+#sidebar-sessions-header {
+  flex-shrink: 0;
+}
+
+.session-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 8px 4px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dimmer);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.session-list-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.session-list-header-actions button {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border-radius: 6px;
   border: none;
   background: transparent;
@@ -378,12 +317,13 @@
   transition: color 0.15s, background 0.15s;
 }
 
-#search-session-btn .lucide { width: 14px; height: 14px; }
-#search-session-btn:hover { color: var(--text); background: var(--sidebar-hover); }
+.session-list-header-actions button .lucide { width: 14px; height: 14px; }
+.session-list-header-actions button:hover { color: var(--text); background: var(--sidebar-hover); }
 
 /* --- Session search --- */
 #session-search {
   padding: 0 12px 8px;
+  position: relative;
 }
 
 #session-search.hidden {
@@ -392,7 +332,7 @@
 
 #session-search-input {
   width: 100%;
-  padding: 7px 10px;
+  padding: 7px 28px 7px 10px;
   border-radius: 8px;
   border: 1px solid var(--border);
   background: var(--input-bg);
@@ -401,6 +341,7 @@
   font-family: inherit;
   outline: none;
   transition: border-color 0.15s;
+  box-sizing: border-box;
 }
 
 #session-search-input:focus {
@@ -410,6 +351,28 @@
 #session-search-input::placeholder {
   color: var(--text-dimmer);
 }
+
+#session-search-clear {
+  position: absolute;
+  right: 16px;
+  top: calc(50% - 4px);
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: transparent;
+  color: var(--text-dimmer);
+  cursor: pointer;
+  padding: 0;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+#session-search-clear .lucide { width: 14px; height: 14px; }
+#session-search-clear:hover { color: var(--text); background: var(--sidebar-hover); }
 
 #search-session-btn.active {
   color: var(--accent);

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -15,6 +15,9 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400;14..32,500;14..32,600&family=Styrene+A+Web:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/file-icons-js@1/css/style.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/css/xterm.min.css">
+<script>
+(function(){try{var k="claude-relay-theme-vars",v=localStorage.getItem(k);if(!v)return;var o=JSON.parse(v),r=document.documentElement,p;for(p in o)r.style.setProperty(p,o[p]);var vt=localStorage.getItem(k.replace("-vars","-variant"));if(vt==="light"){r.classList.add("light-theme");r.classList.remove("dark-theme")}else{r.classList.add("dark-theme");r.classList.remove("light-theme")}var m=document.querySelector('meta[name="theme-color"]');if(m&&o["--bg"])m.setAttribute("content",o["--bg"])}catch(e){}})();
+</script>
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -27,51 +30,56 @@
       <button id="sidebar-toggle-btn" title="Close sidebar"><i data-lucide="panel-left-close"></i></button>
     </div>
     <nav id="sidebar-nav">
-      <div id="project-switcher">
-        <button id="project-switcher-btn" type="button">
-          <div id="project-switcher-label">
-            <span class="ps-title">Projects</span>
-            <div class="ps-current">
-              <span id="project-switcher-name"></span>
-              <span id="project-switcher-count" class="ps-count"></span>
-            </div>
-          </div>
-          <i data-lucide="chevron-down" class="ps-chevron"></i>
-        </button>
-        <div id="project-dropdown" class="hidden">
-          <div class="project-dropdown-header">Projects</div>
-          <div id="project-dropdown-list"></div>
-          <div class="project-dropdown-footer">
-            <button id="project-dropdown-add" type="button"><i data-lucide="plus"></i> <span>Add project</span></button>
-          </div>
+      <div id="project-list-section">
+        <div id="project-list-header">
+          <span class="project-list-title">Projects</span>
+          <button id="project-list-add" type="button" title="Add project"><i data-lucide="plus"></i></button>
         </div>
+        <div id="project-list"></div>
       </div>
       <div id="project-hint" class="hidden">
         <span class="project-hint-text">Run <code>npx claude-relay</code> in other directories to add more projects.</span>
         <button id="project-hint-dismiss" type="button" aria-label="Dismiss"><i data-lucide="x"></i></button>
       </div>
     </nav>
-    <div id="sidebar-panel-sessions" class="sidebar-panel">
+    <div id="sidebar-tools">
+      <div class="sidebar-section-header">
+        <span class="sidebar-section-title">Tools</span>
+      </div>
       <div id="session-actions">
-        <button id="new-session-btn"><i data-lucide="plus"></i> <span>New session</span></button>
         <button id="resume-session-btn" title="Resume a CLI session"><i data-lucide="terminal"></i> <span>Resume CLI</span></button>
         <button id="file-browser-btn"><i data-lucide="folder-tree"></i> <span>File browser</span></button>
         <button id="terminal-sidebar-btn"><i data-lucide="square-terminal"></i> <span>Terminal</span></button>
       </div>
-      <div class="session-list-header">
-        <span>Sessions</span>
-        <button id="search-session-btn" type="button" title="Search sessions"><i data-lucide="search"></i></button>
+    </div>
+    <div id="sidebar-sessions-header">
+      <div id="sessions-header-content">
+        <div class="session-list-header">
+          <span>Sessions</span>
+          <div class="session-list-header-actions">
+            <button id="new-session-btn" type="button" title="New session"><i data-lucide="plus"></i></button>
+            <button id="search-session-btn" type="button" title="Search sessions"><i data-lucide="search"></i></button>
+          </div>
+        </div>
+        <div id="session-search" class="hidden">
+          <input id="session-search-input" type="text" placeholder="Search sessions..." autocomplete="off" spellcheck="false" />
+          <button id="session-search-clear" type="button" aria-label="Clear search"><i data-lucide="x"></i></button>
+        </div>
       </div>
-      <div id="session-search" class="hidden">
-        <input id="session-search-input" type="text" placeholder="Search sessions..." autocomplete="off" spellcheck="false" />
+      <div id="files-header-content" class="hidden">
+        <div class="session-list-header">
+          <span>File Browser</span>
+          <div class="session-list-header-actions">
+            <button id="file-panel-refresh" type="button" title="Refresh file tree"><i data-lucide="refresh-cw"></i></button>
+            <button id="file-panel-close" type="button" title="Close file browser"><i data-lucide="x"></i></button>
+          </div>
+        </div>
       </div>
+    </div>
+    <div id="sidebar-panel-sessions" class="sidebar-panel">
       <div id="session-list"></div>
     </div>
     <div id="sidebar-panel-files" class="sidebar-panel hidden">
-      <div id="file-panel-header">
-        <button id="file-panel-back" type="button"><i data-lucide="arrow-left"></i> <span>Sessions</span></button>
-        <button id="file-panel-refresh" type="button" title="Refresh file tree"><i data-lucide="refresh-cw"></i></button>
-      </div>
       <div id="file-tree"></div>
     </div>
     <div id="sidebar-footer">
@@ -81,7 +89,7 @@
       </button>
       <div id="sidebar-footer-menu" class="hidden">
         <a class="sidebar-menu-item" href="https://github.com/chadbyte/claude-relay" target="_blank" rel="noopener">
-          <i data-lucide="github"></i> <span>GitHub</span>
+          <i data-lucide="star"></i> <span>Star on GitHub</span>
         </a>
         <button class="sidebar-menu-item" id="footer-theme">
           <i data-lucide="palette"></i> <span>Theme</span>
@@ -114,7 +122,8 @@
       <div id="header-left">
         <button id="sidebar-expand-btn" title="Open sidebar"><i data-lucide="panel-left-open"></i></button>
         <button id="hamburger-btn" aria-label="Toggle sidebar"><i data-lucide="menu"></i></button>
-        <span class="project-name" id="project-name">Connecting...</span>
+        <span class="header-title" id="header-title">Connecting...</span>
+        <button id="header-rename-btn" type="button" title="Rename session"><i data-lucide="pencil"></i></button>
       </div>
       <div class="status">
         <div id="debug-menu-wrap" class="hidden">
@@ -297,7 +306,7 @@
       <div id="terminal-tabs" class="terminal-tabs"></div>
       <button class="terminal-new-tab-btn" id="terminal-new-tab" title="New tab"><i data-lucide="plus"></i></button>
       <div class="terminal-header-actions">
-        <button class="file-viewer-btn" id="terminal-close" title="Hide panel"><i data-lucide="chevron-down"></i></button>
+        <button class="file-viewer-btn" id="terminal-close" title="Hide panel"><i data-lucide="chevron-up"></i></button>
       </div>
     </div>
     <div id="terminal-toolbar" class="hidden">

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -1,6 +1,6 @@
 import { iconHtml, refreshIcons } from './icons.js';
 import { escapeHtml, copyToClipboard } from './utils.js';
-import { renderMarkdown, highlightCodeBlocks } from './markdown.js';
+import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks } from './markdown.js';
 import { closeSidebar } from './sidebar.js';
 import { renderUnifiedDiff, renderSplitDiff } from './diff.js';
 
@@ -123,6 +123,7 @@ function renderBody() {
       }
     }
     highlightCodeBlocks(bodyEl);
+    renderMermaidBlocks(bodyEl);
     renderBtn.classList.add("active");
     renderBtn.title = "Show raw";
   } else {

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -240,6 +240,9 @@ export function updatePageTitle() {
   var sessionTitle = "";
   var activeItem = ctx.sessionListEl.querySelector(".session-item.active .session-item-text");
   if (activeItem) sessionTitle = activeItem.textContent;
+  if (ctx.headerTitleEl) {
+    ctx.headerTitleEl.textContent = sessionTitle || ctx.projectName || "Claude Relay";
+  }
   if (ctx.projectName && sessionTitle) {
     document.title = sessionTitle + " - " + ctx.projectName;
   } else if (ctx.projectName) {
@@ -298,6 +301,7 @@ export function initSidebar(_ctx) {
   var searchBtn = ctx.$("search-session-btn");
   var searchBox = ctx.$("session-search");
   var searchInput = ctx.$("session-search-input");
+  var searchClear = ctx.$("session-search-clear");
 
   function openSearch() {
     searchBox.classList.remove("hidden");
@@ -325,6 +329,12 @@ export function initSidebar(_ctx) {
       closeSearch();
     }
   });
+
+  if (searchClear) {
+    searchClear.addEventListener("click", function () {
+      closeSearch();
+    });
+  }
 
   searchInput.addEventListener("input", function () {
     searchQuery = searchInput.value.trim();
@@ -379,24 +389,30 @@ export function initSidebar(_ctx) {
   var fileBrowserBtn = ctx.$("file-browser-btn");
   var sessionsPanel = ctx.$("sidebar-panel-sessions");
   var filesPanel = ctx.$("sidebar-panel-files");
-  var filePanelBack = ctx.$("file-panel-back");
+  var sessionsHeaderContent = ctx.$("sessions-header-content");
+  var filesHeaderContent = ctx.$("files-header-content");
+  var filePanelClose = ctx.$("file-panel-close");
 
   function showFilesPanel() {
     sessionsPanel.classList.add("hidden");
     filesPanel.classList.remove("hidden");
+    if (sessionsHeaderContent) sessionsHeaderContent.classList.add("hidden");
+    if (filesHeaderContent) filesHeaderContent.classList.remove("hidden");
     if (ctx.onFilesTabOpen) ctx.onFilesTabOpen();
   }
 
   function showSessionsPanel() {
     filesPanel.classList.add("hidden");
     sessionsPanel.classList.remove("hidden");
+    if (filesHeaderContent) filesHeaderContent.classList.add("hidden");
+    if (sessionsHeaderContent) sessionsHeaderContent.classList.remove("hidden");
   }
 
   if (fileBrowserBtn) {
     fileBrowserBtn.addEventListener("click", showFilesPanel);
   }
-  if (filePanelBack) {
-    filePanelBack.addEventListener("click", showSessionsPanel);
+  if (filePanelClose) {
+    filePanelClose.addEventListener("click", showSessionsPanel);
   }
 }
 

--- a/lib/public/modules/theme.js
+++ b/lib/public/modules/theme.js
@@ -328,7 +328,11 @@ export function applyTheme(themeId) {
   var mermaidVars = computeMermaidVars(theme);
   try { updateMermaidTheme(mermaidVars); } catch (e) {}
 
-  try { localStorage.setItem(STORAGE_KEY, themeId); } catch (e) {}
+  try {
+    localStorage.setItem(STORAGE_KEY, themeId);
+    localStorage.setItem(STORAGE_KEY + "-vars", JSON.stringify(vars));
+    localStorage.setItem(STORAGE_KEY + "-variant", theme.variant || "dark");
+  } catch (e) {}
 
   for (var j = 0; j < changeCallbacks.length; j++) {
     try { changeCallbacks[j](themeId, vars); } catch (e) {}


### PR DESCRIPTION
## Summary
- Replace project dropdown with inline project list (GitHub-style sidebar)
- Add `[+]` icon buttons for new session and new project
- Pin TOOLS and SESSIONS/FILE BROWSER headers above scroll area
- Add session search X button, inline session rename from header
- Swap FILE BROWSER header (with refresh/close) when file panel is open
- Fix theme flickering on project switch via localStorage CSS variable cache
- Minor fixes: terminal border color, chevron direction, mermaid in file browser, "Star on GitHub" label

## Test plan
- [ ] Verify inline project list renders correctly with multiple projects
- [ ] Click [+] to add project, verify list updates without refresh
- [ ] Switch to file browser, verify header changes to "File Browser" with refresh/close
- [ ] Close file browser, verify header reverts to "Sessions"
- [ ] Switch projects, verify no theme flicker on page reload
- [ ] Rename session from header pencil icon
- [ ] Search sessions and clear with X button
- [ ] Verify terminal border and chevron direction
- [ ] Open markdown file in file browser, verify mermaid diagrams render

🤖 Generated with [Claude Code](https://claude.com/claude-code)