### PR TITLE
fix: remove skeleton placeholders from icon-strip-users at startup

### DIFF
--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -64,11 +64,7 @@
       <div class="skeleton-icon-strip-item"></div>
     </div>
     <button class="icon-strip-add" id="icon-strip-add" title="Add project"><i data-lucide="plus"></i></button>
-    <div class="icon-strip-users" id="icon-strip-users">
-      <div class="skeleton-icon-strip-user"></div>
-      <div class="skeleton-icon-strip-user"></div>
-      <div class="skeleton-icon-strip-user"></div>
-    </div>
+    <div class="icon-strip-users hidden" id="icon-strip-users"></div>
     <div class="icon-strip-me" id="icon-strip-me"></div>
   </div>
 


### PR DESCRIPTION
## Problem

Reported in #272.

In single-user mode, `projects_updated` is broadcast without `allUsers`, so `renderUserStrip` is never called. The three `skeleton-icon-strip-user` divs baked into `index.html` are never cleared, leaving animated placeholder circles permanently overlaying the bottom project icons in the nav rail.

## Root Cause

`broadcastPresenceChange()` in `server.js` has an early return for single-user mode that omits `allUsers` from the payload. Since the client only calls `renderUserStrip` when `msg.allUsers` is present, the skeleton divs in `index.html` are never touched.

## Fix

Start `#icon-strip-users` empty with the `hidden` class. `renderUserStrip` already calls `container.classList.remove('hidden')` and populates the container when `allUsers` arrives in multi-user mode, so the change is safe for both modes — the strip will appear exactly when it should and not before.

One-line change to `index.html`.

**Note:** This fix was verified working in single-user mode. Multi-user mode was not tested locally (no second user available), but the logic path is unchanged — `renderUserStrip` still clears and repopulates the container when called.

Fixes #272