### PR TITLE
fix: preserve externally-provided TLS certificates

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -594,6 +594,8 @@ function ensureCerts(ip) {
     var needRegen = false;
     try {
       var certText = execFileSync("openssl", ["x509", "-in", certPath, "-text", "-noout"], { encoding: "utf8" });
+      // If cert is from an external CA (e.g. Tailscale/Let's Encrypt), never regenerate
+      if (certText.indexOf("mkcert") === -1) return { key: keyPath, cert: certPath, caRoot: caRoot };
       for (var i = 0; i < allIPs.length; i++) {
         if (certText.indexOf(allIPs[i]) === -1) {
           needRegen = true;


### PR DESCRIPTION
## Summary

- **Fixes #230** — `ensureCerts` overwrites external certificates (e.g. from `tailscale cert`) with self-signed mkcert certs on every daemon startup
- Adds a check to skip IP-completeness validation and mkcert regeneration when the existing cert was not issued by mkcert
- External certs (Tailscale, Let's Encrypt, etc.) are now left untouched

## Change

Single line addition in `ensureCerts()`:

```js
if (certText.indexOf("mkcert") === -1) return { key: keyPath, cert: certPath, caRoot: caRoot };
```

This early-returns before the IP SAN check when the cert issuer is not mkcert, preventing regeneration of externally-provided certificates.

## Test plan

- [ ] Provide an external cert (e.g. via `tailscale cert`) and verify it is preserved across daemon restarts
- [ ] Verify mkcert-generated certs still regenerate when IPs change
- [ ] Verify fresh installs with no existing cert still generate via mkcert

🤖 Generated with [Claude Code](https://claude.com/claude-code)