### PR TITLE
fix: remove inherited CLAUDECODE env var to prevent nested session error

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -4,6 +4,10 @@
 if (!Symbol.dispose) Symbol.dispose = Symbol("Symbol.dispose");
 if (!Symbol.asyncDispose) Symbol.asyncDispose = Symbol("Symbol.asyncDispose");
 
+// Remove CLAUDECODE env var so the SDK can spawn Claude Code child processes
+// (prevents "cannot be launched inside another Claude Code session" error)
+delete process.env.CLAUDECODE;
+
 var fs = require("fs");
 var path = require("path");
 var { loadConfig, saveConfig, socketPath, generateSlug, syncClayrc, writeCrashInfo, readCrashInfo, clearCrashInfo } = require("./config");


### PR DESCRIPTION
## Summary
- Daemon이 Claude Code 세션 내에서 시작될 때 상속되는 `CLAUDECODE=1` 환경변수를 제거하여 SDK가 Claude Code 자식 프로세스를 정상적으로 스폰할 수 있도록 수정

Closes #161

## Test plan
- [ ] Claude Code 터미널 내에서 `npx claude-relay daemon start` 실행 후 메시지 전송 시 에러 없이 동작하는지 확인
- [ ] 일반 터미널에서 시작했을 때도 기존과 동일하게 동작하는지 확인