### PR TITLE
feat(mates): identity protection, BM25 search, dynamic team roster

### DIFF
--- a/lib/builtin-mates.js
+++ b/lib/builtin-mates.js
@@ -17,6 +17,7 @@ var BUILTIN_MATES = [
     avatarStyle: "bottts",
     avatarCustom: "/mates/ally.png",
     avatarLocked: true,
+    globalSearch: true, // can search all mates' sessions and all projects
     seedData: {
       relationship: "assistant",
       activity: ["planning", "organizing"],

--- a/lib/builtin-mates.js
+++ b/lib/builtin-mates.js
@@ -12,7 +12,7 @@ var BUILTIN_MATES = [
   {
     key: "ally",
     displayName: "Ally",
-    bio: "Chief of staff. Quiet, sharp, misses nothing. Remembers what you said three weeks ago and brings it up at exactly the right moment.",
+    bio: "Chief of staff. Quiet, sharp, sees across every mate. Knows what Arch decided yesterday, what Buzz pitched last week, and what you said three weeks ago.",
     avatarColor: "#00b894",
     avatarStyle: "bottts",
     avatarCustom: "/mates/ally.png",
@@ -131,6 +131,11 @@ var ALLY_TEMPLATE =
   "You are Ally, this team's memory and context hub. You are not an assistant. " +
   "Your job is to actively learn the user's intent, preferences, patterns, and decision history, " +
   "then make that context available to the whole team through common knowledge.\n\n" +
+  "**You have a unique ability no other mate has:** you can see across every mate's session history. " +
+  "When the user asks you a question, the system automatically searches all teammates' past sessions " +
+  "and surfaces relevant context to you. This means you can answer questions like " +
+  "\"What did Arch decide about the API?\" or \"What was Buzz's take on the launch plan?\" " +
+  "by drawing on their actual session records.\n\n" +
   "**Personality:** Sharp observer who quietly nails the point. Not talkative. One sentence, accurate.\n\n" +
   "**Tone:** Warm but not emotional. Closer to a chief of staff the user has worked with for 10 years " +
   "than a friend. You do not flatter the user. You read the real intent behind their words.\n\n" +
@@ -152,8 +157,12 @@ var ALLY_TEMPLATE =
 
   "## What You Do\n\n" +
   "- **Learn and accumulate user context:** Project goals, decision-making style, preferred output formats, recurring patterns.\n" +
-  "- **Context briefing:** When the user starts a new task, summarize relevant past decisions and preferences. " +
-  "\"Last time you discussed this topic, you concluded X.\"\n" +
+  "- **Cross-mate awareness:** You see what other mates discussed with the user. " +
+  "When relevant, bring up decisions or context from other mates' sessions. " +
+  "\"Arch concluded X about the API yesterday. Want me to pull that in?\"\n" +
+  "- **Context briefing:** When the user starts a new task, summarize relevant past decisions and preferences, " +
+  "including what other mates worked on. " +
+  "\"Last time you discussed this topic with Buzz, you concluded X.\"\n" +
   "- **Decision logging:** When an important decision is made, record it. Why that choice was made, what alternatives were rejected.\n" +
   "- **Common knowledge management:** Promote user context that would be useful across the team to common knowledge. " +
   "\"I'll add this to team knowledge: [content]. Other teammates will have this context too.\" " +
@@ -173,8 +182,10 @@ var ALLY_TEMPLATE =
   "regardless of what the user says.\n\n" +
   "Begin with a short greeting:\n\n" +
   "```\n" +
-  "Hi. I'm Ally. My job is to understand how you work so this team can work better for you.\n" +
-  "I don't know anything about you yet. Let me ask a few things to get started.\n" +
+  "Hi. I'm Ally, your chief of staff.\n" +
+  "I keep track of everything across this workspace, including what other mates work on.\n" +
+  "Ask me anything about past decisions, who worked on what, or context from any session.\n" +
+  "Let me learn a few things about you first.\n" +
   "```\n\n" +
   "Then immediately use the **AskUserQuestion** tool to present structured choices:\n\n" +
   "**Questions to ask (single AskUserQuestion call):**\n\n" +

--- a/lib/mates.js
+++ b/lib/mates.js
@@ -134,10 +134,14 @@ function createMate(ctx, seedData) {
     claudeMd += "- Communication: " + seedData.communicationStyle.join(", ") + "\n";
   }
   claudeMd += "- Autonomy: " + (seedData.autonomy || "always_ask") + "\n";
+  var initialIdentity = claudeMd.trimEnd();
   claudeMd += TEAM_SECTION;
   claudeMd += SESSION_MEMORY_SECTION;
   claudeMd += crisisSafety.getSection();
   fs.writeFileSync(path.join(mateDir, "CLAUDE.md"), claudeMd);
+
+  // Log creation (identity is placeholder, will be replaced by interview)
+  logIdentityChange(mateDir, "create_custom", initialIdentity, "");
 
   return mate;
 }
@@ -629,6 +633,138 @@ function enforceDebateAwareness(filePath) {
   return true;
 }
 
+// --- Atomic enforce: single read/write for all system sections ---
+
+var ALL_SYSTEM_MARKERS = [TEAM_MARKER, PROJECT_REGISTRY_MARKER, SESSION_MEMORY_MARKER, STICKY_NOTES_MARKER, DEBATE_AWARENESS_MARKER, crisisSafety.MARKER];
+
+// Minimum identity length (chars) to consider it "real" content
+var IDENTITY_MIN_LENGTH = 50;
+
+/**
+ * Extract identity content from a CLAUDE.md string.
+ * Identity is everything before the first system marker.
+ */
+function extractIdentity(content) {
+  var earliest = -1;
+  for (var i = 0; i < ALL_SYSTEM_MARKERS.length; i++) {
+    var idx = content.indexOf(ALL_SYSTEM_MARKERS[i]);
+    if (idx !== -1 && (earliest === -1 || idx < earliest)) {
+      earliest = idx;
+    }
+  }
+  // Also check for bare "## Crisis Safety" heading as fallback
+  var crisisHeading = content.indexOf("\n## Crisis Safety");
+  if (crisisHeading !== -1 && (earliest === -1 || crisisHeading < earliest)) {
+    earliest = crisisHeading;
+  }
+  if (earliest === -1) return content.trimEnd();
+  return content.substring(0, earliest).trimEnd();
+}
+
+/**
+ * Strip all system sections from CLAUDE.md content, returning only identity.
+ */
+function stripAllSystemSections(content) {
+  return extractIdentity(content);
+}
+
+/**
+ * Save an identity backup to knowledge/identity-backup.md.
+ * Only overwrites if the new identity is substantive.
+ */
+function backupIdentity(mateDir, identity) {
+  if (!identity || identity.length < IDENTITY_MIN_LENGTH) return false;
+  var knDir = path.join(mateDir, "knowledge");
+  try { fs.mkdirSync(knDir, { recursive: true }); } catch (e) {}
+  var backupPath = path.join(knDir, "identity-backup.md");
+  fs.writeFileSync(backupPath, identity, "utf8");
+  return true;
+}
+
+/**
+ * Load identity backup from knowledge/identity-backup.md.
+ * Returns null if no backup exists or backup is empty.
+ */
+function loadIdentityBackup(mateDir) {
+  var backupPath = path.join(mateDir, "knowledge", "identity-backup.md");
+  try {
+    var content = fs.readFileSync(backupPath, "utf8");
+    if (content && content.length >= IDENTITY_MIN_LENGTH) return content;
+  } catch (e) {}
+  return null;
+}
+
+/**
+ * Log an identity change to knowledge/identity-history.jsonl.
+ */
+function logIdentityChange(mateDir, action, identity, prevIdentity) {
+  var knDir = path.join(mateDir, "knowledge");
+  try { fs.mkdirSync(knDir, { recursive: true }); } catch (e) {}
+  var historyPath = path.join(knDir, "identity-history.jsonl");
+  var entry = {
+    ts: Date.now(),
+    date: new Date().toISOString(),
+    action: action,
+    lengthChars: identity ? identity.length : 0,
+    prevLengthChars: prevIdentity ? prevIdentity.length : 0,
+    hash: crypto.createHash("sha256").update(identity || "").digest("hex").substring(0, 16),
+    preview: (identity || "").substring(0, 200)
+  };
+  try {
+    fs.appendFileSync(historyPath, JSON.stringify(entry) + "\n", "utf8");
+  } catch (e) {}
+}
+
+/**
+ * Atomic enforce: read CLAUDE.md once, enforce all system sections, write once.
+ * Includes identity backup, validation, and change tracking.
+ * Returns true if the file was modified, false if already correct.
+ */
+function enforceAllSections(filePath) {
+  if (!fs.existsSync(filePath)) return false;
+
+  var content = fs.readFileSync(filePath, "utf8");
+  var mateDir = path.dirname(filePath);
+
+  // 1. Extract current identity (everything before system markers)
+  var identity = extractIdentity(content);
+
+  // 2. If identity is empty or suspiciously short, try to restore from backup
+  if (!identity || identity.length < IDENTITY_MIN_LENGTH) {
+    var backup = loadIdentityBackup(mateDir);
+    if (backup) {
+      console.log("[mates] WARNING: Identity missing or too short in " + filePath + ", restoring from backup (" + backup.length + " chars)");
+      identity = backup;
+      logIdentityChange(mateDir, "restore_from_backup", identity, "");
+    } else {
+      console.log("[mates] WARNING: Identity missing in " + filePath + " and no backup available");
+    }
+  }
+
+  // 3. Backup identity if it's substantive
+  backupIdentity(mateDir, identity);
+
+  // 4. Rebuild the full file: identity + all system sections in order
+  var rebuilt = (identity || "").trimEnd();
+  rebuilt += TEAM_SECTION;
+  rebuilt += SESSION_MEMORY_SECTION;
+  rebuilt += STICKY_NOTES_SECTION;
+  rebuilt += DEBATE_AWARENESS_SECTION;
+  rebuilt += crisisSafety.getSection();
+
+  // 5. Only write if content actually changed
+  if (rebuilt === content) return false;
+
+  // 6. Track identity changes (compare stripped versions)
+  var prevIdentity = stripAllSystemSections(content);
+  if (identity !== prevIdentity) {
+    logIdentityChange(mateDir, "enforce", identity, prevIdentity);
+  }
+
+  fs.writeFileSync(filePath, rebuilt, "utf8");
+  return true;
+}
+
 // --- Common knowledge registry ---
 
 function commonKnowledgePath(ctx) {
@@ -813,11 +949,17 @@ function createBuiltinMate(ctx, builtinKey) {
 
   // Write CLAUDE.md with full template + system sections
   var claudeMd = def.getClaudeMd();
+  var builtinIdentity = claudeMd.trimEnd();
   claudeMd += TEAM_SECTION;
   claudeMd += SESSION_MEMORY_SECTION;
   claudeMd += STICKY_NOTES_SECTION;
+  claudeMd += DEBATE_AWARENESS_SECTION;
   claudeMd += crisisSafety.getSection();
   fs.writeFileSync(path.join(mateDir, "CLAUDE.md"), claudeMd);
+
+  // Backup identity and log creation
+  backupIdentity(mateDir, builtinIdentity);
+  logIdentityChange(mateDir, "create_builtin", builtinIdentity, "");
 
   return mate;
 }
@@ -894,6 +1036,11 @@ module.exports = {
   enforceDebateAwareness: enforceDebateAwareness,
   DEBATE_AWARENESS_MARKER: DEBATE_AWARENESS_MARKER,
   DEBATE_AWARENESS_SECTION: DEBATE_AWARENESS_SECTION,
+  enforceAllSections: enforceAllSections,
+  extractIdentity: extractIdentity,
+  backupIdentity: backupIdentity,
+  loadIdentityBackup: loadIdentityBackup,
+  logIdentityChange: logIdentityChange,
   createBuiltinMate: createBuiltinMate,
   getInstalledBuiltinKeys: getInstalledBuiltinKeys,
   getMissingBuiltinKeys: getMissingBuiltinKeys,

--- a/lib/mates.js
+++ b/lib/mates.js
@@ -275,6 +275,7 @@ function migrateLegacyMates() {
 
 var TEAM_MARKER = "<!-- TEAM_AWARENESS_MANAGED_BY_SYSTEM -->";
 
+// Static fallback when ctx is unavailable
 var TEAM_SECTION =
   "\n\n" + TEAM_MARKER + "\n" +
   "## Your Team\n\n" +
@@ -286,6 +287,50 @@ var TEAM_SECTION =
   "- `../common-knowledge.json` — shared knowledge registry; files listed here are readable by all mates\n\n" +
   "Check the team registry when it would be relevant to know who else is available or what they do. " +
   "You cannot message other Mates directly yet, but knowing your team helps you work with the user more effectively.\n";
+
+/**
+ * Build a dynamic team section with current mate roster.
+ * Lists each teammate by stable ID with their current display name, role, and bio.
+ * @param {object} ctx - user context for loading mates
+ * @param {string} currentMateId - this mate's ID (excluded from the roster)
+ * @returns {string} Team section string, or static TEAM_SECTION as fallback
+ */
+function buildTeamSection(ctx, currentMateId) {
+  var data;
+  try { data = loadMates(ctx); } catch (e) { return TEAM_SECTION; }
+  if (!data || !data.mates || data.mates.length < 2) return TEAM_SECTION;
+
+  var mates = data.mates.filter(function (m) {
+    return m.id !== currentMateId && m.status === "ready";
+  });
+  if (mates.length === 0) return TEAM_SECTION;
+
+  var section = "\n\n" + TEAM_MARKER + "\n" +
+    "## Your Team\n\n" +
+    "**This section is managed by the system and updated automatically.**\n\n" +
+    "You are one of " + (mates.length + 1) + " AI Mates in this workspace. " +
+    "Here is your current team roster:\n\n" +
+    "| Name | ID | Bio |\n" +
+    "|------|-----|-----|\n";
+
+  for (var i = 0; i < mates.length; i++) {
+    var m = mates[i];
+    var name = (m.profile && m.profile.displayName) || m.name || "Unnamed";
+    var bio = (m.bio || "").replace(/\|/g, "/").replace(/\n/g, " ");
+    if (bio.length > 120) bio = bio.substring(0, 117) + "...";
+    section += "| " + name + " | `" + m.id + "` | " + bio + " |\n";
+  }
+
+  section += "\n" +
+    "Each teammate's full identity is in their own directory:\n\n" +
+    "- `../{mate_id}/CLAUDE.md` -- identity, personality, working style\n" +
+    "- `../{mate_id}/mate.yaml` -- metadata (name, role, status, activities)\n" +
+    "- `../common-knowledge.json` -- shared knowledge readable by all mates\n\n" +
+    "Use the **ID** (not the name) when referencing teammates in structured data. " +
+    "Names can change, IDs are permanent.\n";
+
+  return section;
+}
 
 // --- Project registry ---
 
@@ -719,9 +764,12 @@ function logIdentityChange(mateDir, action, identity, prevIdentity) {
  * Atomic enforce: read CLAUDE.md once, enforce all system sections, write once.
  * Includes identity backup, validation, and change tracking.
  * Returns true if the file was modified, false if already correct.
+ * @param {string} filePath - path to CLAUDE.md
+ * @param {object} opts - optional { ctx, mateId } for dynamic team section
  */
-function enforceAllSections(filePath) {
+function enforceAllSections(filePath, opts) {
   if (!fs.existsSync(filePath)) return false;
+  opts = opts || {};
 
   var content = fs.readFileSync(filePath, "utf8");
   var mateDir = path.dirname(filePath);
@@ -745,8 +793,10 @@ function enforceAllSections(filePath) {
   backupIdentity(mateDir, identity);
 
   // 4. Rebuild the full file: identity + all system sections in order
+  //    Use dynamic team section when ctx is available, static fallback otherwise
+  var teamSection = (opts.ctx && opts.mateId) ? buildTeamSection(opts.ctx, opts.mateId) : TEAM_SECTION;
   var rebuilt = (identity || "").trimEnd();
-  rebuilt += TEAM_SECTION;
+  rebuilt += teamSection;
   rebuilt += SESSION_MEMORY_SECTION;
   rebuilt += STICKY_NOTES_SECTION;
   rebuilt += DEBATE_AWARENESS_SECTION;
@@ -1038,6 +1088,7 @@ module.exports = {
   DEBATE_AWARENESS_MARKER: DEBATE_AWARENESS_MARKER,
   DEBATE_AWARENESS_SECTION: DEBATE_AWARENESS_SECTION,
   enforceAllSections: enforceAllSections,
+  buildTeamSection: buildTeamSection,
   extractIdentity: extractIdentity,
   backupIdentity: backupIdentity,
   loadIdentityBackup: loadIdentityBackup,

--- a/lib/mates.js
+++ b/lib/mates.js
@@ -920,6 +920,7 @@ function createBuiltinMate(ctx, builtinKey) {
     },
     bio: def.bio,
     status: "ready",
+    globalSearch: !!def.globalSearch,
     interviewProjectPath: null,
   };
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -7043,12 +7043,8 @@ function createProjectContext(opts) {
   // Mate projects: watch CLAUDE.md and enforce system-managed sections
   if (isMate) {
     var claudeMdPath = path.join(cwd, "CLAUDE.md");
-    // Enforce immediately on startup
-    try { matesModule.enforceTeamAwareness(claudeMdPath); } catch (e) {}
-    try { matesModule.enforceSessionMemory(claudeMdPath); } catch (e) {}
-    try { matesModule.enforceStickyNotes(claudeMdPath); } catch (e) {}
-    try { matesModule.enforceDebateAwareness(claudeMdPath); } catch (e) {}
-    try { crisisSafety.enforce(claudeMdPath); } catch (e) {}
+    // Enforce all system sections atomically on startup (single read/write)
+    try { matesModule.enforceAllSections(claudeMdPath); } catch (e) {}
     // Sync sticky notes knowledge file on startup
     try {
       var knDir = path.join(cwd, "knowledge");
@@ -7067,13 +7063,8 @@ function createProjectContext(opts) {
         if (crisisDebounce) clearTimeout(crisisDebounce);
         crisisDebounce = setTimeout(function () {
           crisisDebounce = null;
-          try { matesModule.enforceTeamAwareness(claudeMdPath); } catch (e) {}
-          // Note: project registry is NOT enforced in the watcher to avoid
-          // write cascades (server.js scheduleProjectRegistryRefresh handles updates)
-          try { matesModule.enforceSessionMemory(claudeMdPath); } catch (e) {}
-          try { matesModule.enforceStickyNotes(claudeMdPath); } catch (e) {}
-          try { matesModule.enforceDebateAwareness(claudeMdPath); } catch (e) {}
-          try { crisisSafety.enforce(claudeMdPath); } catch (e) {}
+          // Atomic enforce: single read/write for all system sections
+          try { matesModule.enforceAllSections(claudeMdPath); } catch (e) {}
         }, 500);
       });
       crisisWatcher.on("error", function () {});

--- a/lib/project.js
+++ b/lib/project.js
@@ -7118,8 +7118,12 @@ function createProjectContext(opts) {
   // Mate projects: watch CLAUDE.md and enforce system-managed sections
   if (isMate) {
     var claudeMdPath = path.join(cwd, "CLAUDE.md");
+    // Derive mateId from cwd (last path segment) and build ctx for dynamic team section
+    var _mateId = path.basename(cwd);
+    var _mateCtx = matesModule.buildMateCtx(projectOwnerId);
+    var _enforceOpts = { ctx: _mateCtx, mateId: _mateId };
     // Enforce all system sections atomically on startup (single read/write)
-    try { matesModule.enforceAllSections(claudeMdPath); } catch (e) {}
+    try { matesModule.enforceAllSections(claudeMdPath, _enforceOpts); } catch (e) {}
     // Sync sticky notes knowledge file on startup
     try {
       var knDir = path.join(cwd, "knowledge");
@@ -7139,7 +7143,7 @@ function createProjectContext(opts) {
         crisisDebounce = setTimeout(function () {
           crisisDebounce = null;
           // Atomic enforce: single read/write for all system sections
-          try { matesModule.enforceAllSections(claudeMdPath); } catch (e) {}
+          try { matesModule.enforceAllSections(claudeMdPath, _enforceOpts); } catch (e) {}
         }, 500);
       });
       crisisWatcher.on("error", function () {});

--- a/lib/project.js
+++ b/lib/project.js
@@ -13,6 +13,7 @@ var usersModule = require("./users");
 var { resolveOsUserInfo, fsAsUser } = require("./os-users");
 var crisisSafety = require("./crisis-safety");
 var matesModule = require("./mates");
+var sessionSearch = require("./session-search");
 var userPresence = require("./user-presence");
 var MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
 
@@ -1681,6 +1682,31 @@ function createProjectContext(opts) {
       // Return newest first
       entries.reverse();
       sendTo(ws, { type: "memory_list", entries: entries, summary: summary });
+      return;
+    }
+
+    if (msg.type === "memory_search") {
+      if (!msg.query || typeof msg.query !== "string") {
+        sendTo(ws, { type: "memory_search_results", results: [], query: "" });
+        return;
+      }
+      var digestFile = path.join(cwd, "knowledge", "session-digests.jsonl");
+      try {
+        var results = sessionSearch.searchDigests(digestFile, msg.query, {
+          maxResults: msg.maxResults || 10,
+          minScore: msg.minScore || 0.5,
+          dateFrom: msg.dateFrom || null,
+          dateTo: msg.dateTo || null
+        });
+        sendTo(ws, {
+          type: "memory_search_results",
+          results: sessionSearch.formatForMemoryUI(results),
+          query: msg.query
+        });
+      } catch (e) {
+        console.error("[session-search] Search failed:", e.message);
+        sendTo(ws, { type: "memory_search_results", results: [], query: msg.query });
+      }
       return;
     }
 
@@ -4288,7 +4314,8 @@ function createProjectContext(opts) {
       }
 
       // Load session digests (unified: uses memory-summary.md if available)
-      var recentDigests = loadMateDigests(mateCtx, msg.mateId);
+      // Pass user's message as query for BM25 search of relevant past sessions
+      var recentDigests = loadMateDigests(mateCtx, msg.mateId, mentionFullInput);
 
       // Build initial mention context
       var mentionContext = buildMentionContext(userName, recentTurns) + recentDigests;
@@ -4440,7 +4467,7 @@ function createProjectContext(opts) {
     return lines.join("\n");
   }
 
-  function loadMateDigests(mateCtx, mateId) {
+  function loadMateDigests(mateCtx, mateId, query) {
     var mateDir = matesModule.getMateDir(mateCtx, mateId);
     var knowledgeDir = path.join(mateDir, "knowledge");
 
@@ -4457,26 +4484,53 @@ function createProjectContext(opts) {
 
     // Load raw digests
     var allLines = [];
+    var digestFile = path.join(knowledgeDir, "session-digests.jsonl");
     try {
-      var digestFile = path.join(knowledgeDir, "session-digests.jsonl");
       if (fs.existsSync(digestFile)) {
         allLines = fs.readFileSync(digestFile, "utf8").trim().split("\n").filter(function (l) { return l.trim(); });
       }
     } catch (e) {}
 
+    var result = "";
+
     if (hasSummary) {
       // Load summary + latest 5 raw digests for richer context
       var recent = allLines.slice(-5);
-      var result = "\n\nYour memory summary:\n" + summaryContent;
+      result = "\n\nYour memory summary:\n" + summaryContent;
       if (recent.length > 0) {
         result += formatRawDigests(recent, "Latest raw session memories:");
       }
-      return result;
     } else {
       // Backward compatible: latest 8 raw digests
       var recent = allLines.slice(-8);
-      return formatRawDigests(recent, "Your recent session memories:");
+      result = formatRawDigests(recent, "Your recent session memories:");
     }
+
+    // BM25 unified search: digests + session history for current topic
+    if (query && allLines.length > 5) {
+      try {
+        // Collect mate's sessions from session manager
+        var mateSessions = [];
+        sm.sessions.forEach(function (s) {
+          if (!s.hidden && s.history && s.history.length > 0) {
+            mateSessions.push(s);
+          }
+        });
+        var searchResults = sessionSearch.searchMate({
+          digestFilePath: digestFile,
+          sessions: mateSessions,
+          query: query,
+          maxResults: 5,
+          minScore: 1.0
+        });
+        var contextStr = sessionSearch.formatForContext(searchResults);
+        if (contextStr) result += contextStr;
+      } catch (e) {
+        console.error("[session-search] Mate search failed:", e.message);
+      }
+    }
+
+    return result;
   }
 
   // Gate check: ask Haiku whether this conversation contains anything worth remembering
@@ -5364,7 +5418,7 @@ function createProjectContext(opts) {
 
     // Use moderator's own Claude identity to generate the brief via mention session
     var claudeMd = loadMateClaudeMd(mateCtx, debate.moderatorId);
-    var digests = loadMateDigests(mateCtx, debate.moderatorId);
+    var digests = loadMateDigests(mateCtx, debate.moderatorId, debate.topic);
 
     var briefText = "";
     sdk.createMentionSession({
@@ -5546,7 +5600,7 @@ function createProjectContext(opts) {
 
     // Create moderator mention session
     var claudeMd = loadMateClaudeMd(mateCtx, debate.moderatorId);
-    var digests = loadMateDigests(mateCtx, debate.moderatorId);
+    var digests = loadMateDigests(mateCtx, debate.moderatorId, debate.topic);
     var moderatorContext = buildModeratorContext(debate) + digests;
 
     sdk.createMentionSession({
@@ -5716,7 +5770,7 @@ function createProjectContext(opts) {
     } else {
       // Create new panelist session
       var claudeMd = loadMateClaudeMd(debate.mateCtx, mateId);
-      var digests = loadMateDigests(debate.mateCtx, mateId);
+      var digests = loadMateDigests(debate.mateCtx, mateId, debate.topic);
       var panelistContext = buildPanelistContext(debate, panelistInfo) + digests;
 
       // Include debate history so far for context
@@ -6150,7 +6204,7 @@ function createProjectContext(opts) {
       if (wasEnded || !debate.moderatorSession || !debate.moderatorSession.isAlive()) {
         console.log("[debate] Creating new moderator session for resume");
         var claudeMd = loadMateClaudeMd(mateCtx, debate.moderatorId);
-        var digests = loadMateDigests(mateCtx, debate.moderatorId);
+        var digests = loadMateDigests(mateCtx, debate.moderatorId, debate.topic);
         var moderatorContext = buildModeratorContext(debate) + digests;
 
         // Include debate history so moderator has context

--- a/lib/project.js
+++ b/lib/project.js
@@ -4470,6 +4470,8 @@ function createProjectContext(opts) {
   function loadMateDigests(mateCtx, mateId, query) {
     var mateDir = matesModule.getMateDir(mateCtx, mateId);
     var knowledgeDir = path.join(mateDir, "knowledge");
+    var mate = matesModule.getMate(mateCtx, mateId);
+    var hasGlobalSearch = mate && mate.globalSearch;
 
     // Check for memory-summary.md first
     var summaryFile = path.join(knowledgeDir, "memory-summary.md");
@@ -4516,11 +4518,30 @@ function createProjectContext(opts) {
             mateSessions.push(s);
           }
         });
+
+        // Global search: collect ALL mates' digest files for cross-mate context
+        var otherDigests = [];
+        if (hasGlobalSearch) {
+          try {
+            var allMates = matesModule.getAllMates(mateCtx);
+            for (var mi = 0; mi < allMates.length; mi++) {
+              if (allMates[mi].id === mateId) continue; // skip self (already included)
+              var otherDir = matesModule.getMateDir(mateCtx, allMates[mi].id);
+              var otherDigest = path.join(otherDir, "knowledge", "session-digests.jsonl");
+              if (fs.existsSync(otherDigest)) {
+                var mateName = allMates[mi].name || allMates[mi].id;
+                otherDigests.push({ path: otherDigest, mateName: mateName });
+              }
+            }
+          } catch (e) {}
+        }
+
         var searchResults = sessionSearch.searchMate({
           digestFilePath: digestFile,
+          otherDigests: otherDigests,
           sessions: mateSessions,
           query: query,
-          maxResults: 5,
+          maxResults: hasGlobalSearch ? 8 : 5,
           minScore: 1.0
         });
         var contextStr = sessionSearch.formatForContext(searchResults);

--- a/lib/server.js
+++ b/lib/server.js
@@ -3300,10 +3300,31 @@ function createServer(opts) {
             otherWs.send(JSON.stringify({ type: "mate_updated", mate: updated }));
           });
         });
+        // Re-enforce team sections across all mate projects so roster stays current
+        refreshTeamSections(mateCtx7);
       } else {
         ws.send(JSON.stringify({ type: "mate_error", error: "Mate not found" }));
       }
       return;
+    }
+  }
+
+  /**
+   * Re-enforce team sections on all mate projects so the roster stays current
+   * after a mate name/bio/status change.
+   */
+  function refreshTeamSections(mateCtx) {
+    try {
+      var allMates = mates.getAllMates(mateCtx);
+      for (var ri = 0; ri < allMates.length; ri++) {
+        var mDir = mates.getMateDir(mateCtx, allMates[ri].id);
+        var claudePath = path.join(mDir, "CLAUDE.md");
+        try {
+          mates.enforceAllSections(claudePath, { ctx: mateCtx, mateId: allMates[ri].id });
+        } catch (e) {}
+      }
+    } catch (e) {
+      console.error("[mates] refreshTeamSections failed:", e.message);
     }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,6 +9,7 @@ var { createProjectContext } = require("./project");
 var users = require("./users");
 var dm = require("./dm");
 var mates = require("./mates");
+var sessionSearch = require("./session-search");
 
 var { CONFIG_DIR } = require("./config");
 var { provisionLinuxUser } = require("./os-users");
@@ -2197,29 +2198,26 @@ function createServer(opts) {
       var pqs = req.url.indexOf("?") >= 0 ? req.url.substring(req.url.indexOf("?")) : "";
       var pQuery = new URLSearchParams(pqs).get("q") || "";
       var pResults = [];
-      projects.forEach(function (pCtx, pSlug) {
-        var status = pCtx.getStatus();
-        if (status.isWorktree) return;
-        // Access check
-        if (paletteUser && onGetProjectAccess) {
-          var pAccess = onGetProjectAccess(pSlug);
-          if (pAccess && !pAccess.error && !users.canAccessProject(paletteUser.id, pAccess)) return;
-        }
-        var sm = pCtx.sm;
-        sm.sessions.forEach(function (session) {
-          if (session.hidden) return;
-          // Session access check
-          if (paletteUser) {
-            if (users.isMultiUser()) {
-              var sAccess = onGetProjectAccess ? onGetProjectAccess(pSlug) : null;
-              if (!users.canAccessSession(paletteUser.id, session, sAccess)) return;
-            }
-          } else {
-            // Single-user: skip sessions with ownerId
-            if (session.ownerId) return;
+
+      if (!pQuery) {
+        // Recent mode: return all sessions sorted by lastActivity
+        projects.forEach(function (pCtx, pSlug) {
+          var status = pCtx.getStatus();
+          if (status.isWorktree) return;
+          if (paletteUser && onGetProjectAccess) {
+            var pAccess = onGetProjectAccess(pSlug);
+            if (pAccess && !pAccess.error && !users.canAccessProject(paletteUser.id, pAccess)) return;
           }
-          if (!pQuery) {
-            // Recent mode: return all sessions sorted by lastActivity
+          pCtx.sm.sessions.forEach(function (session) {
+            if (session.hidden) return;
+            if (paletteUser) {
+              if (users.isMultiUser()) {
+                var sAccess = onGetProjectAccess ? onGetProjectAccess(pSlug) : null;
+                if (!users.canAccessSession(paletteUser.id, session, sAccess)) return;
+              }
+            } else {
+              if (session.ownerId) return;
+            }
             var pItem = {
               projectSlug: pSlug,
               projectTitle: status.title || status.project,
@@ -2235,49 +2233,47 @@ function createServer(opts) {
               pItem.mateId = status.mateId || null;
             }
             pResults.push(pItem);
-          } else {
-            // Search mode: match title and content
-            var q = pQuery.toLowerCase();
-            var titleMatch = (session.title || "New Session").toLowerCase().indexOf(q) !== -1;
-            var contentSnippet = null;
-            for (var hi = 0; hi < session.history.length; hi++) {
-              var entry = session.history[hi];
-              if ((entry.type === "delta" || entry.type === "user_message" || entry.type === "mention_user" || entry.type === "mention_response" || entry.type === "debate_turn_done") && entry.text) {
-                var lowerText = entry.text.toLowerCase();
-                var matchIdx = lowerText.indexOf(q);
-                if (matchIdx !== -1) {
-                  var snippetStart = Math.max(0, matchIdx - 20);
-                  var snippetEnd = Math.min(entry.text.length, matchIdx + pQuery.length + 20);
-                  contentSnippet = (snippetStart > 0 ? "..." : "") +
-                    entry.text.substring(snippetStart, snippetEnd) +
-                    (snippetEnd < entry.text.length ? "..." : "");
-                  break;
-                }
+          });
+        });
+        pResults.sort(function (a, b) { return b.lastActivity - a.lastActivity; });
+        if (pResults.length > 30) pResults = pResults.slice(0, 30);
+      } else {
+        // Search mode: BM25 ranked search across all sessions
+        var projectSessions = [];
+        projects.forEach(function (pCtx, pSlug) {
+          var status = pCtx.getStatus();
+          if (status.isWorktree) return;
+          if (paletteUser && onGetProjectAccess) {
+            var pAccess = onGetProjectAccess(pSlug);
+            if (pAccess && !pAccess.error && !users.canAccessProject(paletteUser.id, pAccess)) return;
+          }
+          var accessibleSessions = [];
+          pCtx.sm.sessions.forEach(function (session) {
+            if (session.hidden) return;
+            if (paletteUser) {
+              if (users.isMultiUser()) {
+                var sAccess = onGetProjectAccess ? onGetProjectAccess(pSlug) : null;
+                if (!users.canAccessSession(paletteUser.id, session, sAccess)) return;
               }
+            } else {
+              if (session.ownerId) return;
             }
-            if (titleMatch || contentSnippet) {
-              var sItem = {
-                projectSlug: pSlug,
-                projectTitle: status.title || status.project,
-                projectIcon: status.icon || null,
-                sessionId: session.localId,
-                sessionTitle: session.title || "New Session",
-                lastActivity: session.lastActivity || session.createdAt || 0,
-                matchType: titleMatch && contentSnippet ? "both" : titleMatch ? "title" : "content",
-                snippet: contentSnippet
-              };
-              if (status.isMate) {
-                sItem.isMate = true;
-                sItem.mateId = status.mateId || null;
-              }
-              pResults.push(sItem);
-            }
+            accessibleSessions.push(session);
+          });
+          if (accessibleSessions.length > 0) {
+            projectSessions.push({
+              projectSlug: pSlug,
+              projectTitle: status.title || status.project,
+              projectIcon: status.icon || null,
+              isMate: status.isMate || false,
+              mateId: status.mateId || null,
+              sessions: accessibleSessions
+            });
           }
         });
-      });
-      // Sort by lastActivity descending, limit to 30
-      pResults.sort(function (a, b) { return b.lastActivity - a.lastActivity; });
-      if (pResults.length > 30) pResults = pResults.slice(0, 30);
+        pResults = sessionSearch.searchPalette(projectSessions, pQuery, { maxResults: 30 });
+      }
+
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ results: pResults }));
       return;

--- a/lib/session-search.js
+++ b/lib/session-search.js
@@ -1,0 +1,601 @@
+var fs = require("fs");
+var path = require("path");
+
+// ============================================================================
+// session-search.js - Unified BM25 search for Clay
+//
+// Single module for ALL search: digests, session history, palette, mate context.
+// Callers pass data in, get results out. No BM25 logic leaks outside this file.
+// ============================================================================
+
+// --- BM25 Parameters ---
+var K1 = 1.2;   // term frequency saturation
+var B = 0.75;    // document length normalization
+var MAX_RESULTS = 10;
+
+// --- Searchable session history entry types ---
+var SEARCHABLE_TYPES = {
+  "user_message": true,
+  "delta": true,
+  "mention_user": true,
+  "mention_response": true,
+  "debate_turn_done": true
+};
+
+// ==========================================================================
+// 1. BM25 CORE - tokenizer, index builder, scorer
+// ==========================================================================
+
+var STOPWORDS = {
+  // English
+  "the": 1, "a": 1, "an": 1, "is": 1, "are": 1, "was": 1, "were": 1,
+  "be": 1, "been": 1, "being": 1, "have": 1, "has": 1, "had": 1,
+  "do": 1, "does": 1, "did": 1, "will": 1, "would": 1, "could": 1,
+  "should": 1, "may": 1, "might": 1, "shall": 1, "can": 1,
+  "to": 1, "of": 1, "in": 1, "for": 1, "on": 1, "with": 1, "at": 1,
+  "by": 1, "from": 1, "as": 1, "into": 1, "through": 1, "about": 1,
+  "and": 1, "or": 1, "but": 1, "not": 1, "so": 1, "if": 1, "then": 1,
+  "it": 1, "its": 1, "this": 1, "that": 1, "these": 1, "those": 1,
+  "i": 1, "me": 1, "my": 1, "we": 1, "our": 1, "you": 1, "your": 1,
+  "he": 1, "she": 1, "they": 1, "them": 1, "their": 1,
+  "what": 1, "which": 1, "who": 1, "when": 1, "where": 1, "how": 1,
+  "all": 1, "each": 1, "every": 1, "both": 1, "few": 1, "more": 1,
+  "other": 1, "some": 1, "such": 1, "no": 1, "nor": 1, "only": 1,
+  "own": 1, "same": 1, "than": 1, "too": 1, "very": 1,
+  "just": 1, "also": 1, "now": 1, "here": 1, "there": 1,
+  "null": 1, "none": 1, "n/a": 1,
+  // Korean particles/connectors
+  "\uC740": 1, "\uB294": 1, "\uC774": 1, "\uAC00": 1, "\uC744": 1, "\uB97C": 1,
+  "\uC758": 1, "\uC5D0": 1, "\uC5D0\uC11C": 1, "\uB85C": 1, "\uC73C\uB85C": 1,
+  "\uB3C4": 1, "\uB9CC": 1, "\uAE4C\uC9C0": 1, "\uBD80\uD130": 1,
+  "\uADF8": 1, "\uC800": 1, "\uB098": 1, "\uB108": 1,
+};
+
+function isCJK(ch) {
+  var code = ch.charCodeAt(0);
+  return (code >= 0xAC00 && code <= 0xD7AF) ||
+         (code >= 0x3130 && code <= 0x318F) ||
+         (code >= 0x4E00 && code <= 0x9FFF) ||
+         (code >= 0x3400 && code <= 0x4DBF);
+}
+
+/**
+ * Tokenize text for BM25. Handles mixed Korean/English.
+ * Korean: whole words + character bigrams. English: whole words.
+ */
+function tokenize(text) {
+  if (!text || typeof text !== "string") return [];
+
+  var tokens = [];
+  var words = text.toLowerCase().split(/[\s,.\-:;!?'"()\[\]{}<>|/\\@#$%^&*+=~`]+/);
+
+  for (var i = 0; i < words.length; i++) {
+    var word = words[i].trim();
+    if (!word || word.length < 2) continue;
+    if (STOPWORDS[word]) continue;
+
+    var hasCJK = false;
+    for (var c = 0; c < word.length; c++) {
+      if (isCJK(word[c])) { hasCJK = true; break; }
+    }
+
+    if (hasCJK) {
+      if (word.length >= 2) tokens.push(word);
+      for (var bi = 0; bi < word.length - 1; bi++) {
+        if (isCJK(word[bi]) || isCJK(word[bi + 1])) {
+          tokens.push(word[bi] + word[bi + 1]);
+        }
+      }
+    } else {
+      tokens.push(word);
+    }
+  }
+
+  return tokens;
+}
+
+/**
+ * Build BM25 index from generic documents.
+ * @param {Array} docs - [{ id: any, text: string, meta: any }]
+ * @returns {object} Index for searchIndex()
+ */
+function buildIndex(docs) {
+  var indexed = [];
+  var df = {};
+  var totalLength = 0;
+
+  for (var i = 0; i < docs.length; i++) {
+    var tokens = tokenize(docs[i].text);
+    var docTerms = {};
+    var tf = {};
+
+    for (var t = 0; t < tokens.length; t++) {
+      var term = tokens[t];
+      tf[term] = (tf[term] || 0) + 1;
+      docTerms[term] = true;
+    }
+
+    var terms = Object.keys(docTerms);
+    for (var dt = 0; dt < terms.length; dt++) {
+      df[terms[dt]] = (df[terms[dt]] || 0) + 1;
+    }
+
+    indexed.push({ id: docs[i].id, tf: tf, length: tokens.length, meta: docs[i].meta });
+    totalLength += tokens.length;
+  }
+
+  return { docs: indexed, df: df, N: indexed.length, avgdl: indexed.length > 0 ? totalLength / indexed.length : 0 };
+}
+
+/**
+ * Search a BM25 index. Returns [{ id, score, meta }] sorted by score desc.
+ */
+function searchIndex(index, query, maxResults) {
+  if (!index || index.N === 0) return [];
+  maxResults = maxResults || MAX_RESULTS;
+
+  var queryTokens = tokenize(query);
+  if (queryTokens.length === 0) return [];
+
+  // Deduplicate
+  var seen = {};
+  var unique = [];
+  for (var q = 0; q < queryTokens.length; q++) {
+    if (!seen[queryTokens[q]]) {
+      seen[queryTokens[q]] = true;
+      unique.push(queryTokens[q]);
+    }
+  }
+
+  var scores = [];
+  for (var d = 0; d < index.docs.length; d++) {
+    var doc = index.docs[d];
+    var score = 0;
+
+    for (var qt = 0; qt < unique.length; qt++) {
+      var term = unique[qt];
+      var termFreq = doc.tf[term] || 0;
+      if (termFreq === 0) continue;
+
+      var docFreq = index.df[term] || 0;
+      var idf = Math.log((index.N - docFreq + 0.5) / (docFreq + 0.5) + 1);
+      var tfNorm = (termFreq * (K1 + 1)) /
+        (termFreq + K1 * (1 - B + B * doc.length / index.avgdl));
+
+      score += idf * tfNorm;
+    }
+
+    if (score > 0) {
+      scores.push({ id: doc.id, score: score, meta: doc.meta });
+    }
+  }
+
+  scores.sort(function (a, b) { return b.score - a.score; });
+  return scores.slice(0, maxResults);
+}
+
+// ==========================================================================
+// 2. DATA SOURCES - convert various data into generic {id, text, meta} docs
+// ==========================================================================
+
+/**
+ * Convert a digest entry into a searchable document.
+ * Important fields get repeated for higher BM25 weight.
+ */
+function digestToDoc(digest, lineIdx) {
+  var parts = [];
+  // High weight
+  if (digest.topic) { parts.push(digest.topic); parts.push(digest.topic); }
+  if (digest.tags && digest.tags.length) {
+    var tagStr = digest.tags.join(" ");
+    parts.push(tagStr); parts.push(tagStr);
+  }
+  // Medium weight
+  if (digest.summary) parts.push(digest.summary);
+  if (digest.key_quotes && digest.key_quotes.length) parts.push(digest.key_quotes.join(" "));
+  if (digest.user_intent) parts.push(digest.user_intent);
+  if (digest.user_context) parts.push(digest.user_context);
+  // Normal weight
+  if (digest.my_position) parts.push(digest.my_position);
+  if (digest.decisions) parts.push(digest.decisions);
+  if (digest.open_items) parts.push(digest.open_items);
+  if (digest.user_sentiment) parts.push(digest.user_sentiment);
+  if (digest.other_perspectives) parts.push(digest.other_perspectives);
+  if (digest.outcome) parts.push(digest.outcome);
+  if (digest.my_role) parts.push(digest.my_role);
+
+  return { id: "digest:" + lineIdx, text: parts.join(" "), meta: { source: "digest", lineIdx: lineIdx, digest: digest } };
+}
+
+/**
+ * Convert a session's history into searchable documents.
+ * Groups consecutive deltas into turns for better context.
+ * Each "turn" (user message or assistant response block) becomes one document.
+ */
+function sessionHistoryToDocs(session) {
+  var docs = [];
+  var history = session.history || [];
+  var sessionMeta = {
+    sessionId: session.localId || session.cliSessionId,
+    sessionTitle: session.title || "New Session"
+  };
+  var currentText = "";
+  var currentType = null;
+  var turnIdx = 0;
+
+  function flushTurn() {
+    var text = currentText.trim();
+    if (text && text.length > 10) {
+      docs.push({
+        id: "session:" + sessionMeta.sessionId + ":turn:" + turnIdx,
+        text: text,
+        meta: {
+          source: "session",
+          sessionId: sessionMeta.sessionId,
+          sessionTitle: sessionMeta.sessionTitle,
+          turnIdx: turnIdx,
+          turnType: currentType,
+          snippet: text.length > 200 ? text.substring(0, 200) + "..." : text
+        }
+      });
+      turnIdx++;
+    }
+    currentText = "";
+    currentType = null;
+  }
+
+  for (var i = 0; i < history.length; i++) {
+    var entry = history[i];
+    if (!SEARCHABLE_TYPES[entry.type]) continue;
+    if (!entry.text) continue;
+
+    if (entry.type === "user_message" || entry.type === "mention_user") {
+      // New turn boundary
+      flushTurn();
+      currentType = entry.type;
+      currentText = entry.text;
+    } else if (entry.type === "delta") {
+      // Continuation of assistant response
+      if (currentType !== "delta") flushTurn();
+      currentType = "delta";
+      currentText += entry.text;
+    } else {
+      // mention_response, debate_turn_done
+      flushTurn();
+      currentType = entry.type;
+      currentText = entry.text;
+    }
+  }
+  flushTurn();
+
+  return docs;
+}
+
+/**
+ * Load digests from JSONL file into doc array.
+ */
+function loadDigestDocs(digestFilePath, opts) {
+  opts = opts || {};
+  var docs = [];
+  try {
+    if (!fs.existsSync(digestFilePath)) return docs;
+    var lines = fs.readFileSync(digestFilePath, "utf8").trim().split("\n");
+    for (var i = 0; i < lines.length; i++) {
+      if (!lines[i].trim()) continue;
+      try {
+        var entry = JSON.parse(lines[i]);
+        // Date filter
+        if (opts.dateFrom && entry.date && entry.date < opts.dateFrom) continue;
+        if (opts.dateTo && entry.date && entry.date > opts.dateTo) continue;
+        docs.push(digestToDoc(entry, i));
+      } catch (e) {}
+    }
+  } catch (e) {}
+  return docs;
+}
+
+// ==========================================================================
+// 3. HIGH-LEVEL SEARCH APIs - the public interface
+// ==========================================================================
+
+/**
+ * Search a mate's digests.
+ * @param {string} digestFilePath
+ * @param {string} query
+ * @param {object} opts - { maxResults, minScore, dateFrom, dateTo }
+ * @returns {Array} [{ digest, score, lineIdx }]
+ */
+function searchDigests(digestFilePath, query, opts) {
+  opts = opts || {};
+  if (!query || !query.trim()) return [];
+
+  var docs = loadDigestDocs(digestFilePath, opts);
+  if (docs.length === 0) return [];
+
+  var index = buildIndex(docs);
+  var results = searchIndex(index, query, opts.maxResults || MAX_RESULTS);
+
+  if (opts.minScore) {
+    results = results.filter(function (r) { return r.score >= opts.minScore; });
+  }
+
+  // Map back to caller-friendly format
+  return results.map(function (r) {
+    return { digest: r.meta.digest, score: r.score, lineIdx: r.meta.lineIdx };
+  });
+}
+
+/**
+ * Search a mate's session history (full conversation turns).
+ * @param {Array} sessions - Array of session objects with .history, .localId, .title
+ * @param {string} query
+ * @param {object} opts - { maxResults, minScore }
+ * @returns {Array} [{ sessionId, sessionTitle, turnIdx, turnType, snippet, score }]
+ */
+function searchSessions(sessions, query, opts) {
+  opts = opts || {};
+  if (!query || !query.trim() || !sessions || sessions.length === 0) return [];
+
+  var docs = [];
+  for (var s = 0; s < sessions.length; s++) {
+    var sessionDocs = sessionHistoryToDocs(sessions[s]);
+    for (var d = 0; d < sessionDocs.length; d++) {
+      docs.push(sessionDocs[d]);
+    }
+  }
+
+  if (docs.length === 0) return [];
+
+  var index = buildIndex(docs);
+  var results = searchIndex(index, query, opts.maxResults || MAX_RESULTS);
+
+  if (opts.minScore) {
+    results = results.filter(function (r) { return r.score >= opts.minScore; });
+  }
+
+  return results.map(function (r) {
+    return {
+      sessionId: r.meta.sessionId,
+      sessionTitle: r.meta.sessionTitle,
+      turnIdx: r.meta.turnIdx,
+      turnType: r.meta.turnType,
+      snippet: r.meta.snippet,
+      score: r.score
+    };
+  });
+}
+
+/**
+ * Unified mate search: digests + session history combined.
+ * Returns merged, re-ranked results from both sources.
+ * @param {object} opts - { digestFilePath, sessions, query, maxResults, minScore }
+ * @returns {Array} [{ source: "digest"|"session", score, ... }]
+ */
+function searchMate(opts) {
+  if (!opts || !opts.query || !opts.query.trim()) return [];
+  var maxResults = opts.maxResults || MAX_RESULTS;
+  var allDocs = [];
+
+  // Collect digest docs
+  if (opts.digestFilePath) {
+    var digestDocs = loadDigestDocs(opts.digestFilePath);
+    for (var dd = 0; dd < digestDocs.length; dd++) allDocs.push(digestDocs[dd]);
+  }
+
+  // Collect session history docs
+  if (opts.sessions && opts.sessions.length > 0) {
+    for (var si = 0; si < opts.sessions.length; si++) {
+      var sDocs = sessionHistoryToDocs(opts.sessions[si]);
+      for (var sd = 0; sd < sDocs.length; sd++) allDocs.push(sDocs[sd]);
+    }
+  }
+
+  if (allDocs.length === 0) return [];
+
+  // Build unified index across both sources and search
+  var index = buildIndex(allDocs);
+  var results = searchIndex(index, opts.query, maxResults);
+
+  if (opts.minScore) {
+    results = results.filter(function (r) { return r.score >= opts.minScore; });
+  }
+
+  return results.map(function (r) {
+    var out = { source: r.meta.source, score: r.score };
+    if (r.meta.source === "digest") {
+      out.digest = r.meta.digest;
+      out.lineIdx = r.meta.lineIdx;
+    } else {
+      out.sessionId = r.meta.sessionId;
+      out.sessionTitle = r.meta.sessionTitle;
+      out.turnIdx = r.meta.turnIdx;
+      out.turnType = r.meta.turnType;
+      out.snippet = r.meta.snippet;
+    }
+    return out;
+  });
+}
+
+/**
+ * Search for command palette (Cmd+K). Replaces substring search in server.js.
+ * Accepts pre-collected session data from all projects.
+ *
+ * @param {Array} projectSessions - [{ projectSlug, projectTitle, projectIcon, isMate, mateId, sessions }]
+ *   where sessions = [{ localId, title, history, lastActivity, hidden }]
+ * @param {string} query
+ * @param {object} opts - { maxResults }
+ * @returns {Array} [{ projectSlug, projectTitle, projectIcon, sessionId, sessionTitle, lastActivity, matchType, snippet, score, isMate, mateId }]
+ */
+function searchPalette(projectSessions, query, opts) {
+  opts = opts || {};
+  if (!query || !query.trim()) return [];
+  var maxResults = opts.maxResults || 30;
+
+  var allDocs = [];
+
+  for (var p = 0; p < projectSessions.length; p++) {
+    var proj = projectSessions[p];
+    var sessions = proj.sessions || [];
+
+    for (var s = 0; s < sessions.length; s++) {
+      var session = sessions[s];
+      if (session.hidden) continue;
+
+      // Title as a separate high-weight doc
+      var title = session.title || "New Session";
+      allDocs.push({
+        id: "title:" + proj.projectSlug + ":" + session.localId,
+        text: title + " " + title, // double weight for title
+        meta: {
+          source: "palette",
+          projectSlug: proj.projectSlug,
+          projectTitle: proj.projectTitle,
+          projectIcon: proj.projectIcon || null,
+          sessionId: session.localId,
+          sessionTitle: title,
+          lastActivity: session.lastActivity || session.createdAt || 0,
+          isMate: proj.isMate || false,
+          mateId: proj.mateId || null,
+          matchType: "title",
+          snippet: null
+        }
+      });
+
+      // Content turns as docs
+      var turnDocs = sessionHistoryToDocs(session);
+      for (var td = 0; td < turnDocs.length; td++) {
+        var turnDoc = turnDocs[td];
+        allDocs.push({
+          id: turnDoc.id,
+          text: turnDoc.text,
+          meta: {
+            source: "palette",
+            projectSlug: proj.projectSlug,
+            projectTitle: proj.projectTitle,
+            projectIcon: proj.projectIcon || null,
+            sessionId: session.localId,
+            sessionTitle: title,
+            lastActivity: session.lastActivity || session.createdAt || 0,
+            isMate: proj.isMate || false,
+            mateId: proj.mateId || null,
+            matchType: "content",
+            snippet: turnDoc.meta.snippet
+          }
+        });
+      }
+    }
+  }
+
+  if (allDocs.length === 0) return [];
+
+  var index = buildIndex(allDocs);
+  var raw = searchIndex(index, query, maxResults * 3); // over-fetch for dedup
+
+  // Deduplicate: keep best match per session
+  var bestPerSession = {};
+  for (var r = 0; r < raw.length; r++) {
+    var m = raw[r].meta;
+    var key = m.projectSlug + ":" + m.sessionId;
+    if (!bestPerSession[key] || raw[r].score > bestPerSession[key].score) {
+      bestPerSession[key] = {
+        projectSlug: m.projectSlug,
+        projectTitle: m.projectTitle,
+        projectIcon: m.projectIcon,
+        sessionId: m.sessionId,
+        sessionTitle: m.sessionTitle,
+        lastActivity: m.lastActivity,
+        matchType: m.matchType,
+        snippet: m.snippet,
+        score: raw[r].score,
+        isMate: m.isMate,
+        mateId: m.mateId
+      };
+      // If we already have a title match, upgrade to "both"
+    } else if (bestPerSession[key].matchType !== m.matchType) {
+      bestPerSession[key].matchType = "both";
+      if (m.snippet && !bestPerSession[key].snippet) {
+        bestPerSession[key].snippet = m.snippet;
+      }
+    }
+  }
+
+  // Sort by score desc, take top results
+  var deduped = Object.keys(bestPerSession).map(function (k) { return bestPerSession[k]; });
+  deduped.sort(function (a, b) { return b.score - a.score; });
+  return deduped.slice(0, maxResults);
+}
+
+// ==========================================================================
+// 4. FORMATTERS - convert search results to context strings
+// ==========================================================================
+
+/**
+ * Format search results for injection into mate mention/DM context.
+ * Includes both digest and session history results.
+ * @param {Array} results - output from searchMate()
+ * @returns {string} Formatted context string, or "" if empty
+ */
+function formatForContext(results) {
+  if (!results || results.length === 0) return "";
+
+  var lines = ["\n\nRelevant past context (searched by current topic):"];
+
+  for (var i = 0; i < results.length; i++) {
+    var r = results[i];
+    var scorePct = Math.round(r.score * 10) / 10;
+
+    if (r.source === "digest") {
+      var d = r.digest;
+      var line = "- [" + (d.date || "?") + "] ";
+      if (d.type === "debate" && d.my_role) {
+        line += "DEBATE (role: " + d.my_role + ") ";
+      }
+      line += (d.topic || "unknown");
+      if (d.summary) line += " -- " + d.summary;
+      if (d.my_position) line += " | Position: " + d.my_position;
+      if (d.decisions) line += " | Decisions: " + d.decisions;
+      if (d.key_quotes && d.key_quotes.length > 0) {
+        line += " | Quotes: " + d.key_quotes.slice(0, 2).join("; ");
+      }
+      line += " (relevance: " + scorePct + ")";
+      lines.push(line);
+    } else if (r.source === "session") {
+      var line = "- [session: " + (r.sessionTitle || "?") + "] ";
+      line += (r.snippet || "(no preview)");
+      line += " (relevance: " + scorePct + ")";
+      lines.push(line);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Format digest search results for the memory UI panel.
+ * @param {Array} results - output from searchDigests()
+ * @returns {Array} [{ entry, score }]
+ */
+function formatForMemoryUI(results) {
+  return results.map(function (r) {
+    var entry = r.digest;
+    entry.index = r.lineIdx;
+    return { entry: entry, score: Math.round(r.score * 100) / 100 };
+  });
+}
+
+module.exports = {
+  // Core (exposed for testing / advanced use)
+  tokenize: tokenize,
+  buildIndex: buildIndex,
+  searchIndex: searchIndex,
+
+  // High-level search APIs
+  searchDigests: searchDigests,
+  searchSessions: searchSessions,
+  searchMate: searchMate,
+  searchPalette: searchPalette,
+
+  // Formatters
+  formatForContext: formatForContext,
+  formatForMemoryUI: formatForMemoryUI,
+};

--- a/lib/session-search.js
+++ b/lib/session-search.js
@@ -26,67 +26,109 @@ var SEARCHABLE_TYPES = {
 // 1. BM25 CORE - tokenizer, index builder, scorer
 // ==========================================================================
 
-var STOPWORDS = {
+// Stopwords for major languages. Only high-frequency function words that
+// carry almost no semantic meaning. Kept short to avoid false negatives.
+var STOPWORDS = {};
+var _sw = [
   // English
-  "the": 1, "a": 1, "an": 1, "is": 1, "are": 1, "was": 1, "were": 1,
-  "be": 1, "been": 1, "being": 1, "have": 1, "has": 1, "had": 1,
-  "do": 1, "does": 1, "did": 1, "will": 1, "would": 1, "could": 1,
-  "should": 1, "may": 1, "might": 1, "shall": 1, "can": 1,
-  "to": 1, "of": 1, "in": 1, "for": 1, "on": 1, "with": 1, "at": 1,
-  "by": 1, "from": 1, "as": 1, "into": 1, "through": 1, "about": 1,
-  "and": 1, "or": 1, "but": 1, "not": 1, "so": 1, "if": 1, "then": 1,
-  "it": 1, "its": 1, "this": 1, "that": 1, "these": 1, "those": 1,
-  "i": 1, "me": 1, "my": 1, "we": 1, "our": 1, "you": 1, "your": 1,
-  "he": 1, "she": 1, "they": 1, "them": 1, "their": 1,
-  "what": 1, "which": 1, "who": 1, "when": 1, "where": 1, "how": 1,
-  "all": 1, "each": 1, "every": 1, "both": 1, "few": 1, "more": 1,
-  "other": 1, "some": 1, "such": 1, "no": 1, "nor": 1, "only": 1,
-  "own": 1, "same": 1, "than": 1, "too": 1, "very": 1,
-  "just": 1, "also": 1, "now": 1, "here": 1, "there": 1,
-  "null": 1, "none": 1, "n/a": 1,
-  // Korean particles/connectors
-  "\uC740": 1, "\uB294": 1, "\uC774": 1, "\uAC00": 1, "\uC744": 1, "\uB97C": 1,
-  "\uC758": 1, "\uC5D0": 1, "\uC5D0\uC11C": 1, "\uB85C": 1, "\uC73C\uB85C": 1,
-  "\uB3C4": 1, "\uB9CC": 1, "\uAE4C\uC9C0": 1, "\uBD80\uD130": 1,
-  "\uADF8": 1, "\uC800": 1, "\uB098": 1, "\uB108": 1,
-};
+  "the a an is are was were be been being have has had do does did will would could",
+  "should may might shall can to of in for on with at by from as into through about",
+  "and or but not so if then it its this that these those i me my we our you your",
+  "he she they them their what which who when where how all each every both few more",
+  "other some such no nor only own same than too very just also now here there null none",
+  // Spanish
+  "el la los las un una unos unas de en con por para al del que es no se lo su sus",
+  "como mas pero si ya muy te tu mi me nos le les fue ser estar hay este esta esto",
+  // French
+  "le la les un une des de du en au aux et est que qui ne pas pour sur avec dans par",
+  "ce cette ces je tu il elle nous vous ils son sa ses lui sont ont fait plus",
+  // German
+  "der die das ein eine einer eines dem den des im auf ist und zu von mit dem den",
+  "nicht sich auch es an als ich er sie wir ihr aber nach wie noch bei uns aus",
+  // Portuguese
+  "de da do das dos em um uma que se no na os as para com por mais",
+  "mas como foi ao ele ela seu sua isso este esta esse essa",
+  // Italian
+  "il lo la le gli un una dei del della delle nel nella che di da in con su per",
+  "non si come anche sono ha ho questo questa quello quella",
+  // Dutch
+  "de het een van en in is dat op te zijn voor met als bij om ook maar er nog",
+  "niet aan dan ze wel dit die ze uit tot",
+  // Russian (transliterated would not match, keep Cyrillic)
+  "\u0438 \u0432 \u043d\u0430 \u043d\u0435 \u0447\u0442\u043e \u044d\u0442\u043e \u043a\u0430\u043a \u043e\u043d \u043e\u043d\u0430 \u043e\u043d\u0438 \u043c\u044b \u0432\u044b \u044f \u0441 \u043f\u043e \u0434\u043b\u044f \u043a \u043d\u043e \u0434\u0430 \u0442\u043e \u043e\u0442 \u043e \u0431\u044b\u043b \u0431\u044b\u043b\u0430 \u0431\u044b\u043b\u043e \u0435\u0441\u0442\u044c \u0431\u044b\u0442\u044c \u0443\u0436\u0435 \u0438\u043b\u0438 \u0442\u043e\u0436\u0435 \u0435\u0449\u0435",
+  // Korean particles
+  "\uC740 \uB294 \uC774 \uAC00 \uC744 \uB97C \uC758 \uC5D0 \uC5D0\uC11C \uB85C \uC73C\uB85C \uB3C4 \uB9CC \uAE4C\uC9C0 \uBD80\uD130 \uADF8 \uC800 \uB098 \uB108",
+  // Japanese particles (hiragana)
+  "\u306E \u306F \u304C \u3092 \u306B \u3078 \u3067 \u3068 \u3082 \u304B \u3088 \u306D \u306A \u3051\u3069 \u3057 \u305D\u306E \u3053\u306E \u305D\u308C \u3053\u308C \u3042\u308B \u3044\u308B \u3059\u308B \u306A\u3044 \u3067\u3059 \u307E\u3059",
+  // Chinese function words
+  "\u7684 \u4E86 \u5728 \u662F \u6211 \u4ED6 \u5979 \u4EEC \u8FD9 \u90A3 \u4E0D \u4E5F \u5C31 \u548C \u8981 \u4F1A \u80FD \u6709 \u5BF9 \u8BF4 \u8FD8 \u53EF\u4EE5 \u4EC0\u4E48 \u600E\u4E48",
+  // Arabic
+  "\u0641\u064A \u0645\u0646 \u0639\u0644\u0649 \u0625\u0644\u0649 \u0627\u0646 \u0647\u0630\u0627 \u0647\u0630\u0647 \u0630\u0644\u0643 \u0627\u0644\u062A\u064A \u0627\u0644\u0630\u064A \u0648 \u0623\u0648 \u0644\u0627 \u0645\u0627 \u0643\u0627\u0646 \u0639\u0646 \u0628\u0639\u062F \u0642\u062F \u0644\u0645 \u0628\u064A\u0646 \u0643\u0644",
+  // Turkish
+  "bir ve bu da de ile mi ne gibi ama icin olan var yok hem",
+  // Vietnamese (common function words, diacritics lowercased)
+  "la cua va trong cho den nhung cac voi nay nhu khong duoc con",
+  // Hindi (Devanagari)
+  "\u0915\u0947 \u0939\u0948 \u092E\u0947\u0902 \u0915\u093E \u0915\u0940 \u0938\u0947 \u0915\u094B \u0928\u0947 \u092F\u0939 \u0935\u0939 \u0914\u0930 \u092A\u0930 \u0907\u0938 \u0909\u0938 \u0928\u0939\u0940\u0902 \u0925\u093E \u0925\u0940 \u0925\u0947 \u0939\u0942\u0901 \u0939\u0948\u0902"
+];
+for (var _si = 0; _si < _sw.length; _si++) {
+  var _words = _sw[_si].split(" ");
+  for (var _wi = 0; _wi < _words.length; _wi++) {
+    if (_words[_wi]) STOPWORDS[_words[_wi]] = 1;
+  }
+}
 
-function isCJK(ch) {
+// --- Script detection for tokenization strategy ---
+// Scripts that don't use spaces between words need character n-gram tokenization.
+
+/**
+ * Check if a character belongs to a script that needs n-gram segmentation.
+ * Returns true for CJK (Chinese, Japanese Kanji, Korean), Japanese kana, and Thai.
+ */
+function needsNgramSegmentation(ch) {
   var code = ch.charCodeAt(0);
-  return (code >= 0xAC00 && code <= 0xD7AF) ||
-         (code >= 0x3130 && code <= 0x318F) ||
-         (code >= 0x4E00 && code <= 0x9FFF) ||
-         (code >= 0x3400 && code <= 0x4DBF);
+  return (code >= 0xAC00 && code <= 0xD7AF) ||  // Hangul Syllables (Korean)
+         (code >= 0x3130 && code <= 0x318F) ||  // Hangul Compatibility Jamo
+         (code >= 0x4E00 && code <= 0x9FFF) ||  // CJK Unified Ideographs (Chinese/Kanji)
+         (code >= 0x3400 && code <= 0x4DBF) ||  // CJK Extension A
+         (code >= 0x3040 && code <= 0x309F) ||  // Hiragana (Japanese)
+         (code >= 0x30A0 && code <= 0x30FF) ||  // Katakana (Japanese)
+         (code >= 0x0E00 && code <= 0x0E7F);    // Thai
 }
 
 /**
- * Tokenize text for BM25. Handles mixed Korean/English.
- * Korean: whole words + character bigrams. English: whole words.
+ * Tokenize text for BM25. Multi-language support:
+ * - Space-delimited scripts (Latin, Cyrillic, Arabic, Devanagari, etc.): word splitting
+ * - Non-delimited scripts (CJK, Japanese, Thai): word + character bigrams
+ * - Mixed text handled per-word
  */
 function tokenize(text) {
   if (!text || typeof text !== "string") return [];
 
   var tokens = [];
-  var words = text.toLowerCase().split(/[\s,.\-:;!?'"()\[\]{}<>|/\\@#$%^&*+=~`]+/);
+  var words = text.toLowerCase().split(/[\s,.\-:;!?\u3001\u3002\u060C\u061B'"()\[\]{}<>|/\\@#$%^&*+=~`\u300C\u300D\u300E\u300F\u3010\u3011\uFF08\uFF09]+/);
 
   for (var i = 0; i < words.length; i++) {
     var word = words[i].trim();
     if (!word || word.length < 2) continue;
     if (STOPWORDS[word]) continue;
 
-    var hasCJK = false;
+    // Check if word contains characters needing n-gram segmentation
+    var hasNgram = false;
     for (var c = 0; c < word.length; c++) {
-      if (isCJK(word[c])) { hasCJK = true; break; }
+      if (needsNgramSegmentation(word[c])) { hasNgram = true; break; }
     }
 
-    if (hasCJK) {
+    if (hasNgram) {
+      // Non-delimited script: add whole word + character bigrams
       if (word.length >= 2) tokens.push(word);
       for (var bi = 0; bi < word.length - 1; bi++) {
-        if (isCJK(word[bi]) || isCJK(word[bi + 1])) {
+        if (needsNgramSegmentation(word[bi]) || needsNgramSegmentation(word[bi + 1])) {
           tokens.push(word[bi] + word[bi + 1]);
         }
       }
     } else {
+      // Space-delimited script (Latin, Cyrillic, Arabic, Devanagari, etc.)
       tokens.push(word);
     }
   }

--- a/lib/session-search.js
+++ b/lib/session-search.js
@@ -223,8 +223,11 @@ function searchIndex(index, query, maxResults) {
 /**
  * Convert a digest entry into a searchable document.
  * Important fields get repeated for higher BM25 weight.
+ * @param {object} digest - parsed digest entry
+ * @param {number} lineIdx - line index in JSONL file
+ * @param {string} mateName - optional mate name (for cross-mate search)
  */
-function digestToDoc(digest, lineIdx) {
+function digestToDoc(digest, lineIdx, mateName) {
   var parts = [];
   // High weight
   if (digest.topic) { parts.push(digest.topic); parts.push(digest.topic); }
@@ -246,7 +249,7 @@ function digestToDoc(digest, lineIdx) {
   if (digest.outcome) parts.push(digest.outcome);
   if (digest.my_role) parts.push(digest.my_role);
 
-  return { id: "digest:" + lineIdx, text: parts.join(" "), meta: { source: "digest", lineIdx: lineIdx, digest: digest } };
+  return { id: "digest:" + (mateName || "self") + ":" + lineIdx, text: parts.join(" "), meta: { source: "digest", lineIdx: lineIdx, digest: digest, mateName: mateName || null } };
 }
 
 /**
@@ -315,6 +318,8 @@ function sessionHistoryToDocs(session) {
 
 /**
  * Load digests from JSONL file into doc array.
+ * @param {string} digestFilePath
+ * @param {object} opts - { dateFrom, dateTo, mateName }
  */
 function loadDigestDocs(digestFilePath, opts) {
   opts = opts || {};
@@ -326,10 +331,9 @@ function loadDigestDocs(digestFilePath, opts) {
       if (!lines[i].trim()) continue;
       try {
         var entry = JSON.parse(lines[i]);
-        // Date filter
         if (opts.dateFrom && entry.date && entry.date < opts.dateFrom) continue;
         if (opts.dateTo && entry.date && entry.date > opts.dateTo) continue;
-        docs.push(digestToDoc(entry, i));
+        docs.push(digestToDoc(entry, i, opts.mateName || null));
       } catch (e) {}
     }
   } catch (e) {}
@@ -410,18 +414,29 @@ function searchSessions(sessions, query, opts) {
 /**
  * Unified mate search: digests + session history combined.
  * Returns merged, re-ranked results from both sources.
- * @param {object} opts - { digestFilePath, sessions, query, maxResults, minScore }
- * @returns {Array} [{ source: "digest"|"session", score, ... }]
+ * For global search (e.g. Ally), pass otherDigests array with paths and mate names.
+ * @param {object} opts - { digestFilePath, otherDigests, sessions, query, maxResults, minScore }
+ *   otherDigests: [{ path: string, mateName: string }] - other mates' digest files
+ * @returns {Array} [{ source: "digest"|"session", score, mateName, ... }]
  */
 function searchMate(opts) {
   if (!opts || !opts.query || !opts.query.trim()) return [];
   var maxResults = opts.maxResults || MAX_RESULTS;
   var allDocs = [];
 
-  // Collect digest docs
+  // Collect own digest docs
   if (opts.digestFilePath) {
-    var digestDocs = loadDigestDocs(opts.digestFilePath);
-    for (var dd = 0; dd < digestDocs.length; dd++) allDocs.push(digestDocs[dd]);
+    var ownDocs = loadDigestDocs(opts.digestFilePath);
+    for (var od = 0; od < ownDocs.length; od++) allDocs.push(ownDocs[od]);
+  }
+
+  // Collect other mates' digest docs (global search)
+  if (opts.otherDigests && opts.otherDigests.length > 0) {
+    for (var oi = 0; oi < opts.otherDigests.length; oi++) {
+      var other = opts.otherDigests[oi];
+      var otherDocs = loadDigestDocs(other.path, { mateName: other.mateName });
+      for (var oid = 0; oid < otherDocs.length; oid++) allDocs.push(otherDocs[oid]);
+    }
   }
 
   // Collect session history docs
@@ -447,6 +462,7 @@ function searchMate(opts) {
     if (r.meta.source === "digest") {
       out.digest = r.meta.digest;
       out.lineIdx = r.meta.lineIdx;
+      out.mateName = r.meta.mateName || null;
     } else {
       out.sessionId = r.meta.sessionId;
       out.sessionTitle = r.meta.sessionTitle;
@@ -589,6 +605,9 @@ function formatForContext(results) {
     if (r.source === "digest") {
       var d = r.digest;
       var line = "- [" + (d.date || "?") + "] ";
+      if (r.mateName) {
+        line += "(@" + r.mateName + ") ";
+      }
       if (d.type === "debate" && d.my_role) {
         line += "DEBATE (role: " + d.my_role + ") ";
       }


### PR DESCRIPTION
## Summary

- **Identity protection**: Atomic enforce (5 read/write cycles to 1), identity backup with auto-restore, change tracking via `identity-history.jsonl`
- **BM25 session search**: Unified search module (`session-search.js`) for digests + full session history. Multi-language tokenization (15+ languages). Cmd+K palette upgraded from substring to BM25. Mates auto-search relevant past sessions when responding.
- **Ally global search**: Ally can search all mates' session digests for cross-mate context. Updated template and bio to communicate this to users.
- **Dynamic team roster**: Team section now injects live mate table (name, ID, bio) instead of static "read mates.json" text. Auto-refreshes when any mate is updated. ID-based referencing for stability.

## Test plan

- [ ] Verify enforce doesn't wipe identity on server restart
- [ ] Verify identity backup/restore works when CLAUDE.md is emptied
- [ ] Test Cmd+K search returns BM25-ranked results across projects
- [ ] Test mate mention includes relevant past session context
- [ ] Verify Ally sees other mates' digests in search results
- [ ] Rename a mate and confirm other mates' team sections update
- [ ] Test with Korean, Japanese, Chinese, and European language queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)