### PR TITLE
feat(scheduler): add minute and hour options to custom recurrence

### DIFF
--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -1673,6 +1673,8 @@
         <span class="sched-custom-label">Every</span>
         <input type="number" class="sched-custom-interval" id="sched-custom-interval" value="1" min="1" max="99">
         <select class="sched-field-select sched-custom-unit" id="sched-custom-unit">
+          <option value="minute">Minute</option>
+          <option value="hour">Hour</option>
           <option value="day">Day</option>
           <option value="week" selected>Week</option>
           <option value="month">Month</option>

--- a/lib/public/modules/scheduler.js
+++ b/lib/public/modules/scheduler.js
@@ -2656,6 +2656,16 @@ function buildCustomCron(h, m) {
   var interval = parseInt(document.getElementById("sched-custom-interval").value, 10) || 1;
   var unit = document.getElementById("sched-custom-unit").value;
 
+  if (unit === "minute") {
+    if (interval === 1) return "* * * * *";
+    return "*/" + interval + " * * * *";
+  }
+
+  if (unit === "hour") {
+    if (interval === 1) return m + " * * * *";
+    return m + " */" + interval + " * * *";
+  }
+
   if (unit === "day") {
     if (interval === 1) return m + " " + h + " * * *";
     return m + " " + h + " */" + interval + " * *";


### PR DESCRIPTION
## Summary

- Adds Minute and Hour options to the custom repeat unit dropdown
- Generates correct cron expressions for sub-day intervals (e.g. `*/30 * * * *` for every 30 minutes, `0 */2 * * *` for every 2 hours)
- Backend cron parser already supports these intervals, so this is a frontend-only change

Related to #235

## Test plan

- [ ] Open custom recurrence settings and verify Minute and Hour appear in the unit dropdown
- [ ] Set a minute interval (e.g. every 30 minutes) and verify the generated cron is correct
- [ ] Set an hour interval (e.g. every 2 hours) and verify the generated cron is correct
- [ ] Verify existing Day/Week/Month/Year options still work as before