### PR TITLE
fix: use /bin/sh as POSIX fallback shell instead of /bin/zsh

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -13,7 +13,7 @@ function createTerminal(cwd, cols, rows, osUserInfo) {
   // Determine shell: prefer target user's shell, then $SHELL, then platform default
   var shell = (osUserInfo && osUserInfo.shell)
     || process.env.SHELL
-    || (process.platform === "win32" ? process.env.COMSPEC || "cmd.exe" : "/bin/zsh");
+    || (process.platform === "win32" ? process.env.COMSPEC || "cmd.exe" : "/bin/sh");
 
   // Build a minimal, isolated environment (no daemon env leakage)
   var termEnv = buildUserEnv(osUserInfo);


### PR DESCRIPTION
## Problem

On systems without zsh (e.g. Debian/Ubuntu minimal installs), the hardcoded `/bin/zsh` fallback in `terminal.js` causes `execvp(3) failed.: No such file or directory` on every terminal open attempt, with repeated `[Process exited]` messages.

The shell resolution chain is:
1. `osUserInfo.shell` — null in single-user mode
2. `process.env.SHELL` — absent when the daemon is launched via systemd without `SHELL` in the unit environment
3. Hardcoded fallback: `/bin/zsh` — not present on many Linux systems

## Fix

Change the Unix fallback from `/bin/zsh` to `/bin/sh`. `/bin/sh` is POSIX-guaranteed and present on every Unix system.

## Diff

One character change in `lib/terminal.js`.