### PR TITLE
fix(scheduler): allow "Run now" for loops without JUDGE.md

### DIFF
--- a/lib/public/modules/scheduler.js
+++ b/lib/public/modules/scheduler.js
@@ -1619,9 +1619,9 @@ export function handleLoopRegistryFiles(msg) {
   // Disable "Run now" if PROMPT.md or JUDGE.md is missing
   var runBtn = contentDetailEl ? contentDetailEl.querySelector('[data-action="run"]') : null;
   if (runBtn) {
-    var filesReady = !!msg.prompt && !!msg.judge;
+    var filesReady = !!msg.prompt;
     runBtn.disabled = !filesReady;
-    runBtn.title = filesReady ? "Run now" : "PROMPT.md and JUDGE.md are required to run";
+    runBtn.title = filesReady ? "Run now" : "PROMPT.md is required to run";
   }
 }
 


### PR DESCRIPTION
## Summary

- The scheduler UI required both PROMPT.md and JUDGE.md to enable the "Run now" button, but JUDGE.md is optional — single-iteration loops work fine without it
- The server-side `startLoop()` already handles this correctly; the UI validation was too strict
- Removed the sdk-bridge warmup change per maintainer feedback

## Test plan

- [ ] Create a loop with only PROMPT.md (no JUDGE.md) and verify "Run now" is enabled
- [ ] Create a loop with both PROMPT.md and JUDGE.md and verify "Run now" still works
- [ ] Verify loops without PROMPT.md still show "Run now" disabled