### PR TITLE
Fix encodeCwd to match Claude Code's path encoding

### DIFF
--- a/lib/notes.js
+++ b/lib/notes.js
@@ -8,8 +8,8 @@ function createNotesManager(opts) {
   var cwd = opts.cwd;
 
   // Storage path: ~/.clay/notes/{encodedCwd}.json
-  var encodedCwd = utils.encodeCwd(cwd);
   var notesDir = path.join(config.CONFIG_DIR, "notes");
+  var encodedCwd = utils.resolveEncodedFile(notesDir, cwd, ".json");
   var notesFile = path.join(notesDir, encodedCwd + ".json");
 
   // In-memory cache

--- a/lib/project.js
+++ b/lib/project.js
@@ -253,8 +253,8 @@ function createProjectContext(opts) {
   // Loop state persistence
   var _loopConfig = require("./config");
   var _loopUtils = require("./utils");
-  var _loopEncodedCwd = _loopUtils.encodeCwd(cwd);
   var _loopDir = path.join(_loopConfig.CONFIG_DIR, "loops");
+  var _loopEncodedCwd = _loopUtils.resolveEncodedFile(_loopDir, cwd, ".json");
   var _loopStatePath = path.join(_loopDir, _loopEncodedCwd + ".json");
 
   function saveLoopState() {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -16,8 +16,9 @@ function createSessionManager(opts) {
   var skillNames = null;        // Claude-only skills to filter from slash menu
 
   // --- Session persistence (centralized in ~/.clay/sessions/{encoded-cwd}/) ---
-  var encodedCwd = utils.encodeCwd(cwd);
-  var sessionsDir = path.join(config.CONFIG_DIR, "sessions", encodedCwd);
+  var sessionsBase = path.join(config.CONFIG_DIR, "sessions");
+  var encodedCwd = utils.resolveEncodedDir(sessionsBase, cwd);
+  var sessionsDir = path.join(sessionsBase, encodedCwd);
   fs.mkdirSync(sessionsDir, { recursive: true });
 
   // Auto-migrate sessions from legacy locations:

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,17 +2,61 @@
  * Shared utility functions.
  */
 
+var fs = require("fs");
+
 /**
  * Encode a cwd path into a filesystem-safe directory/file name.
- * Replaces forward slashes and dots with hyphens so that usernames
- * like "jon.doe" don't break session/note lookups.
+ * Replaces forward slashes, dots, and underscores with hyphens so that
+ * usernames and workspace paths like "jon.doe_42" don't break session/note
+ * lookups. This aligns to Claude Code CLI's encoding logic.
  *
- * Example: "/Users/jon.doe/my-project" -> "-Users-jon-doe-my-project"
+ * Example: "/Users/jon.doe_42/my_project" -> "-Users-jon-doe-42-my-project"
  */
 function encodeCwd(cwd) {
+  return cwd.replace(/[\/\._]/g, "-");
+}
+
+/**
+ * Legacy encoding (pre-underscore fix). Only slashes and dots were replaced.
+ * Used for fallback resolution of on-disk data written before the fix.
+ */
+function legacyEncodeCwd(cwd) {
   return cwd.replace(/[\/\.]/g, "-");
+}
+
+/**
+ * Resolve an encoded directory path with legacy fallback.
+ * Returns the new-encoding path if it exists (or if neither exists),
+ * falls back to the legacy-encoded path if only that one is present.
+ */
+function resolveEncodedDir(baseDir, cwd) {
+  var newEncoded = encodeCwd(cwd);
+  var legacyEncoded = legacyEncodeCwd(cwd);
+  if (newEncoded === legacyEncoded) return newEncoded;
+  var newPath = baseDir + "/" + newEncoded;
+  var legacyPath = baseDir + "/" + legacyEncoded;
+  try { if (fs.statSync(newPath).isDirectory()) return newEncoded; } catch (e) {}
+  try { if (fs.statSync(legacyPath).isDirectory()) return legacyEncoded; } catch (e) {}
+  return newEncoded;
+}
+
+/**
+ * Resolve an encoded file path with legacy fallback.
+ * Same logic as resolveEncodedDir but checks for file existence.
+ */
+function resolveEncodedFile(baseDir, cwd, ext) {
+  var newEncoded = encodeCwd(cwd);
+  var legacyEncoded = legacyEncodeCwd(cwd);
+  if (newEncoded === legacyEncoded) return newEncoded;
+  var newPath = baseDir + "/" + newEncoded + (ext || "");
+  var legacyPath = baseDir + "/" + legacyEncoded + (ext || "");
+  try { if (fs.statSync(newPath).isFile()) return newEncoded; } catch (e) {}
+  try { if (fs.statSync(legacyPath).isFile()) return legacyEncoded; } catch (e) {}
+  return newEncoded;
 }
 
 module.exports = {
   encodeCwd: encodeCwd,
+  resolveEncodedDir: resolveEncodedDir,
+  resolveEncodedFile: resolveEncodedFile,
 };


### PR DESCRIPTION
Claude Code replaces slashes, dots, AND underscores with hyphens when encoding project paths, e.g.: 
`/home/user/my_example_workspace`
becomes:
`-home-user-my-example-workspace`

Clay's encodeCwd does not replace underscores, only swapping slashes and dots. This causes CLI session import to look in the wrong directory for any workspace with underscores in the path.