### PR TITLE
Replace twemoji JS with COLR font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## WIP
 
+## v2.8.2
+
+- Replace twemoji JS parsing with Twemoji COLR font — eliminates emoji blinking during streaming, removes MutationObserver overhead
+- Remove twemoji.min.js script and all parseEmojis calls across codebase
+
 ## v2.8.1
 
 - Disable twemoji in chat area, use native emoji rendering

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1,6 +1,6 @@
 import { showToast, copyToClipboard, escapeHtml } from './modules/utils.js';
 import { refreshIcons, iconHtml, randomThinkingVerb } from './modules/icons.js';
-import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, closeMermaidModal, parseEmojis } from './modules/markdown.js';
+import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, closeMermaidModal } from './modules/markdown.js';
 import { initSidebar, renderSessionList, handleSearchResults, updatePageTitle, getActiveSearchQuery, buildSearchTimeline, removeSearchTimeline, populateCliSessionList, renderIconStrip, initIconStrip, getEmojiCategories } from './modules/sidebar.js';
 import { initRewind, setRewindMode, showRewindModal, clearPendingRewindUuid, addRewindButton } from './modules/rewind.js';
 import { initNotifications, showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './modules/notifications.js';
@@ -181,7 +181,7 @@ import { initProfile } from './modules/profile.js';
     }
     // Normal update (no animation)
     greetEl.textContent = getGreeting();
-    parseEmojis(greetEl);
+
     applyWeatherTooltip(greetEl);
   }
 
@@ -213,13 +213,13 @@ import { initProfile } from './modules/profile.js';
       if (step < totalSteps) {
         var idx = (startIdx + step) % SLOT_EMOJIS.length;
         greetEl.textContent = prefix + " " + SLOT_EMOJIS[idx];
-        parseEmojis(greetEl);
+    
         step++;
         setTimeout(tick, intervals[step - 1]);
       } else {
         // Final: land on actual weather
         greetEl.textContent = prefix + " " + weatherEmoji;
-        parseEmojis(greetEl);
+    
         applyWeatherTooltip(greetEl);
       }
     }
@@ -366,7 +366,7 @@ import { initProfile } from './modules/profile.js';
         })(projects[p]);
       }
       // Render emoji icons
-      parseEmojis(projectsList);
+
     }
 
     // --- Week strip ---
@@ -451,7 +451,7 @@ import { initProfile } from './modules/profile.js';
             pbGrid.appendChild(card);
           })(pbs[pi]);
         }
-        parseEmojis(pbGrid);
+
       }
     }
 
@@ -498,7 +498,7 @@ import { initProfile } from './modules/profile.js';
     }
 
     // Render twemoji for all emoji in the hub
-    parseEmojis(homeHub);
+
   }
 
   function handleHubSchedules(msg) {
@@ -617,7 +617,7 @@ import { initProfile } from './modules/profile.js';
           var pIcon = cachedProjects[pi].icon || null;
           if (pIcon) {
             tbIcon.textContent = pIcon;
-            parseEmojis(tbIcon);
+
             tbIcon.classList.add("has-icon");
             try { localStorage.setItem("clay-project-icon-" + (currentSlug || "default"), pIcon); } catch (e) {}
           } else {
@@ -736,7 +736,7 @@ import { initProfile } from './modules/profile.js';
       var _tbi = $("title-bar-project-icon");
       if (_tbi) {
         _tbi.textContent = _cachedProjectIcon;
-        parseEmojis(_tbi);
+
         _tbi.classList.add("has-icon");
       }
     }
@@ -1848,7 +1848,7 @@ import { initProfile } from './modules/profile.js';
       bubble.appendChild(textEl);
     }
 
-    parseEmojis(bubble);
+
     div.appendChild(bubble);
 
     // Action bar below bubble (icons visible on hover)
@@ -1975,7 +1975,6 @@ import { initProfile } from './modules/profile.js';
     if (highlightTimer) clearTimeout(highlightTimer);
     highlightTimer = setTimeout(function () {
       highlightCodeBlocks(contentEl);
-      parseEmojis(contentEl);
     }, 150);
 
     scrollToBottom();
