### PR TITLE
fix: session history, debate loading UI, skill-install env

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -5131,6 +5131,10 @@ function createProjectContext(opts) {
         if (skillUserInfo) {
           skillSpawnOpts.uid = skillUserInfo.uid;
           skillSpawnOpts.gid = skillUserInfo.gid;
+          skillSpawnOpts.env = Object.assign({}, process.env, {
+            HOME: skillUserInfo.home,
+            npm_config_cache: require("path").join(skillUserInfo.home, ".npm"),
+          });
         }
         console.log("[skill-install] spawning: npx skills add " + url + " --skill " + skill + " --yes " + scopeFlag + " (cwd: " + spawnCwd + ")");
         var child = spawn("npx", ["skills", "add", url, "--skill", skill, "--yes", scopeFlag], skillSpawnOpts);
@@ -5315,8 +5319,12 @@ function createProjectContext(opts) {
           res.end('{"error":"missing skills array"}');
           return;
         }
-        // Read installed versions
-        var globalSkillsDir = path.join(require("./config").REAL_HOME, ".claude", "skills");
+        // Read installed versions (use requesting user's home in multi-user setups)
+        var skillUserHome = (function () {
+          var sui = getOsUserInfoForReq(req);
+          return sui ? sui.home : require("./config").REAL_HOME;
+        })();
+        var globalSkillsDir = path.join(skillUserHome, ".claude", "skills");
         var projectSkillsDir = path.join(cwd, ".claude", "skills");
         var results = [];
         var pending = skills.length;

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -31,7 +31,7 @@ import { initMateWizard, openMateWizard, closeMateWizard, handleMateCreated } fr
 import { initCommandPalette, handlePaletteSessionSwitch, setPaletteVersion } from './modules/command-palette.js';
 import { initLongPress } from './modules/longpress.js';
 import { initMention, handleMentionStart, handleMentionStream, handleMentionDone, handleMentionError, handleMentionActivity, renderMentionUser, renderMentionResponse } from './modules/mention.js';
-import { initDebate, handleDebateStarted, handleDebateResumed, handleDebateTurn, handleDebateActivity, handleDebateStream, handleDebateTurnDone, handleDebateCommentQueued, handleDebateCommentInjected, handleDebateEnded, handleDebateError, renderDebateStarted, renderDebateTurnDone, renderDebateEnded, renderDebateCommentInjected, renderDebateUserResume, openDebateModal, closeDebateModal, openQuickDebateModal, handleDebateBriefReady, renderDebateBriefReady, isDebateActive, resetDebateState } from './modules/debate.js';
+import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateResumed, handleDebateTurn, handleDebateActivity, handleDebateStream, handleDebateTurnDone, handleDebateCommentQueued, handleDebateCommentInjected, handleDebateEnded, handleDebateError, renderDebateStarted, renderDebateTurnDone, renderDebateEnded, renderDebateCommentInjected, renderDebateUserResume, openDebateModal, closeDebateModal, openQuickDebateModal, handleDebateBriefReady, renderDebateBriefReady, isDebateActive, resetDebateState } from './modules/debate.js';
 
 // --- Base path for multi-project routing ---
   var slugMatch = location.pathname.match(/^\/p\/([a-z0-9_-]+)/);
@@ -4979,6 +4979,7 @@ import { initDebate, handleDebateStarted, handleDebateResumed, handleDebateTurn,
         // --- Debate ---
         case "debate_preparing":
           showDebateSticky("preparing", msg);
+          handleDebatePreparing(msg);
           break;
 
         case "debate_brief_ready":

--- a/lib/public/css/debate.css
+++ b/lib/public/css/debate.css
@@ -331,6 +331,54 @@
   color: var(--text);
 }
 
