### PR TITLE
Fix file viewer tab rendering width

### DIFF
--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -677,6 +677,7 @@
   color: var(--text);
   white-space: pre-wrap;
   word-break: break-word;
+  tab-size: 2;
 }
 
 .file-viewer-body pre code {
@@ -700,6 +701,7 @@
   line-height: 1.55;
   white-space: pre;
   word-break: normal;
+  tab-size: 2;
 }
 
 .file-viewer-gutter {


### PR DESCRIPTION
## Summary

- Set `tab-size: 2` on `.file-viewer-body pre` and `.file-viewer-code pre` to match the existing `tab-size: 2` already used in the history/diff view (`.file-history-split-code pre`)
- Without this, the main file viewer falls back to the browser default of 8 spaces per tab

## Test plan

- [ ] Open a file containing tab characters in the file viewer
- [ ] Confirm tabs render at 2-space width instead of 8