@@ -1996,7 +1995,6 @@ import { initProfile } from './modules/profile.js';
       if (contentEl) {
         contentEl.innerHTML = renderMarkdown(currentFullText);
         highlightCodeBlocks(contentEl);
-        parseEmojis(contentEl);
       }
     }
   }
@@ -2008,7 +2006,6 @@ import { initProfile } from './modules/profile.js';
       if (contentEl) {
         highlightCodeBlocks(contentEl);
         renderMermaidBlocks(contentEl);
-        parseEmojis(contentEl);
       }
       if (currentFullText) {
         addCopyHandler(currentMsgEl, currentFullText);

--- a/lib/public/css/base.css
+++ b/lib/public/css/base.css
@@ -58,6 +58,13 @@
   font-display: swap;
 }
 
+/* --- Twemoji COLR Font (cross-platform consistent emoji via font, no JS parsing) --- */
+@font-face {
+  font-family: 'Twemoji';
+  src: url('https://cdn.jsdelivr.net/npm/twemoji-colr-font@15.0.3/twemoji.woff2') format('woff2');
+  font-display: swap;
+}
+
 /* --- Reset & Variables --- */
 * {
   margin: 0;
@@ -159,7 +166,7 @@ html, body {
   height: 100%;
   background: var(--bg);
   color: var(--text);
-  font-family: "Pretendard", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-family: "Pretendard", "Twemoji", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   font-size: 15px;
   line-height: 1.6;
   overflow: hidden;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -1361,7 +1361,6 @@
 <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5/lib/xterm.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0/lib/addon-fit.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/twemoji@14.0.2/dist/twemoji.min.js"></script>
 <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -1,6 +1,6 @@
 import { iconHtml, refreshIcons } from './icons.js';
 import { escapeHtml, copyToClipboard } from './utils.js';
-import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, exportMarkdownAsPdf, parseEmojis } from './markdown.js';
+import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, exportMarkdownAsPdf } from './markdown.js';
 import { closeSidebar } from './sidebar.js';
 import { renderUnifiedDiff, renderSplitDiff } from './diff.js';
 import { initFileIcons, getFileIconSvg, getFolderIconSvg } from './fileicons.js';
@@ -198,7 +198,6 @@ function renderBody() {
     }
     highlightCodeBlocks(bodyEl);
     renderMermaidBlocks(bodyEl);
-    parseEmojis(bodyEl);
     renderBtn.classList.add("active");
     renderBtn.title = "Show raw";
     pdfBtn.classList.remove("hidden");

--- a/lib/public/modules/markdown.js
+++ b/lib/public/modules/markdown.js
@@ -27,114 +27,12 @@ export function renderMarkdown(text) {
 }
 
 /**
- * Parse all Unicode emojis inside an element into Twemoji SVGs.
- * Safe to call on any DOM element — skips <pre>/<code> to avoid mangling.
- * With the global MutationObserver active, manual calls are rarely needed.
+ * parseEmojis — no-op stub.
+ * Emoji rendering is now handled by the Twemoji COLR font via CSS @font-face.
+ * No DOM manipulation needed — the font renders emoji glyphs directly.
+ * This stub is kept so existing callers don't break.
  */
