### PR TITLE
fix(sessions): prevent ownerId backfill from scrambling session dates

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -1288,8 +1288,8 @@ function createProjectContext(opts) {
       autoCreated = true;
     }
     if (active && !autoCreated) {
-      // Backfill ownerId for legacy sessions restored without one
-      if (!active.ownerId && wsUser) {
+      // Backfill ownerId for legacy sessions restored without one (multi-user only)
+      if (!active.ownerId && wsUser && usersModule.isMultiUser()) {
         active.ownerId = wsUser.id;
         sm.saveSessionFile(active);
       }
@@ -3483,8 +3483,8 @@ function createProjectContext(opts) {
     var session = getSessionForWs(ws);
     if (!session) return;
 
-    // Backfill ownerId for legacy sessions restored without one
-    if (!session.ownerId && ws._clayUser) {
+    // Backfill ownerId for legacy sessions restored without one (multi-user only)
+    if (!session.ownerId && ws._clayUser && usersModule.isMultiUser()) {
       session.ownerId = ws._clayUser.id;
       sm.saveSessionFile(session);
     }

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -76,7 +76,6 @@ function createSessionManager(opts) {
 
   function saveSessionFile(session) {
     if (!session.cliSessionId) return;
-    session.lastActivity = Date.now();
     try {
       var metaObj = {
         type: "meta",


### PR DESCRIPTION
## Summary

- In single-user mode, the synthetic `_single` user triggered ownerId backfill on each page refresh, calling `saveSessionFile` which bumped `lastActivity` to `Date.now()`. The backfilled session then became invisible (filtered by `!s.ownerId`), so the next refresh hit the next session — cascading through all sessions over multiple refreshes.
- Guard ownerId backfill with `isMultiUser()` so it never fires for the synthetic `_single` user
- Remove unconditional `lastActivity = Date.now()` from `saveSessionFile` so metadata-only saves (renames, debate state, owner backfill) don't scramble sort order. `appendToSessionFile` still bumps it on real activity.

## Test plan

- [ ] Open Clay in single-user mode with existing sessions
- [ ] Verify sessions retain their original order after multiple page refreshes
- [ ] Verify no sessions get tagged with `_single` ownerId
- [ ] Verify `lastActivity` only updates when actual messages are sent, not on metadata saves (rename, debate state)
- [ ] Verify ownerId backfill still works correctly in multi-user mode