### PR TITLE
Fix context panel still showing inflated usage

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1057,8 +1057,7 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
     // Use latest turn values (not cumulative) since each turn's input_tokens
     // already includes the full conversation context up to that point
     if (usage) {
-      contextData.input = (usage.input_tokens || usage.inputTokens || 0)
-          + (usage.cache_read_input_tokens || usage.cacheReadInputTokens || 0);
+      contextData.input = (usage.input_tokens || usage.inputTokens || 0);
       contextData.output = usage.output_tokens || usage.outputTokens || 0;
       contextData.cacheRead = usage.cache_read_input_tokens || usage.cacheReadInputTokens || 0;
       contextData.cacheWrite = usage.cache_creation_input_tokens || usage.cacheCreationInputTokens || 0;


### PR DESCRIPTION
## Summary

- The v2.7.0 fix for #177 correctly changed `var used = contextData.input` but didn't fix how `contextData.input` is calculated
- `input_tokens` from the CLI SDK already includes cached tokens, so adding `cache_read_input_tokens` on top was double-counting
- This caused the context panel to show ~300K used instead of ~25K for the same conversation

## Change

```diff
-contextData.input = (usage.input_tokens || usage.inputTokens || 0)
-    + (usage.cache_read_input_tokens || usage.cacheReadInputTokens || 0);
+contextData.input = (usage.input_tokens || usage.inputTokens || 0);
```

## Test plan

- [x] Ran local relay and compared context panel numbers against CLI `/context` output — they now match