-export function parseEmojis(el) {
-  if (typeof twemoji === "undefined" || !el) return;
-  twemoji.parse(el, { folder: "svg", ext: ".svg" });
-}
-
-/**
- * Global Twemoji auto-parser.
- * Observes all DOM mutations and automatically converts Unicode emojis to
- * Twemoji SVGs. This eliminates the need to call parseEmojis() manually
- * after every DOM update.
- */
-var twemojiOpts = { folder: "svg", ext: ".svg" };
-var SKIP_TAGS = { PRE: 1, CODE: 1, SCRIPT: 1, STYLE: 1, TEXTAREA: 1, INPUT: 1 };
-var emojiRegex = /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{27BF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}\u{20E3}\u{E0020}-\u{E007F}]/u;
-var pendingNodes = [];
-var flushScheduled = false;
-
-function shouldSkip(node) {
-  var el = node.nodeType === 3 ? node.parentElement : node;
-  while (el) {
-    if (SKIP_TAGS[el.tagName]) return true;
-    // Already parsed — img.emoji is what twemoji produces
-    if (el.tagName === "IMG" && el.classList && el.classList.contains("emoji")) return true;
-    // Skip chat messages area — use native emoji
-    if (el.id === "messages") return true;
-    el = el.parentElement;
-  }
-  return false;
-}
-
-function flushTwemoji() {
-  flushScheduled = false;
-  if (typeof twemoji === "undefined") return;
-  var nodes = pendingNodes;
-  pendingNodes = [];
-  for (var i = 0; i < nodes.length; i++) {
-    var node = nodes[i];
-    if (!node.isConnected) continue;
-    if (shouldSkip(node)) continue;
-    // For text nodes, parse the parent element
-    var target = node.nodeType === 3 ? node.parentElement : node;
-    if (target) twemoji.parse(target, twemojiOpts);
-  }
-}
-
-function queueTwemoji(node) {
-  pendingNodes.push(node);
-  if (!flushScheduled) {
-    flushScheduled = true;
-    requestAnimationFrame(flushTwemoji);
-  }
-}
-
-// Start observing once DOM is ready
-(function initTwemojiObserver() {
-  if (typeof twemoji === "undefined") return;
-  if (typeof MutationObserver === "undefined") return;
-
-  var observer = new MutationObserver(function (mutations) {
-    for (var m = 0; m < mutations.length; m++) {
-      var mut = mutations[m];
-      // New nodes added
-      if (mut.type === "childList") {
-        for (var n = 0; n < mut.addedNodes.length; n++) {
-          var added = mut.addedNodes[n];
-          if (added.nodeType === 1) {
-            // Element — check if it contains emoji text
-            if (emojiRegex.test(added.textContent || "")) {
-              queueTwemoji(added);
-            }
-          } else if (added.nodeType === 3) {
-            // Text node
-            if (emojiRegex.test(added.data || "")) {
-              queueTwemoji(added);
-            }
-          }
-        }
-      }
-      // Text content changed
-      if (mut.type === "characterData") {
-        if (emojiRegex.test(mut.target.data || "")) {
-          queueTwemoji(mut.target);
-        }
-      }
-    }
-  });
-
-  function start() {
-    // Parse everything already in the page
-    twemoji.parse(document.body, twemojiOpts);
-    // Watch for future changes
-    observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    });
-  }
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", start);
-  } else {
-    start();
-  }
-})();
+export function parseEmojis() {}
 
 var langAliases = { jsonl: "json", dotenv: "bash" };
 

--- a/lib/public/modules/project-settings.js
+++ b/lib/public/modules/project-settings.js
@@ -1,7 +1,6 @@
 // project-settings.js — Project settings panel (profile, defaults, instructions, env)
 import { refreshIcons } from './icons.js';
 import { showToast } from './utils.js';
-import { parseEmojis } from './markdown.js';
 
 var ctx = null;
 var panelEl = null;
@@ -253,7 +252,6 @@ function updateIconPreview(icon) {
   var removeBtn = document.getElementById("ps-icon-remove-btn");
   if (preview) {
     preview.textContent = icon || "";
-    if (icon) parseEmojis(preview);
   }
   if (removeBtn) {
     removeBtn.classList.toggle("hidden", !icon);
@@ -338,7 +336,7 @@ function showPsEmojiPicker() {
         grid.appendChild(btn);
       })(emojis[i]);
     }
-    parseEmojis(grid);
+
     scrollArea.scrollTop = 0;
   }
 
@@ -350,7 +348,6 @@ function showPsEmojiPicker() {
   }
 
   buildGrid(EMOJI_CATEGORIES[0].emojis);
