### PR TITLE
Make PIN optional for bypass permissions mode

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -120,7 +120,7 @@ for (var i = 0; i < args.length; i++) {
     console.log("  --list             List all registered projects");
     console.log("  --headless         Start daemon and exit immediately (implies --yes)");
     console.log("  --dangerously-skip-permissions");
-    console.log("                     Bypass all permission prompts (requires --pin)");
+    console.log("                     Bypass all permission prompts (PIN recommended)");
     process.exit(0);
   }
 }
@@ -2398,9 +2398,7 @@ var currentVersion = require("../package.json").version;
     if (autoYes) {
       var pin = cliPin || null;
       if (dangerouslySkipPermissions && !pin) {
-        console.error("  " + sym.warn + "  " + a.red + "--dangerously-skip-permissions requires --pin <pin>" + a.reset);
-        process.exit(1);
-        return;
+        console.log("  " + sym.warn + "  " + a.yellow + "Skip permissions enabled without a PIN — anyone with network access can use this relay unrestricted" + a.reset);
       }
       console.log("  " + sym.done + "  Auto-accepted disclaimer");
       console.log("  " + sym.done + "  PIN: " + (pin ? "Enabled" : "Skipped"));
@@ -2423,10 +2421,7 @@ var currentVersion = require("../package.json").version;
     } else {
       setup(function (pin, keepAwake) {
         if (dangerouslySkipPermissions && !pin) {
-          log(sym.warn + "  " + a.red + "--dangerously-skip-permissions requires a PIN." + a.reset);
-          log(a.dim + "     Please set a PIN to use skip permissions mode." + a.reset);
-          process.exit(1);
-          return;
+          log(sym.warn + "  " + a.yellow + "Skip permissions enabled without a PIN — anyone with network access can use this relay unrestricted" + a.reset);
         }
 
         // Check ~/.clayrc for previous projects to restore

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -643,6 +643,7 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
   var currentEffort = "medium";
   var currentBetas = [];
   var skipPermsEnabled = false;
+  var pinEnabled = false;
 
   var MODE_OPTIONS = [
     { value: "default", label: "Default" },
@@ -763,9 +764,7 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
     if (!configModeList) return;
     configModeList.innerHTML = "";
     var options = MODE_OPTIONS.slice();
-    if (skipPermsEnabled) {
-      options.push(MODE_FULL_AUTO);
-    }
+    options.push(MODE_FULL_AUTO);
     for (var i = 0; i < options.length; i++) {
       var opt = options[i];
       var btn = document.createElement("button");
@@ -775,6 +774,16 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
       btn.textContent = opt.label;
       btn.addEventListener("click", function () {
         var mode = this.dataset.mode;
+        if (mode === "bypassPermissions" && !pinEnabled && !skipPermsEnabled) {
+          showFullAutoWarning(function () {
+            if (ws && ws.readyState === 1) {
+              ws.send(JSON.stringify({ type: "set_permission_mode", mode: mode }));
+            }
+            configPopover.classList.add("hidden");
+            configChip.classList.remove("active");
+          });
+          return;
+        }
         if (ws && ws.readyState === 1) {
           ws.send(JSON.stringify({ type: "set_permission_mode", mode: mode }));
         }
@@ -783,6 +792,46 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
       });
       configModeList.appendChild(btn);
     }
+  }
+
+  function showFullAutoWarning(onConfirm) {
+    var existing = document.getElementById("full-auto-warning-modal");
+    if (existing) existing.remove();
+
+    var overlay = document.createElement("div");
+    overlay.id = "full-auto-warning-modal";
+    overlay.className = "modal-overlay";
+    overlay.style.cssText = "position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.5);";
+
+    var dialog = document.createElement("div");
+    dialog.style.cssText = "background:var(--bg-primary);border:1px solid var(--border);border-radius:12px;padding:24px;max-width:420px;width:90%;box-shadow:0 8px 32px rgba(0,0,0,0.3);";
+
+    dialog.innerHTML =
+      '<div style="font-size:15px;font-weight:600;color:var(--text-warning, #f59e0b);margin-bottom:12px;">No PIN set</div>' +
+      '<div style="font-size:13px;color:var(--text-secondary);line-height:1.5;margin-bottom:20px;">' +
+        'Full auto mode lets Claude run commands and edit files without asking for permission. ' +
+        'Without a PIN, anyone with network access to this relay can use it unrestricted.' +
+        '<br><br>' +
+        'Consider setting a PIN in Server Settings for security.' +
+      '</div>' +
+      '<div style="display:flex;gap:8px;justify-content:flex-end;">' +
+        '<button id="full-auto-warn-cancel" style="padding:6px 16px;border-radius:6px;border:1px solid var(--border);background:var(--bg-secondary);color:var(--text-primary);cursor:pointer;font-size:13px;">Cancel</button>' +
+        '<button id="full-auto-warn-confirm" style="padding:6px 16px;border-radius:6px;border:none;background:var(--text-warning, #f59e0b);color:#000;cursor:pointer;font-size:13px;font-weight:500;">Enable anyway</button>' +
+      '</div>';
+
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    document.getElementById("full-auto-warn-cancel").addEventListener("click", function () {
+      overlay.remove();
+    });
+    document.getElementById("full-auto-warn-confirm").addEventListener("click", function () {
+      overlay.remove();
+      onConfirm();
+    });
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) overlay.remove();
+    });
   }
 
   function rebuildEffortBar() {
@@ -2567,10 +2616,12 @@ import { initSkills, handleSkillInstalled, handleSkillUninstalled } from './modu
 
         case "daemon_config":
           updateDaemonConfig(msg.config);
+          if (msg.config) pinEnabled = !!msg.config.pinEnabled;
           break;
 
         case "set_pin_result":
           handleSetPinResult(msg);
+          if (msg.ok) pinEnabled = !!msg.pinEnabled;
           break;
 
         case "set_keep_awake_result":

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -805,6 +805,9 @@ function createSDKBridge(opts) {
       if (session.acceptEditsAfterStart) delete session.acceptEditsAfterStart;
       if (modeToApply && modeToApply !== "default") {
         queryOptions.permissionMode = modeToApply;
+        if (modeToApply === "bypassPermissions") {
+          queryOptions.allowDangerouslySkipPermissions = true;
+        }
       }
     }
 
@@ -997,7 +1000,11 @@ function createSDKBridge(opts) {
       return;
     }
     try {
-      await session.queryInstance.setPermissionMode(mode);
+      if (mode === "bypassPermissions") {
+        await session.queryInstance.setPermissionMode(mode, { allowDangerouslySkipPermissions: true });
+      } else {
+        await session.queryInstance.setPermissionMode(mode);
+      }
       sm.currentPermissionMode = mode;
       send({ type: "config_state", model: sm.currentModel || "", mode: sm.currentPermissionMode, effort: sm.currentEffort || "medium", betas: sm.currentBetas || [] });
     } catch (e) {


### PR DESCRIPTION
## Summary

- Removes the hard requirement for a PIN when enabling `--dangerously-skip-permissions` or selecting "Full auto" mode from the UI
- The CLI now prints a yellow warning instead of exiting with an error when no PIN is set
- The web UI shows a confirmation dialog explaining the security risk when enabling Full auto without a PIN — the user can cancel or proceed at their own discretion
- "Full auto" mode is now always visible in the mode dropdown, not just when the CLI flag was used at startup

## Changes

- **bin/cli.js**: Replace `process.exit(1)` with a warning when `--dangerously-skip-permissions` is used without `--pin`. Update help text from "requires --pin" to "PIN recommended".
- **lib/public/app.js**: Always show "Full auto" in mode selector. Track `pinEnabled` state from daemon config. Show warning modal when enabling without a PIN.
- **lib/sdk-bridge.js**: Pass `allowDangerouslySkipPermissions` when `bypassPermissions` is set from the UI (not just CLI flag), both at query creation and mid-session mode switches.

## Test plan

- [ ] Start relay with `--dangerously-skip-permissions` and no `--pin` — should warn but not exit
- [ ] Start relay with `--dangerously-skip-permissions --pin 123456` — should work as before
- [ ] Open web UI without skip-perms CLI flag, select "Full auto" without a PIN set — should show warning dialog
- [ ] Confirm the warning — mode should switch to Full auto successfully
- [ ] Cancel the warning — mode should stay unchanged
- [ ] Set a PIN, then select "Full auto" — should switch immediately with no warning
- [ ] Start with CLI `--dangerously-skip-permissions` — mode should be locked as before, no downgrade possible