### PR TITLE
fix: preserve daemon.json TLS settings and user island name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,3 +7,4 @@
 - All user-facing messages, code comments, and commit messages must be in English only.
 - Commit messages must follow Angular Commit Convention (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `perf:`, `test:`, `style:`, `ci:`, `build:`). Use `!` or `BREAKING CHANGE:` footer for breaking changes. Always use the `angular-commit` skill when committing.
 - Never use browser-native `alert()`, `confirm()`, or `prompt()`. Always use custom JS dialogs/modals instead.
+- When rebuilding daemon config (e.g. `restartDaemonFromConfig()`), always use `Object.assign({}, lastConfig, overrides)` to preserve all existing settings. Never reconstruct config by manually listing fields.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -443,20 +443,13 @@ async function restartDaemonFromConfig() {
   }
 
   // Rebuild config (preserve everything except pid)
-  var newConfig = {
+  var newConfig = Object.assign({}, lastConfig, {
     pid: null,
     port: targetPort,
-    pinHash: lastConfig.pinHash || null,
-    tls: lastConfig.tls !== undefined ? lastConfig.tls : useHttps,
-    debug: lastConfig.debug || false,
-    keepAwake: lastConfig.keepAwake || false,
-    dangerouslySkipPermissions: lastConfig.dangerouslySkipPermissions || false,
-    osUsers: lastConfig.osUsers || false,
     projects: (lastConfig.projects || []).filter(function (p) {
       return fs.existsSync(p.path);
-    }),
-    removedProjects: lastConfig.removedProjects || [],
-  };
+    })
+  });
 
   ensureConfigDir();
   saveConfig(newConfig);

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -727,7 +727,7 @@
     <div class="user-island-profile">
       <div class="user-island-avatar"><span class="user-island-avatar-letter">?</span></div>
       <div class="user-island-info">
-        <span class="user-island-name">Awesome Clay User</span>
+        <span class="user-island-name"></span>
         <span class="user-island-cta hidden">Personalize your name</span>
       </div>
     </div>

--- a/lib/public/modules/profile.js
+++ b/lib/public/modules/profile.js
@@ -64,7 +64,10 @@ export function debouncedSave() {
 export function applyToIsland() {
   var avatarWrap = document.querySelector('.user-island-avatar');
   var nameEl = document.querySelector('.user-island-name');
-  if (!avatarWrap || !nameEl) return;
+  if (!avatarWrap || !nameEl) {
+    requestAnimationFrame(applyToIsland);
+    return;
+  }
 
   var displayName = profile.name || 'Awesome Clay User';
 


### PR DESCRIPTION
## Summary
- **#259**: `restartDaemonFromConfig()` was manually listing config fields, dropping `tls` and `builtinCert` on auto-upgrade. Replaced with `Object.assign()` to preserve all existing settings.
- **#260**: Removed hardcoded "Awesome Clay User" placeholder from index.html and added `requestAnimationFrame` retry in `applyToIsland()` for DOM timing safety.

## Test plan
- [ ] Set `tls: false, builtinCert: false` in daemon.json, trigger auto-upgrade, verify settings are preserved
- [ ] Load page and confirm saved profile name appears in user island (not "Awesome Clay User")
- [ ] Verify reverse proxy (Caddy/nginx) deployments survive daemon restart

Fixes #259, Fixes #260