### PR TITLE
fix(ws): reconnect WebSocket on mobile tab resume

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -1328,6 +1328,12 @@ function createProjectContext(opts) {
   }
 
   function handleMessage(ws, msg) {
+    // --- Ping/pong for connection liveness (mobile resume) ---
+    if (msg.type === "ping") {
+      sendTo(ws, { type: "pong" });
+      return;
+    }
+
     // --- DM messages (delegated to server-level handler) ---
     if (msg.type === "dm_open" || msg.type === "dm_send" || msg.type === "dm_list" || msg.type === "dm_typing" || msg.type === "dm_add_favorite" || msg.type === "dm_remove_favorite" || msg.type === "mate_create" || msg.type === "mate_list" || msg.type === "mate_delete" || msg.type === "mate_update") {
       if (typeof opts.onDmMessage === "function") {

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -1581,6 +1581,7 @@ import { initMention, handleMentionStart, handleMentionStream, handleMentionDone
   var reconnectDelay = 1000;
   var disconnectNotifTimer = null;
   var disconnectNotifShown = false;
+  var pongTimer = null;
   var activityEl = null;
   var currentMsgEl = null;
   var currentFullText = "";
@@ -4670,6 +4671,10 @@ import { initMention, handleMentionStart, handleMentionStream, handleMentionDone
           handleSetPinResult(msg);
           break;
 
+        case "pong":
+          if (pongTimer) { clearTimeout(pongTimer); pongTimer = null; }
+          break;
+
         case "set_keep_awake_result":
           handleKeepAwakeChanged(msg);
           break;
@@ -4950,6 +4955,40 @@ import { initMention, handleMentionStart, handleMentionStream, handleMentionDone
     }, reconnectDelay);
     reconnectDelay = Math.min(reconnectDelay * 1.5, 10000);
   }
+
+  // --- Reconnect on visibility/network change (mobile tab suspend) ---
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden) return;
+    // Tab became visible — check if WS is still alive
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      // Connection looks open; send a ping to verify it's not stale
+      try { ws.send(JSON.stringify({ type: "ping" })); } catch (e) {}
+      // If no pong within 3s, connection is stale — reconnect
+      if (pongTimer) clearTimeout(pongTimer);
+      pongTimer = setTimeout(function () {
+        pongTimer = null;
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.onclose = null;
+          ws.close();
+        }
+        if (!savedMainWs) connect();
+      }, 3000);
+      return;
+    }
+    // WS is closed or closing — reconnect immediately
+    if (savedMainWs) return; // don't touch main WS while in mate DM
+    reconnectDelay = 1000;
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    connect();
+  });
+
+  window.addEventListener("online", function () {
+    if (ws && ws.readyState === WebSocket.OPEN) return;
+    if (savedMainWs) return;
+    reconnectDelay = 1000;
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    connect();
+  });
 
   // --- Input module (sendMessage, autoResize, paste/image, slash menu, input handlers) ---
   initInput({


### PR DESCRIPTION
## Summary

On mobile (iOS Safari, Android Chrome), switching to another app suspends the browser tab and silently kills the WebSocket connection. When returning to Clay, the UI stays stuck on "disconnected" because:

1. The `ws.onclose` event often never fires after a mobile suspend — the OS just drops the TCP connection without a proper close handshake
2. There is no `visibilitychange` or `pageshow` listener to detect the tab becoming active again
3. There is no application-level heartbeat to detect stale connections that appear open but are actually dead

The only workaround is force-closing the browser and reopening Clay.

## Changes

- **`lib/public/app.js`**: Add `visibilitychange` listener that checks WebSocket health when the tab becomes visible. If the socket appears open, it sends an application-level `ping` and waits 3s for a `pong` — if none arrives, the connection is treated as stale and reconnected. If the socket is already closed, it reconnects immediately. Also adds an `online` event listener to reconnect when the browser regains network connectivity.
- **`lib/project.js`**: Add server-side `ping`/`pong` handler so the client can verify connection liveness.

## Test plan

- [ ] Open Clay on a mobile device (or simulate with desktop browser tab suspension)
- [ ] Switch to another app for 30+ seconds
- [ ] Switch back to Clay — should reconnect automatically within a few seconds
- [ ] Verify normal desktop usage is unaffected (no spurious reconnects)
- [ ] Test with mate DM mode active — main WS should not be disturbed during DM