### PR TITLE
fix(scheduler): update existing event instead of creating duplicate on edit

### DIFF
--- a/lib/public/modules/scheduler.js
+++ b/lib/public/modules/scheduler.js
@@ -2725,22 +2725,41 @@ function submitCreateSchedule() {
       if (maxIterations > 100) maxIterations = 100;
     }
 
-    send({
-      type: "schedule_create",
-      data: {
-        name: name,
-        taskId: taskId,
-        description: description,
-        date: dateVal,
-        time: timeVal,
-        allDay: false,
-        cron: cron,
-        enabled: cron ? true : false,
-        color: createColor,
-        recurrenceEnd: recurrenceEnd,
-        maxIterations: maxIterations,
-      },
-    });
+    if (createEditingRecId) {
+      send({
+        type: "loop_registry_update",
+        id: createEditingRecId,
+        data: {
+          name: name,
+          description: description,
+          date: dateVal,
+          time: timeVal,
+          allDay: false,
+          cron: cron,
+          enabled: cron ? true : false,
+          color: createColor,
+          recurrenceEnd: recurrenceEnd,
+          maxIterations: maxIterations,
+        },
+      });
+    } else {
+      send({
+        type: "schedule_create",
+        data: {
+          name: name,
+          taskId: taskId,
+          description: description,
+          date: dateVal,
+          time: timeVal,
+          allDay: false,
+          cron: cron,
+          enabled: cron ? true : false,
+          color: createColor,
+          recurrenceEnd: recurrenceEnd,
+          maxIterations: maxIterations,
+        },
+      });
+    }
 
     closeCreateModal();
   });

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -291,9 +291,14 @@ function createLoopRegistry(opts) {
     if (data.enabled !== undefined) rec.enabled = data.enabled;
     if (data.maxIterations !== undefined) rec.maxIterations = data.maxIterations;
     if (data.date !== undefined) rec.date = data.date;
+    if (data.time !== undefined) rec.time = data.time;
     if (data.recurrenceEnd !== undefined) rec.recurrenceEnd = data.recurrenceEnd;
     if (data.mode !== undefined) rec.mode = data.mode;
     if (data.prompt !== undefined) rec.prompt = data.prompt;
+    if (data.description !== undefined) rec.description = data.description;
+    if (data.color !== undefined) rec.color = data.color;
+    if (data.allDay !== undefined) rec.allDay = data.allDay;
+    if (data.linkedTaskId !== undefined) rec.linkedTaskId = data.linkedTaskId;
     rec.updatedAt = Date.now();
     if (rec.cron && rec.enabled) {
       rec.nextRunAt = nextRunTime(rec.cron);


### PR DESCRIPTION
## Summary

- `submitCreateSchedule()` now checks `createEditingRecId` and sends `loop_registry_update` instead of `schedule_create` when editing an existing event
- Server-side `update()` extended to handle `time`, `description`, `color`, `allDay`, and `linkedTaskId` fields that were previously ignored

Fixes #237

## Test plan

- [ ] Create a recurring calendar event
- [ ] Edit the event (change time, recurrence, description, etc.)
- [ ] Verify the original event is updated in place, no duplicate created
- [ ] Verify creating new events still works as before