+/* --- Preparing indicator (shown while brief is being generated) --- */
+.debate-preparing-indicator {
+  max-width: var(--content-width);
+  margin: 32px auto;
+  padding: 0 20px;
+}
+
+.debate-preparing-inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 20px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent2) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent2) 15%, transparent);
+}
+
+.debate-preparing-spinner {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--accent2);
+  animation: spin 1.2s linear infinite;
+}
+
+.debate-preparing-spinner .lucide {
+  width: 20px;
+  height: 20px;
+}
+
+.debate-preparing-text {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.debate-preparing-dots {
+  animation: blink-dots 1.4s steps(4, end) infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes blink-dots {
+  0%, 20% { opacity: 0; }
+  40% { opacity: 1; }
+}
+
 /* --- Activity bar inside turns --- */
 .debate-activity-bar {
   margin: 4px 0;

--- a/lib/public/modules/debate.js
+++ b/lib/public/modules/debate.js
@@ -31,6 +31,11 @@ export function resetDebateState() {
   flushTurnStream();
   currentTurnEl = null;
   currentTurnMateId = null;
+  // Remove preparing indicator if present
+  if (ctx && ctx.messagesEl) {
+    var prep = ctx.messagesEl.querySelector(".debate-preparing-indicator");
+    if (prep) prep.remove();
+  }
 }
 
 function buildAvatarUrl(meta) {
@@ -85,7 +90,43 @@ export function handleDebateResumed(msg) {
   showDebateInfoFloat(msg);
 }
 
+export function handleDebatePreparing(msg) {
+  debatePhase = "preparing";
+
+  if (!ctx.messagesEl) return;
+
+  // Remove any existing preparing indicator
+  var existing = ctx.messagesEl.querySelector(".debate-preparing-indicator");
+  if (existing) existing.remove();
+
+  var el = document.createElement("div");
+  el.className = "debate-preparing-indicator";
+
+  var moderatorName = msg.moderatorName || "Moderator";
+  var panelistNames = (msg.panelists || []).map(function (p) { return p.name; }).filter(Boolean).join(", ");
+
+  el.innerHTML =
+    '<div class="debate-preparing-inner">' +
+      '<div class="debate-preparing-spinner">' + iconHtml("loader") + '</div>' +
+      '<div class="debate-preparing-text">' +
+        '<strong>' + escapeHtml(moderatorName) + '</strong> is setting up the debate' +
+        (panelistNames ? ' with <strong>' + escapeHtml(panelistNames) + '</strong>' : '') +
+        '<span class="debate-preparing-dots">...</span>' +
+      '</div>' +
+    '</div>';
+
+  ctx.messagesEl.appendChild(el);
+  refreshIcons();
+  if (ctx.scrollToBottom) ctx.scrollToBottom();
+}
+
 export function handleDebateStarted(msg) {
+  // Remove preparing indicator when debate goes live
+  if (ctx.messagesEl) {
+    var prep = ctx.messagesEl.querySelector(".debate-preparing-indicator");
+    if (prep) prep.remove();
+  }
+
   debateActive = true;
   debateTopic = msg.topic || "";
   debateRound = 1;

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -821,9 +821,14 @@ function createSDKBridge(opts) {
           worker._readyResolve = null;
           // Let the readyPromise hang; the query_error handler will clean up
         }
-        // Notify message handlers about unexpected exit so sessions don't hang
+        // Notify message handlers about unexpected exit so sessions don't hang.
+        // Always dispatch a fallback query_error. The handler is idempotent:
+        // it checks isProcessing before taking action, and cleanupSessionWorker
+        // guards against stale workers. This covers all exit cases including
+        // signal kills (code=null) and normal exits where the IPC query_error
+        // was lost due to connection timing.
         if (code === 0 && !worker.ready) {
-          // Worker exited cleanly before sending "ready" — something is wrong
+          // Worker exited cleanly before sending "ready"
           for (var h = 0; h < worker.messageHandlers.length; h++) {
             worker.messageHandlers[h]({
               type: "query_error",
@@ -832,15 +837,33 @@ function createSDKBridge(opts) {
               stderr: worker._stderrBuf || null,
             });
           }
-        }
-        if (code !== 0 && code !== null) {
+        } else if (code !== 0 || code === null || signal) {
+          // Worker crashed, was killed by signal, or exited abnormally
           var stderrText = worker._stderrBuf || "";
+          var exitReason = signal
+            ? "Worker killed by " + signal
+            : (stderrText || "Worker exited with code " + code);
           for (var h = 0; h < worker.messageHandlers.length; h++) {
             worker.messageHandlers[h]({
               type: "query_error",
-              error: stderrText || "Worker exited with code " + code,
+              error: exitReason,
               exitCode: code,
               stderr: stderrText || null,
+            });
+          }
+        } else if (worker.messageHandlers.length > 0) {
+          // Normal exit (code=0, ready=true). Dispatch fallback in case the
+          // IPC query_done/query_error was lost (e.g. connection closed early).
+          var fallbackMsg = worker._abortSent
+            ? "Worker aborted"
+            : "Worker exited before query completed";
+          for (var h = 0; h < worker.messageHandlers.length; h++) {
+            worker.messageHandlers[h]({
+              type: "query_error",
+              error: fallbackMsg,
+              exitCode: 0,
+              stderr: worker._stderrBuf || null,
+              _fallback: true,
             });
           }
         }
@@ -863,13 +886,17 @@ function createSDKBridge(opts) {
 
     worker.kill = function() {
       worker.send({ type: "shutdown" });
-      // Force kill after 3 seconds if still alive
+      // Force kill after 5 seconds if still alive (gives SDK time to save session)
       setTimeout(function() {
         if (worker.process && !worker.process.killed) {
           try { worker.process.kill("SIGKILL"); } catch (e) {}
         }
-      }, 3000);
-      cleanupWorker(worker);
+      }, 5000);
+      // Don't call cleanupWorker here. Let the exit handler do it after
+      // the worker has had time to save SDK session state to disk.
+      // Closing the connection prematurely causes the worker to exit
+      // before the SDK can flush its session file, leading to "no
+      // conversation found" errors on resume (OS multi-user mode).
     };
 
     return worker;
@@ -942,7 +969,7 @@ function createSDKBridge(opts) {
     session.pendingElicitations = {};
     session.streamedText = false;
     session.responsePreview = "";
-    session.abortController = { abort: function() { worker.send({ type: "abort" }); } };
+    session.abortController = { abort: function() { worker._abortSent = true; worker.send({ type: "abort" }); } };
 
     // Build initial user message content
     var content = [];
@@ -1049,6 +1076,9 @@ function createSDKBridge(opts) {
           break;
 
         case "query_done":
+          // Mark that we received a proper IPC completion, so the exit
+          // handler fallback knows not to double-process.
+          worker._queryEnded = true;
           // Stream ended normally
           if (session.isProcessing && session.taskStopRequested) {
             session.isProcessing = false;
@@ -1066,6 +1096,10 @@ function createSDKBridge(opts) {
           break;
 
         case "query_error": {
+          // Skip fallback errors from exit handler if we already handled the real one
+          if (msg._fallback && worker._queryEnded) break;
+          // Mark that we received a proper IPC completion
+          worker._queryEnded = true;
           // Check session-not-found before isProcessing gate (it can arrive after processing is cleared)
           var qerrLower = (msg.error || "").toLowerCase();
           // Only match the exact SDK error, not generic worker stderr

--- a/lib/sdk-worker.js
+++ b/lib/sdk-worker.js
@@ -124,8 +124,7 @@ function handleMessage(msg) {
       handleWarmup(msg);
       break;
     case "shutdown":
-      cleanup();
-      process.exit(0);
+      gracefulExit(0);
       break;
     default:
       console.error("[sdk-worker] Unknown message type:", msg.type);
@@ -393,6 +392,7 @@ async function handleWarmup(msg) {
 }
 
 // --- Cleanup ---
+var _exitScheduled = false;
 function cleanup() {
   if (_keepAlive) {
     try { clearInterval(_keepAlive); } catch (e) {}
@@ -406,6 +406,16 @@ function cleanup() {
   if (conn && !conn.destroyed) {
     try { conn.end(); } catch (e) {}
   }
+}
+
+// Exit with a grace period so the SDK can flush session state to disk.
+// Without this, process.exit(0) kills pending async writes and the
+// session file may be incomplete, causing "no conversation found" on resume.
+function gracefulExit(code) {
+  if (_exitScheduled) return;
+  _exitScheduled = true;
+  cleanup();
+  setTimeout(function() { process.exit(code); }, 800);
 }
 
 // Keep event loop alive — without this, Node may exit if the socket handle
@@ -436,25 +446,21 @@ conn.on("data", function(chunk) {
 
 conn.on("error", function(err) {
   console.error("[sdk-worker] Socket error:", err.message);
-  cleanup();
-  process.exit(1);
+  gracefulExit(1);
 });
 
 conn.on("close", function() {
   try { require("fs").writeSync(2, "[sdk-worker] EXIT REASON: socket closed\n"); } catch (e) {}
-  cleanup();
-  process.exit(0);
+  gracefulExit(0);
 });
 
 // Handle process signals
 process.on("SIGTERM", function() {
   try { require("fs").writeSync(2, "[sdk-worker] EXIT REASON: SIGTERM\n"); } catch (e) {}
-  cleanup();
-  process.exit(0);
+  gracefulExit(0);
 });
 
 process.on("SIGINT", function() {
   try { require("fs").writeSync(2, "[sdk-worker] EXIT REASON: SIGINT\n"); } catch (e) {}
-  cleanup();
-  process.exit(0);
+  gracefulExit(0);
 });


### PR DESCRIPTION
## Summary
- fix: prevent session history loss after stop in OS multi-user mode
- fix(ui): show loading indicator during debate preparing phase
- fix: set HOME and npm_config_cache env for skill-install child process

## Changed files
- `lib/project.js` - session history preservation logic
- `lib/public/app.js`, `lib/public/css/debate.css`, `lib/public/modules/debate.js` - debate loading UI
- `lib/sdk-bridge.js`, `lib/sdk-worker.js` - skill-install child process env setup