### PR TITLE
Fix context panel showing inflated usage on tool-use turns

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1052,13 +1052,21 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
     contextTurnsEl.textContent = String(contextData.turns);
   }
 
-  function accumulateContext(cost, usage, modelUsage) {
+  function accumulateContext(cost, usage, modelUsage, lastStreamInputTokens) {
     if (cost != null) contextData.cost += cost;
     // Use latest turn values (not cumulative) since each turn's input_tokens
     // already includes the full conversation context up to that point
     if (usage) {
-      contextData.input = (usage.input_tokens || usage.inputTokens || 0)
-          + (usage.cache_read_input_tokens || usage.cacheReadInputTokens || 0);
+      // Prefer per-call input_tokens from the last stream message_start event
+      // when available — result.usage.input_tokens sums all API calls in a turn,
+      // inflating context usage when tools are involved.
+      // Falls back to the summed value for setups that don't emit message_start.
+      if (lastStreamInputTokens) {
+        contextData.input = lastStreamInputTokens;
+      } else {
+        contextData.input = (usage.input_tokens || usage.inputTokens || 0)
+            + (usage.cache_read_input_tokens || usage.cacheReadInputTokens || 0);
+      }
       contextData.output = usage.output_tokens || usage.outputTokens || 0;
       contextData.cacheRead = usage.cache_read_input_tokens || usage.cacheReadInputTokens || 0;
       contextData.cacheWrite = usage.cache_creation_input_tokens || usage.cacheCreationInputTokens || 0;
@@ -1880,7 +1888,7 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
           replayingHistory = false;
           // Restore accurate context data from the last result in full history
           if (msg.lastUsage || msg.lastModelUsage) {
-            accumulateContext(msg.lastCost, msg.lastUsage, msg.lastModelUsage);
+            accumulateContext(msg.lastCost, msg.lastUsage, msg.lastModelUsage, msg.lastStreamInputTokens);
           }
           updateContextPanel();
           updateUsagePanel();
@@ -2302,7 +2310,7 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
           finalizeAssistantBlock();
           addTurnMeta(msg.cost, msg.duration);
           accumulateUsage(msg.cost, msg.usage);
-          accumulateContext(msg.cost, msg.usage, msg.modelUsage);
+          accumulateContext(msg.cost, msg.usage, msg.modelUsage, msg.lastStreamInputTokens);
           break;
 
         case "done":

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -159,6 +159,11 @@ function createSDKBridge(opts) {
     if (parsed.type === "stream_event" && parsed.event) {
       var evt = parsed.event;
 
+      if (evt.type === "message_start" && evt.message && evt.message.usage) {
+        var u = evt.message.usage;
+        session.lastStreamInputTokens = (u.input_tokens || 0) + (u.cache_read_input_tokens || 0);
+      }
+
       if (evt.type === "content_block_start") {
         var block = evt.content_block;
         var idx = evt.index;
@@ -309,6 +314,8 @@ function createSDKBridge(opts) {
       session.taskIdMap = {};
       session.isProcessing = false;
       onProcessingChanged();
+      var lastStreamInput = session.lastStreamInputTokens || null;
+      session.lastStreamInputTokens = null;
       sendAndRecord(session, {
         type: "result",
         cost: parsed.total_cost_usd,
@@ -316,6 +323,7 @@ function createSDKBridge(opts) {
         usage: parsed.usage || null,
         modelUsage: parsed.modelUsage || null,
         sessionId: parsed.session_id,
+        lastStreamInputTokens: lastStreamInput,
       });
       if (parsed.fast_mode_state) {
         sendAndRecord(session, { type: "fast_mode_state", state: parsed.fast_mode_state });

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -237,17 +237,19 @@ function createSessionManager(opts) {
     var lastUsage = null;
     var lastModelUsage = null;
     var lastCost = null;
+    var lastStreamInputTokens = null;
     for (var j = total - 1; j >= 0; j--) {
       if (session.history[j].type === "result") {
         var r = session.history[j];
         lastUsage = r.usage || null;
         lastModelUsage = r.modelUsage || null;
         lastCost = r.cost != null ? r.cost : null;
+        lastStreamInputTokens = r.lastStreamInputTokens || null;
         break;
       }
     }
 
-    send({ type: "history_done", lastUsage: lastUsage, lastModelUsage: lastModelUsage, lastCost: lastCost });
+    send({ type: "history_done", lastUsage: lastUsage, lastModelUsage: lastModelUsage, lastCost: lastCost, lastStreamInputTokens: lastStreamInputTokens });
   }
 
   function switchSession(localId) {


### PR DESCRIPTION
## Summary

- When a turn involves tool use, the CLI SDK makes multiple API calls (e.g., decide to use tool → process tool result). The `result.usage.input_tokens` field sums `input_tokens` across all API calls in the turn, inflating the context panel's "used" count.
- This fix captures per-call `input_tokens` from `message_start` stream events and uses the last one (which reflects actual context size) instead of the summed total.

## What we observed

We tested with a setup using Kiro Gateway (an API proxy) but the issue affects any setup where tool use triggers multiple API calls per turn:

| Turn type | `result.usage.input_tokens` | Last `message_start` input_tokens | CLI `/context` |
|---|---|---|---|
| Simple reply (no tools) | ~24K | ~24K | ~24K |
| Read a file (1 tool) | ~49K | ~24K | ~24K |
| Multiple tools | ~85K | ~28K | ~28K |

The `result.usage.input_tokens` doubles/triples on tool-use turns because it sums all API calls. The last `message_start` event's `input_tokens` matches the CLI's `/context` output.

## How it works

1. **sdk-bridge.js**: Captures `input_tokens + cache_read_input_tokens` from each `message_start` stream event (last one wins, since it reflects the final context size)
2. **sdk-bridge.js**: Passes `lastStreamInputTokens` through the `result` message to the frontend
3. **sessions.js**: Persists and restores `lastStreamInputTokens` through history replay
4. **app.js**: Uses `lastStreamInputTokens` for context display when available, falls back to the existing `result.usage` calculation when not

## Backwards compatibility

If `message_start` stream events are never emitted (different SDK versions, non-streaming setups), `lastStreamInputTokens` is `null` and the existing fallback path runs unchanged. No breakage for any setup.

## Caveat

We tested this with Kiro Gateway, not a standard Claude subscription (we don't have one). The `message_start` events are present in our setup and the fix works correctly. We believe this applies to standard setups too since the CLI SDK streams `message_start` events, but we couldn't verify directly.

## Test plan

- [x] Verified `message_start` stream events carry per-call `input_tokens`
- [x] Verified last `message_start` value matches CLI `/context` on tool-use turns
- [x] Verified simple turns (no tools) show correct values
- [x] Verified history replay restores correct context after page reload
- [x] Verified fallback path works when `lastStreamInputTokens` is null