### PR TITLE
v2.4.3 (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## WIP
 
+## v2.4.3
+
+- Fix SDK failing to spawn Claude Code when daemon is started from within a Claude Code session (#161)
+  - Remove inherited `CLAUDECODE` env var to prevent "nested session" error
+
 ## v2.4.2
 
 - Fix skill discovery: merge global (`~/.claude/skills/`) and project (`.claude/skills/`) skills for slash menu (#160)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-relay",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Web UI for Claude Code. Any device. Push notifications.",
   "bin": {
     "claude-relay": "./bin/cli.js",


### PR DESCRIPTION
## Summary
- Bump version to 2.4.3
- Update CHANGELOG with #161 fix (remove inherited CLAUDECODE env var)