### PR TITLE
Fix session routing, multi-user disable, v2.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## WIP
 
+## v2.9.2
+
+- Fix session message routing: use per-connection session tracking instead of global activeSessionId to prevent cross-session message leaking (#206)
+- Fix `send()` broadcasts leaking status, error, and user messages to unrelated sessions
+- Fix SDK bridge broadcasting session-specific errors to all clients
+- Add "Disable multi-user mode" option to settings menu with confirmation prompt
+- Filter sessions with ownerId on initial connection in single-user mode
+- Fallback to most recent accessible session when active session is inaccessible
+- Style client count as accent pill badge with users icon in topbar
+- Fix dev mode skipping setup flow (consent, port, PIN) after shutdown
+
 ## v2.9.1
 
 - Replace mobile settings nav with dropdown select for better UX

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,7 +28,7 @@ if (_isDev) process.env.CLAY_DEV = "1";
 var { loadConfig, saveConfig, configPath, socketPath, logPath, ensureConfigDir, isDaemonAlive, isDaemonAliveAsync, generateSlug, clearStaleConfig, loadClayrc, saveClayrc, readCrashInfo } = require("../lib/config");
 var { sendIPCCommand } = require("../lib/ipc");
 var { generateAuthToken } = require("../lib/server");
-var { enableMultiUser, hasAdmin, isMultiUser } = require("../lib/users");
+var { enableMultiUser, disableMultiUser, hasAdmin, isMultiUser } = require("../lib/users");
 
 function openUrl(url) {
   try {
@@ -2319,7 +2319,7 @@ function showSettingsMenu(config, ip) {
       items.push({ label: "Set PIN", value: "pin" });
     }
     if (muEnabled) {
-      items.push({ label: "Multi-user mode (enabled)", value: "multi_user" });
+      items.push({ label: "Disable multi-user mode", value: "disable_multi_user" });
     } else {
       items.push({ label: "Enable multi-user mode", value: "multi_user" });
     }
@@ -2365,39 +2365,51 @@ function showSettingsMenu(config, ip) {
         break;
 
       case "multi_user":
-        if (muEnabled && hasAdmin()) {
+        var muResult = enableMultiUser();
+        log(sym.bar);
+        log(sym.bar + "  " + a.yellow + sym.warn + " Experimental Feature" + a.reset);
+        log(sym.bar);
+        log(sym.bar + "  " + a.dim + "Multi-user mode is experimental and may change in future releases." + a.reset);
+        log(sym.bar + "  " + a.dim + "Sharing access to AI-powered tools may be subject to your provider's" + a.reset);
+        log(sym.bar + "  " + a.dim + "terms of service. Please review the applicable usage policies before" + a.reset);
+        log(sym.bar + "  " + a.dim + "granting access to other users." + a.reset);
+        log(sym.bar);
+        if (muResult.setupCode) {
+          log(sym.bar + "  " + a.green + "Multi-user mode enabled." + a.reset);
           log(sym.bar);
-          log(sym.bar + "  " + a.dim + "Multi-user mode is already enabled and an admin account exists." + a.reset);
-          log(sym.bar + "  " + a.dim + "No changes made." + a.reset);
+          log(sym.bar + "  Setup code:  " + a.bold + muResult.setupCode + a.reset);
           log(sym.bar);
-          promptSelect("Back?", [{ label: "Back", value: "back" }], function () {
-            showSettingsMenu(config, ip);
-          });
+          log(sym.bar + "  " + a.dim + "Open Clay in your browser and enter this code to create the admin account." + a.reset);
+          log(sym.bar + "  " + a.dim + "The code is single-use and will be cleared once the admin is set up." + a.reset);
         } else {
-          var muResult = enableMultiUser();
-          log(sym.bar);
-          log(sym.bar + "  " + a.yellow + sym.warn + " Experimental Feature" + a.reset);
-          log(sym.bar);
-          log(sym.bar + "  " + a.dim + "Multi-user mode is experimental and may change in future releases." + a.reset);
-          log(sym.bar + "  " + a.dim + "Sharing access to AI-powered tools may be subject to your provider's" + a.reset);
-          log(sym.bar + "  " + a.dim + "terms of service. Please review the applicable usage policies before" + a.reset);
-          log(sym.bar + "  " + a.dim + "granting access to other users." + a.reset);
-          log(sym.bar);
-          if (muResult.setupCode) {
-            log(sym.bar + "  " + a.green + "Multi-user mode enabled." + a.reset);
-            log(sym.bar);
-            log(sym.bar + "  Setup code:  " + a.bold + muResult.setupCode + a.reset);
-            log(sym.bar);
-            log(sym.bar + "  " + a.dim + "Open Clay in your browser and enter this code to create the admin account." + a.reset);
-            log(sym.bar + "  " + a.dim + "The code is single-use and will be cleared once the admin is set up." + a.reset);
-          } else {
-            log(sym.bar + "  " + a.dim + "Multi-user mode is already enabled." + a.reset);
-          }
-          log(sym.bar);
-          promptSelect("Back?", [{ label: "Back", value: "back" }], function () {
-            showSettingsMenu(config, ip);
-          });
+          log(sym.bar + "  " + a.dim + "Multi-user mode is already enabled." + a.reset);
         }
+        log(sym.bar);
+        promptSelect("Back?", [{ label: "Back", value: "back" }], function () {
+          showSettingsMenu(config, ip);
+        });
+        break;
+
+      case "disable_multi_user":
+        log(sym.bar);
+        log(sym.bar + "  " + a.yellow + sym.warn + " Disable multi-user mode?" + a.reset);
+        log(sym.bar);
+        log(sym.bar + "  " + a.dim + "Sessions created by other users will no longer be visible." + a.reset);
+        log(sym.bar + "  " + a.dim + "User accounts will be preserved and restored if re-enabled." + a.reset);
+        log(sym.bar);
+        promptSelect("Confirm", [
+          { label: "Disable multi-user mode", value: "confirm" },
+          { label: "Cancel", value: "cancel" },
+        ], function (confirmChoice) {
+          if (confirmChoice === "confirm") {
+            disableMultiUser();
+            log(sym.bar);
+            log(sym.done + "  " + a.green + "Multi-user mode disabled." + a.reset);
+            log(sym.bar + "  " + a.dim + "Restart the daemon for changes to take full effect." + a.reset);
+            log(sym.bar);
+          }
+          showSettingsMenu(config, ip);
+        });
         break;
 
       case "logs":
@@ -2456,7 +2468,12 @@ var currentVersion = require("../package.json").version;
       clearStaleConfig();
       await new Promise(function (resolve) { setTimeout(resolve, 500); });
     }
-    // First run — go through setup (disclaimer, port, PIN, etc.)
+    // No running daemon — clear config so setup runs fresh
+    if (!devAlive && devConfig) {
+      if (devConfig.pid) clearStaleConfig();
+      devConfig = null;
+    }
+    // No config — go through setup (disclaimer, port, PIN, etc.)
     if (!devConfig) {
       setup(function (pin, keepAwake) {
         devMode(pin, keepAwake, null);

--- a/lib/project.js
+++ b/lib/project.js
@@ -156,6 +156,15 @@ function createProjectContext(opts) {
     }
   }
 
+  function sendToSession(sessionId, obj) {
+    var data = JSON.stringify(obj);
+    for (var ws of clients) {
+      if (ws.readyState === 1 && ws._clayActiveSession === sessionId) {
+        ws.send(data);
+      }
+    }
+  }
+
   function sendToSessionOthers(sender, sessionId, obj) {
     var data = JSON.stringify(obj);
     for (var ws of clients) {
@@ -712,7 +721,7 @@ function createProjectContext(opts) {
     session.isProcessing = true;
     onProcessingChanged();
     session.sentToolResults = {};
-    send({ type: "status", status: "processing" });
+    sendToSession(session.localId, { type: "status", status: "processing" });
     session.acceptEditsAfterStart = true;
     session.singleTurn = true;
     sdk.startQuery(session, loopState.promptText);
@@ -1025,12 +1034,14 @@ function createProjectContext(opts) {
       });
     }
 
-    // Session list (filtered for multi-user)
+    // Session list (filtered for access control)
     var allSessions = [].concat(Array.from(sm.sessions.values())).filter(function (s) { return !s.hidden; });
     if (usersModule.isMultiUser() && wsUser) {
       allSessions = allSessions.filter(function (s) {
         return usersModule.canAccessSession(wsUser.id, s, { visibility: "public" });
       });
+    } else if (!usersModule.isMultiUser()) {
+      allSessions = allSessions.filter(function (s) { return !s.ownerId; });
     }
     sendTo(ws, {
       type: "session_list",
@@ -1057,11 +1068,22 @@ function createProjectContext(opts) {
       }),
     });
 
-    // Restore active session for this client (check access in multi-user mode)
+    // Restore active session for this client (check access)
     var active = sm.getActiveSession();
     if (active && usersModule.isMultiUser() && wsUser) {
       if (!usersModule.canAccessSession(wsUser.id, active, { visibility: "public" })) {
         active = null;
+      }
+    } else if (active && !usersModule.isMultiUser() && active.ownerId) {
+      active = null;
+    }
+    // Fallback: pick the most recent accessible session
+    if (!active && allSessions.length > 0) {
+      active = allSessions[0];
+      for (var fi = 1; fi < allSessions.length; fi++) {
+        if ((allSessions[fi].lastActivity || 0) > (active.lastActivity || 0)) {
+          active = allSessions[fi];
+        }
       }
     }
     if (active) {
@@ -1110,6 +1132,10 @@ function createProjectContext(opts) {
   }
 
   // --- WS message handler ---
+  function getSessionForWs(ws) {
+    return sm.sessions.get(ws._clayActiveSession) || null;
+  }
+
   function handleMessage(ws, msg) {
     if (msg.type === "push_subscribe") {
       if (pushModule && msg.subscription) pushModule.addSubscription(msg.subscription, msg.replaceEndpoint);
@@ -1117,7 +1143,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "load_more_history") {
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (!session || typeof msg.before !== "number") return;
       var before = msg.before;
       var from = sm.findTurnBoundary(session.history, Math.max(0, before - sm.HISTORY_PAGE_SIZE));
@@ -1135,9 +1161,9 @@ function createProjectContext(opts) {
       var sessionOpts = {};
       if (ws._clayUser) sessionOpts.ownerId = ws._clayUser.id;
       if (msg.sessionVisibility) sessionOpts.sessionVisibility = msg.sessionVisibility;
-      var newSess = sm.createSession(sessionOpts, usersModule.isMultiUser() ? ws : undefined);
+      var newSess = sm.createSession(sessionOpts, ws);
+      ws._clayActiveSession = newSess.localId;
       if (usersModule.isMultiUser()) {
-        ws._clayActiveSession = newSess.localId;
         broadcastPresence();
       }
       return;
@@ -1161,11 +1187,11 @@ function createProjectContext(opts) {
             break;
           }
         }
-        var _rws = usersModule.isMultiUser() ? ws : undefined;
-        sm.resumeSession(msg.cliSessionId, { history: history, title: title }, _rws);
+        var resumed = sm.resumeSession(msg.cliSessionId, { history: history, title: title }, ws);
+        if (resumed) ws._clayActiveSession = resumed.localId;
       }).catch(function () {
-        var _rws = usersModule.isMultiUser() ? ws : undefined;
-        sm.resumeSession(msg.cliSessionId, undefined, _rws);
+        var resumed = sm.resumeSession(msg.cliSessionId, undefined, ws);
+        if (resumed) ws._clayActiveSession = resumed.localId;
       });
       return;
     }
@@ -1210,7 +1236,8 @@ function createProjectContext(opts) {
           sm.switchSession(msg.id, ws);
           broadcastPresence();
         } else {
-          sm.switchSession(msg.id);
+          ws._clayActiveSession = msg.id;
+          sm.switchSession(msg.id, ws);
         }
       }
       return;
@@ -1218,7 +1245,7 @@ function createProjectContext(opts) {
 
     if (msg.type === "delete_session") {
       if (msg.id && sm.sessions.has(msg.id)) {
-        sm.deleteSession(msg.id, usersModule.isMultiUser() ? ws : undefined);
+        sm.deleteSession(msg.id, ws);
       }
       return;
     }
@@ -1285,7 +1312,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "stop") {
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (session && session.abortController && session.isProcessing) {
         session.abortController.abort();
       }
@@ -1306,22 +1333,22 @@ function createProjectContext(opts) {
       // Verify target is actually a claude process before killing
       if (!sdk.isClaudeProcess(pid)) {
         console.error("[project] Refused to kill PID " + pid + ": not a claude process");
-        send({ type: "error", text: "Process " + pid + " is not a Claude process." });
+        sendTo(ws, { type: "error", text: "Process " + pid + " is not a Claude process." });
         return;
       }
       try {
         process.kill(pid, "SIGTERM");
         console.log("[project] Sent SIGTERM to conflicting Claude process PID " + pid);
-        send({ type: "process_killed", pid: pid });
+        sendTo(ws, { type: "process_killed", pid: pid });
       } catch (e) {
         console.error("[project] Failed to kill PID " + pid + ":", e.message);
-        send({ type: "error", text: "Failed to kill process " + pid + ": " + (e.message || e) });
+        sendTo(ws, { type: "error", text: "Failed to kill process " + pid + ": " + (e.message || e) });
       }
       return;
     }
 
     if (msg.type === "set_model" && msg.model) {
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (session) {
         sdk.setModel(session, msg.model);
       }
@@ -1332,7 +1359,7 @@ function createProjectContext(opts) {
       if (typeof opts.onSetServerDefaultModel === "function") {
         opts.onSetServerDefaultModel(msg.model);
       }
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (session) {
         sdk.setModel(session, msg.model);
       }
@@ -1343,7 +1370,7 @@ function createProjectContext(opts) {
       if (typeof opts.onSetProjectDefaultModel === "function") {
         opts.onSetProjectDefaultModel(slug, msg.model);
       }
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (session) {
         sdk.setModel(session, msg.model);
       }
@@ -1357,7 +1384,7 @@ function createProjectContext(opts) {
         return;
       }
       sm.currentPermissionMode = msg.mode;
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (session) {
         sdk.setPermissionMode(session, msg.mode);
       }
@@ -1371,7 +1398,7 @@ function createProjectContext(opts) {
       }
       if (!dangerouslySkipPermissions) {
         sm.currentPermissionMode = msg.mode;
-        var session = sm.getActiveSession();
+        var session = getSessionForWs(ws);
         if (session) {
           sdk.setPermissionMode(session, msg.mode);
         }
@@ -1386,7 +1413,7 @@ function createProjectContext(opts) {
       }
       if (!dangerouslySkipPermissions) {
         sm.currentPermissionMode = msg.mode;
-        var session = sm.getActiveSession();
+        var session = getSessionForWs(ws);
         if (session) {
           sdk.setPermissionMode(session, msg.mode);
         }
@@ -1426,7 +1453,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "rewind_preview") {
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (!session || !session.cliSessionId || !msg.uuid) return;
 
       (async function () {
@@ -1455,7 +1482,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "rewind_execute") {
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (!session || !session.cliSessionId || !msg.uuid) return;
       var mode = msg.mode || "both";
 
@@ -1510,11 +1537,11 @@ function createProjectContext(opts) {
           onProcessingChanged();
 
           sm.saveSessionFile(session);
-          sm.switchSession(session.localId, usersModule.isMultiUser() ? ws : undefined);
+          sm.switchSession(session.localId, ws);
           sm.sendAndRecord(session, { type: "rewind_complete", mode: mode });
           sm.broadcastSessionList();
         } catch (err) {
-          send({ type: "rewind_error", text: "Rewind failed: " + err.message });
+          sendTo(ws, { type: "rewind_error", text: "Rewind failed: " + err.message });
         } finally {
           if (result && result.isTemp) result.cleanup();
         }
@@ -1523,7 +1550,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "ask_user_response") {
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (!session) return;
       var toolId = msg.toolId;
       var answers = msg.answers || {};
@@ -1544,7 +1571,7 @@ function createProjectContext(opts) {
     }
 
     if (msg.type === "permission_response") {
-      var session = sm.getActiveSession();
+      var session = getSessionForWs(ws);
       if (!session) return;
       var requestId = msg.requestId;
       var decision = msg.decision;
@@ -1612,17 +1639,17 @@ function createProjectContext(opts) {
             newSession.title = "Plan execution (cleared context)";
             sm.saveSessionFile(newSession);
             sm.broadcastSessionList();
-            send(userMsg);
+            sendToSession(newSession.localId, userMsg);
 
             newSession.isProcessing = true;
             onProcessingChanged();
             newSession.sentToolResults = {};
-            send({ type: "status", status: "processing" });
+            sendToSession(newSession.localId, { type: "status", status: "processing" });
             newSession.acceptEditsAfterStart = true;
             sdk.startQuery(newSession, planPrompt);
           } catch (e) {
             console.error("[project] Error starting plan execution:", e);
-            send({ type: "error", text: "Failed to start plan execution: " + (e.message || e) });
+            sendTo(ws, { type: "error", text: "Failed to start plan execution: " + (e.message || e) });
           }
         });
         return;
@@ -1640,13 +1667,13 @@ function createProjectContext(opts) {
             var userMsg = { type: "user_message", text: feedback };
             session.history.push(userMsg);
             sm.appendToSessionFile(session, userMsg);
-            send(userMsg);
+            sendToSession(session.localId, userMsg);
 
             if (!session.isProcessing) {
               session.isProcessing = true;
               onProcessingChanged();
               session.sentToolResults = {};
-              send({ type: "status", status: "processing" });
+              sendToSession(session.localId, { type: "status", status: "processing" });
               if (!session.queryInstance) {
                 sdk.startQuery(session, feedback);
               } else {
@@ -2415,11 +2442,11 @@ function createProjectContext(opts) {
       // Send crafting prompt and start the conversation with Claude.
       craftingSession.history.push({ type: "user_message", text: craftingPrompt });
       sm.appendToSessionFile(craftingSession, { type: "user_message", text: craftingPrompt });
-      send({ type: "user_message", text: craftingPrompt });
+      sendToSession(craftingSession.localId, { type: "user_message", text: craftingPrompt });
       craftingSession.isProcessing = true;
       onProcessingChanged();
       craftingSession.sentToolResults = {};
-      send({ type: "status", status: "processing" });
+      sendToSession(craftingSession.localId, { type: "status", status: "processing" });
       sdk.startQuery(craftingSession, craftingPrompt);
 
       send({ type: "ralph_crafting_started", sessionId: craftingSession.localId, taskId: newLoopId, source: recordSource });
@@ -2609,7 +2636,7 @@ function createProjectContext(opts) {
     if (msg.type !== "message") return;
     if (!msg.text && (!msg.images || msg.images.length === 0) && (!msg.pastes || msg.pastes.length === 0)) return;
 
-    var session = sm.getActiveSession();
+    var session = getSessionForWs(ws);
     if (!session) return;
 
     var userMsg = { type: "user_message", text: msg.text || "" };
@@ -2641,7 +2668,7 @@ function createProjectContext(opts) {
       session.isProcessing = true;
       onProcessingChanged();
       session.sentToolResults = {};
-      send({ type: "status", status: "processing" });
+      sendToSession(session.localId, { type: "status", status: "processing" });
       if (!session.queryInstance) {
         sdk.startQuery(session, fullText, msg.images);
       } else {

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -2659,9 +2659,10 @@ import { initAdmin, checkAdminAccess } from './modules/admin.js';
           // Non-multi-user mode: simple count in topbar
           if (!msg.users) {
             var countEl = document.getElementById("client-count");
-            if (countEl) {
+            var countTextEl = document.getElementById("client-count-text");
+            if (countEl && countTextEl) {
               if (msg.count > 1) {
-                countEl.textContent = msg.count;
+                countTextEl.textContent = msg.count + " connected";
                 countEl.classList.remove("hidden");
               } else {
                 countEl.classList.add("hidden");

--- a/lib/public/css/menus.css
+++ b/lib/public/css/menus.css
@@ -407,12 +407,9 @@
 .notif-action.copied { color: var(--success); }
 
 #client-count {
-  display: inline-flex;
-  align-items: center;
   cursor: default;
+  font-size: 11px;
 }
-
-#client-count.hidden { display: none; }
 
 .client-avatar {
   width: 22px;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -43,7 +43,7 @@
     <div class="top-bar-actions">
       <!-- Pill badges -->
       <div id="skip-perms-pill" class="top-bar-pill pill-error hidden"><i data-lucide="shield-off"></i> <span>Skip perms</span></div>
-      <span id="client-count" class="hidden"></span>
+      <div id="client-count" class="top-bar-pill pill-accent hidden"><i data-lucide="users"></i> <span id="client-count-text"></span></div>
       <label id="theme-toggle-btn" class="theme-toggle" title="Toggle dark/light mode">
         <input type="checkbox" id="theme-toggle-check">
         <span class="theme-toggle-track">

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -111,9 +111,7 @@ function createSDKBridge(opts) {
     if (parsed.session_id && !session.cliSessionId) {
       session.cliSessionId = parsed.session_id;
       sm.saveSessionFile(session);
-      if (session.localId === sm.activeSessionId) {
-        send({ type: "session_id", cliSessionId: session.cliSessionId });
-      }
+      sendAndRecord(session, { type: "session_id", cliSessionId: session.cliSessionId });
     } else if (parsed.session_id) {
       session.cliSessionId = parsed.session_id;
     }
@@ -704,7 +702,7 @@ function createSDKBridge(opts) {
     try {
       sdk = await getSDK();
     } catch (e) {
-      send({ type: "error", text: "Failed to load Claude SDK: " + (e.message || e) });
+      sendAndRecord(session, { type: "error", text: "Failed to load Claude SDK: " + (e.message || e) });
       throw e;
     }
     var mq = createMessageQueue();
@@ -738,7 +736,7 @@ function createSDKBridge(opts) {
     } catch (e) {
       session.isProcessing = false;
       onProcessingChanged();
-      send({ type: "error", text: "Failed to load Claude SDK: " + (e.message || e) });
+      sendAndRecord(session, { type: "error", text: "Failed to load Claude SDK: " + (e.message || e) });
       sendAndRecord(session, { type: "done", code: 1 });
       sm.broadcastSessionList();
       return;
@@ -831,7 +829,7 @@ function createSDKBridge(opts) {
       session.queryInstance = null;
       session.messageQueue = null;
       session.abortController = null;
-      send({ type: "error", text: "Failed to start query: " + (e.message || e) });
+      sendAndRecord(session, { type: "error", text: "Failed to start query: " + (e.message || e) });
       sendAndRecord(session, { type: "done", code: 1 });
       sm.broadcastSessionList();
       return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-server",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "Web UI for Claude Code. Any device. Push notifications.",
   "bin": {
     "clay-server": "./bin/cli.js",


### PR DESCRIPTION
## Summary

- Fix session message routing using per-connection `ws._clayActiveSession` instead of global `activeSessionId` to prevent cross-session message leaking (#206)
- Fix `send()` broadcasts leaking status, error, and user messages to unrelated sessions
- Fix SDK bridge broadcasting session-specific errors to all clients
- Add "Disable multi-user mode" option to settings menu with confirmation
- Filter sessions with `ownerId` on initial connection in single-user mode
- Fallback to most recent accessible session when active session is inaccessible
- Style client count as accent pill badge with users icon in topbar
- Fix dev mode skipping setup flow (consent, port, PIN) after shutdown

Closes #206

## Test plan

- [ ] Open 2+ browser tabs to same project in single-user mode
- [ ] Create multiple sessions, send messages in each
- [ ] Verify messages stay in their own session (no cross-session leaking)
- [ ] Verify session switching shows correct history
- [ ] Verify model responses route to correct session only
- [ ] Test disable multi-user mode from settings menu
- [ ] Test dev mode shutdown → restart shows setup flow
- [ ] Verify client count pill badge displays correctly