### PR TITLE
Fix 169 Windows paths now work for session file creation.

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -15,7 +15,7 @@ function createSessionManager(opts) {
   var skillNames = null;        // Claude-only skills to filter from slash menu
 
   // --- Session persistence (centralized in ~/.clay/sessions/{encoded-cwd}/) ---
-  var encodedCwd = cwd.replace(/\//g, "-");
+  var encodedCwd = cwd.replace(/\//g, "-").replace(/\\/g, "-").replace(/:/g, "-");
   var sessionsDir = path.join(config.CONFIG_DIR, "sessions", encodedCwd);
   fs.mkdirSync(sessionsDir, { recursive: true });
 


### PR DESCRIPTION
- added replacing windows path tokens like posix ones were for creating session directory