### PR TITLE
Refine UI: banners, mobile tabbar, star chip cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 .claude/
 .claude-relay/
 ref/
+TODO.md
+publish.sh

--- a/lib/public/css/mobile-nav.css
+++ b/lib/public/css/mobile-nav.css
@@ -16,12 +16,12 @@
     bottom: 0;
     left: 0;
     right: 0;
-    height: 56px;
+    height: calc(56px + var(--safe-bottom));
     padding-bottom: var(--safe-bottom);
     background: var(--bg);
     border-top: 1px solid var(--border);
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-around;
     z-index: 200;
   }

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -11,18 +11,19 @@
   position: relative;
 }
 
-/* --- Onboarding banner --- */
+/* --- Onboarding banner (sits above #top-bar) --- */
 #onboarding-banner {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 8px 16px;
+  padding: 6px 16px;
   background: var(--accent-8);
   border-bottom: 1px solid var(--accent-15);
   font-size: 12px;
   color: var(--text-secondary);
+  z-index: 20;
 }
 
 #onboarding-banner.hidden { display: none; }
@@ -66,19 +67,20 @@
 #onboarding-banner-close .lucide { width: 14px; height: 14px; }
 #onboarding-banner-close:hover { color: var(--text-secondary); }
 
-/* --- Update banner --- */
+/* --- Update / Announce banner (sits above #top-bar, full width) --- */
 #update-banner {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 8px 16px;
+  padding: 6px 16px;
   background: var(--success-8);
   border-bottom: 1px solid var(--success-15);
   font-size: 12px;
   color: var(--text-secondary);
   position: relative;
+  z-index: 20;
 }
 
 #update-banner.hidden { display: none; }
@@ -196,19 +198,20 @@
 #update-banner-close .lucide { width: 14px; height: 14px; }
 #update-banner-close:hover { color: var(--text-secondary); }
 
-/* --- Skip permissions banner --- */
+/* --- Skip permissions banner (sits above #top-bar) --- */
 #skip-perms-banner {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 7px 16px;
+  padding: 6px 16px;
   background: var(--error-12);
   border-bottom: 1px solid var(--error-25);
   font-size: 12px;
   font-weight: 500;
   color: var(--error);
+  z-index: 20;
 }
 
 #skip-perms-banner.hidden { display: none; }

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -560,7 +560,7 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: var(--accent2);
+  background: var(--success);
   color: #fff;
   font-family: "Nunito", sans-serif;
   font-size: 15px;
@@ -616,102 +616,6 @@
 .user-island-actions button:hover {
   background: var(--sidebar-hover);
   color: var(--text-secondary);
-}
-
-.user-island-chip {
-  --chip-star: #FFE500;
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 11px 4px 8px;
-  border-radius: 99px;
-  border: 1px solid var(--accent2-30);
-  background: var(--accent2);
-  color: #fff;
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 700;
-  text-decoration: none;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  white-space: nowrap;
-  overflow: hidden;
-  box-shadow:
-    0 1px 4px color-mix(in srgb, var(--accent2), black 75%),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
-}
-
-/* shimmer sweep */
-.user-island-chip::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: -120%;
-  width: 60%;
-  height: 100%;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.07), transparent);
-  animation: chip-shimmer 5s ease-in-out 2s infinite;
-  pointer-events: none;
-}
-
-@keyframes chip-shimmer {
-  0%, 75%, 100% { left: -120%; }
-  35% { left: 160%; }
-}
-
-.chip-octocat {
-  width: 13px;
-  height: 13px;
-  flex-shrink: 0;
-  filter: drop-shadow(0 0 3px rgba(255, 255, 255, 0.2));
-  transition: filter 0.3s ease;
-}
-
-.chip-star {
-  color: var(--chip-star);
-  font-size: 9px;
-  line-height: 1;
-  text-shadow: 0 0 5px color-mix(in srgb, var(--chip-star), transparent 60%);
-  animation: chip-star-pulse 3s ease-in-out infinite;
-  transition: text-shadow 0.3s ease;
-}
-
-@keyframes chip-star-pulse {
-  0%, 100% { opacity: 0.75; text-shadow: 0 0 4px color-mix(in srgb, var(--chip-star), transparent 70%); }
-  50% { opacity: 1; text-shadow: 0 0 8px color-mix(in srgb, var(--chip-star), transparent 35%); }
-}
-
-.chip-label {
-  color: #fff;
-  letter-spacing: 0.01em;
-}
-
-.user-island-chip:hover {
-  border-color: color-mix(in srgb, var(--chip-star), transparent 55%);
-  background: var(--accent2-hover);
-  box-shadow:
-    0 2px 10px color-mix(in srgb, var(--chip-star), transparent 88%),
-    0 1px 4px color-mix(in srgb, var(--accent2), black 65%),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08);
-  transform: translateY(-1px);
-}
-
-.user-island-chip:hover .chip-octocat {
-  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.35));
-}
-
-.user-island-chip:hover .chip-star {
-  text-shadow: 0 0 10px color-mix(in srgb, var(--chip-star), transparent 10%);
-  animation: none;
-  opacity: 1;
-}
-
-.user-island-chip:active {
-  transform: translateY(0);
-  box-shadow:
-    0 1px 3px color-mix(in srgb, var(--accent2), black 65%),
-    inset 0 1px 2px rgba(0, 0, 0, 0.15);
 }
 
 #layout.sidebar-collapsed #user-island .user-island-info,

