### PR TITLE
fix: add chat layout toggle to mobile settings sheet

### DIFF
--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -4,7 +4,7 @@ import { iconHtml, refreshIcons } from './icons.js';
 import { openProjectSettings } from './project-settings.js';
 import { triggerShare } from './qrcode.js';
 import { parseEmojis } from './markdown.js';
-import { getCurrentTheme } from './theme.js';
+import { getCurrentTheme, getChatLayout, setChatLayout } from './theme.js';
 import { showMateProfilePopover } from './profile.js';
 import { closeArchive } from './sticky-notes.js';
 import { closeScheduler } from './scheduler.js';
@@ -1720,6 +1720,27 @@ function renderSheetSettings(listEl) {
   });
 
   listEl.appendChild(themeBtn);
+
+  // Chat Layout switch button
+  var currentLayout = getChatLayout();
+  var isBubble = currentLayout === "bubble";
+  var layoutBtn = document.createElement("button");
+  layoutBtn.className = "mobile-more-item";
+  layoutBtn.innerHTML = '<i data-lucide="' + (isBubble ? "monitor" : "message-circle") + '"></i>'
+    + '<span class="mobile-more-item-label">Switch to ' + (isBubble ? "Channel" : "Bubble") + '</span>';
+
+  layoutBtn.addEventListener("click", function () {
+    var next = getChatLayout() === "bubble" ? "channel" : "bubble";
+    setChatLayout(next);
+    fetch('/api/user/chat-layout', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ layout: next })
+    });
+    closeMobileSheet();
+  });
+
+  listEl.appendChild(layoutBtn);
 
   // "Open as app" — only show if not already in PWA standalone mode
   if (!document.documentElement.classList.contains("pwa-standalone")) {


### PR DESCRIPTION
## Problem

The mobile settings sheet (`renderSheetSettings` in `sidebar.js`) was missing the Bubble/Channel layout toggle that exists in the desktop Settings → Appearance panel.

On mobile, the layout defaults to Channel with no way to change it — the desktop settings modal is unreachable from the mobile bottom tab bar, and the chat layout option was never added to the mobile sheet.

## Fix

Adds a "Switch to Bubble/Channel" button to the mobile settings sheet, directly after the theme toggle. It:
- Reads current layout via `getChatLayout()` from `theme.js` (already exported)
- Labels and icons itself based on current state (same pattern as the theme button)
- Calls `setChatLayout()` for immediate local effect
- Persists via `PUT /api/user/chat-layout` (same as the desktop panel)
- Closes the sheet after toggling

## Changes

- `lib/public/modules/sidebar.js`: extend `theme.js` import + add layout button block in `renderSheetSettings`