### PR TITLE
fix(sessions): run SDK title migration only once per project

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -628,13 +628,18 @@ function createSessionManager(opts) {
   }
 
   function migrateSessionTitles(getSDK, migrateCwd) {
+    var markerPath = path.join(sessionsDir, ".sdk-titles-migrated");
+    try { fs.accessSync(markerPath); return; } catch (e) {}
     var toMigrate = [];
     sessions.forEach(function(s) {
       if (s.cliSessionId && s.title && s.title !== "New Session" && s.title !== "Resumed session") {
         toMigrate.push({ cliSessionId: s.cliSessionId, title: s.title });
       }
     });
-    if (toMigrate.length === 0) return;
+    if (toMigrate.length === 0) {
+      try { fs.writeFileSync(markerPath, ""); } catch (e) {}
+      return;
+    }
     getSDK().then(function(sdkMod) {
       var chain = Promise.resolve();
       for (var i = 0; i < toMigrate.length; i++) {
@@ -648,6 +653,7 @@ function createSessionManager(opts) {
       }
       chain.then(function() {
         console.log("[session] Migrated " + toMigrate.length + " session title(s) to SDK format");
+        try { fs.writeFileSync(markerPath, ""); } catch (e) {}
       }).catch(function(e) {
         console.error("[session] Migration chain failed:", e.message || e);
       });


### PR DESCRIPTION
## Summary
- `migrateSessionTitles` calls `renameSession` on every titled session on every daemon restart, rewriting SDK `.jsonl` files and resetting their mtime
- Claude CLI uses mtime to show "last active" — so every restart makes all sessions appear recently active
- Fix: add a `.sdk-titles-migrated` marker file so the migration only runs once

## Test plan
- [ ] Start daemon fresh (no marker file) — migration runs once, marker created
- [ ] Restart daemon — migration skipped, session mtimes untouched
- [ ] Create a new session with a title, restart — new session gets migrated (marker deleted or new sessions detected)