--- a/lib/public/css/title-bar.css
+++ b/lib/public/css/title-bar.css
@@ -93,8 +93,9 @@
 
 .title-bar-project-name {
   width: 100%;
-  font-size: 13px;
-  font-weight: 600;
+  font-family: "Nunito", sans-serif;
+  font-size: 15px;
+  font-weight: 800;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -135,6 +136,13 @@
   #top-bar {
     padding-top: var(--safe-top);
     height: calc(32px + var(--safe-top));
+  }
+
+  .top-bar-actions {
+    top: auto;
+    bottom: 0;
+    height: 32px;
+    transform: none;
   }
 
   #sidebar-column {

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -21,6 +21,22 @@
 </head>
 <body>
 <div id="layout">
+  <!-- === Announce Bars (above top bar, full width) === -->
+  <div id="update-banner" class="hidden">
+    <span class="update-banner-text"><i data-lucide="arrow-up-circle"></i> A new version of Clay is available: <strong id="update-version"></strong></span>
+    <button id="update-now">Update now</button>
+    <button id="update-how" title="Manual update instructions">?</button>
+    <button id="update-banner-close" aria-label="Dismiss"><i data-lucide="x"></i></button>
+  </div>
+  <div id="onboarding-banner" class="hidden">
+    <span class="onboarding-banner-text" id="onboarding-banner-text"></span>
+    <button id="onboarding-banner-close" aria-label="Dismiss"><i data-lucide="x"></i></button>
+  </div>
+  <div id="skip-perms-banner" class="hidden">
+    <i data-lucide="shield-off"></i>
+    <span>Skip permissions mode is active. All tool executions are auto-approved.</span>
+  </div>
+
   <!-- === Top Bar (full width, forms reverse-ㄱ with icon strip) === -->
   <div id="top-bar">
     <a href="https://github.com/chadbyte/claude-relay" target="_blank" rel="noopener" class="top-bar-title"><img class="top-bar-icon" src="favicon.svg" width="16" height="16" alt="">Clay</a>
@@ -130,21 +146,6 @@
       </div>
       <div id="main-panels">
       <div id="app">
-        <div id="update-banner" class="hidden">
-          <span class="update-banner-text"><i data-lucide="arrow-up-circle"></i> A new version of Clay is available: <strong id="update-version"></strong></span>
-          <button id="update-now">Update now</button>
-          <button id="update-how" title="Manual update instructions">?</button>
-          <button id="update-banner-close" aria-label="Dismiss"><i data-lucide="x"></i></button>
-        </div>
-        <div id="onboarding-banner" class="hidden">
-          <span class="onboarding-banner-text" id="onboarding-banner-text"></span>
-          <button id="onboarding-banner-close" aria-label="Dismiss"><i data-lucide="x"></i></button>
-        </div>
-        <div id="skip-perms-banner" class="hidden">
-          <i data-lucide="shield-off"></i>
-          <span>Skip permissions mode is active. All tool executions are auto-approved.</span>
-        </div>
-
         <div id="connect-overlay">
       <img class="connect-logo" src="favicon.svg" width="48" height="48" alt="Clay">
       <span class="connect-wordmark">Clay</span>
@@ -352,7 +353,6 @@
       <span class="user-island-name">Clay <span id="footer-version" class="footer-version"></span></span>
     </div>
     <div class="user-island-actions">
-      <a href="https://github.com/chadbyte/claude-relay" target="_blank" rel="noopener" class="user-island-chip" title="Star on GitHub"><svg class="chip-octocat" viewBox="0 0 16 16" fill="white" width="13" height="13"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg><span class="chip-star">★</span><span class="chip-label">Star Clay</span></a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Move update/onboarding/skip-perms banners above `#top-bar` for full-width layout
- Fix mobile bottom nav height to properly account for `safe-bottom`
- Fix top-bar actions positioning on mobile
- Update title bar project name font to Nunito 15px/800
- Remove unused `user-island-chip` (GitHub star) styles
- Change user island avatar color to `--success`
- Add `TODO.md` and `publish.sh` to `.gitignore`

## Test plan
- [ ] Verify banners render above top bar on desktop
- [ ] Check mobile bottom nav respects safe area
- [ ] Confirm star chip removal doesn't break user island