-  parseEmojis(tabBar);
 
   anchor.innerHTML = "";
   anchor.appendChild(picker);

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -2,7 +2,6 @@ import { escapeHtml, copyToClipboard } from './utils.js';
 import { iconHtml, refreshIcons } from './icons.js';
 import { openProjectSettings } from './project-settings.js';
 import { triggerShare } from './qrcode.js';
-import { parseEmojis } from './markdown.js';
 
 var ctx;
 
@@ -1714,7 +1713,7 @@ function showEmojiPicker(slug, anchorEl) {
         grid.appendChild(btn);
       })(emojis[i]);
     }
-    parseEmojis(grid);
+
     scrollArea.scrollTop = 0;
   }
 
@@ -1728,8 +1727,7 @@ function showEmojiPicker(slug, anchorEl) {
   // Start with first category (Frequent)
   buildGrid(EMOJI_CATEGORIES[0].emojis);
 
-  // Parse tabs with twemoji
-  parseEmojis(tabBar);
+
 
   document.body.appendChild(picker);
   emojiPickerEl = picker;
@@ -1993,7 +1991,6 @@ export function renderIconStrip(projects, currentSlug) {
       var emojiSpan = document.createElement("span");
       emojiSpan.className = "project-emoji";
       emojiSpan.textContent = p.icon;
-      parseEmojis(emojiSpan);
       el.appendChild(emojiSpan);
     } else {
       el.appendChild(document.createTextNode(getProjectAbbrev(p.name)));

--- a/lib/public/modules/sticky-notes.js
+++ b/lib/public/modules/sticky-notes.js
@@ -1,5 +1,4 @@
 import { refreshIcons, iconHtml } from './icons.js';
-import { parseEmojis } from './markdown.js';
 
 var ctx;
 var notes = new Map();  // id -> { data, el }
@@ -1124,7 +1123,6 @@ function renderArchiveCards() {
       var bodyLines = (noteData.data.text || "").split("\n").slice(1).join("\n").trim();
       if (bodyLines) {
         body.innerHTML = renderMiniMarkdown("_\n" + bodyLines).replace('<div class="sn-title">_</div>', "");
-        parseEmojis(body);
       }
       card.appendChild(body);
 

--- a/lib/public/modules/tools.js
+++ b/lib/public/modules/tools.js
@@ -1,6 +1,6 @@
 import { escapeHtml, copyToClipboard } from './utils.js';
 import { iconHtml, refreshIcons, randomThinkingVerb } from './icons.js';
-import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, parseEmojis } from './markdown.js';
+import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks } from './markdown.js';
 import { renderUnifiedDiff, renderSplitDiff, renderPatchDiff } from './diff.js';
 import { openFile } from './filebrowser.js';
 
@@ -744,7 +744,6 @@ export function renderPlanCard(content) {
   body.innerHTML = renderMarkdown(content);
   highlightCodeBlocks(body);
   renderMermaidBlocks(body);
-  parseEmojis(body);
 
   var copyBtn = header.querySelector(".plan-card-copy");
   if (copyBtn) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-server",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Web UI for Claude Code. Any device. Push notifications.",
   "bin": {
     "clay-server": "./bin/cli.js",


### PR DESCRIPTION
## Summary

- Replace twemoji.min.js DOM parsing (MutationObserver + `parseEmojis()`) with Twemoji COLR web font via `@font-face`
- Eliminates emoji blinking during streaming caused by repeated `innerHTML` resets destroying twemoji `<img>` elements
- Remove ~100 lines of observer/queue/flush code and all `parseEmojis` calls across 8 files
- Bump version to 2.8.2

## Test plan

- [ ] Verify emoji renders as Twemoji style (not Apple/system emoji) across chat, sidebar, emoji picker
- [ ] Confirm no blinking during streaming messages with emoji
- [ ] Test on Safari/iOS (COLRv0 supported iOS 11+)
- [ ] Check emoji picker grid renders correctly without twemoji.parse()