### PR TITLE
fix(debate): session visibility, active dots, and context sources extension prompt

### DIFF
--- a/lib/project-debate.js
+++ b/lib/project-debate.js
@@ -768,6 +768,13 @@ function attachDebate(ctx) {
     ctx.sdk.startQuery(setupSession, craftingPrompt, undefined, ctx.getLinuxUserForSession(setupSession));
   }
 
+  // --- Mate strip processing indicator ---
+  // Broadcast mention_processing so the correct mate's active dot lights up
+  // on the mate strip during debate turns (instead of always the moderator's).
+  function debateMateProcessing(mateId, active) {
+    ctx.send({ type: "mention_processing", mateId: mateId, active: active });
+  }
+
   // --- Live debate ---
 
   function startDebateLive(session) {
@@ -817,6 +824,7 @@ function attachDebate(ctx) {
     ctx.sendToSession(debateSession.localId, debateStartEntry);
 
     // Signal moderator's first turn
+    debateMateProcessing(debate.moderatorId, true);
     ctx.sendToSession(debateSession.localId, {
       type: "debate_turn",
       mateId: debate.moderatorId,
@@ -871,6 +879,7 @@ function attachDebate(ctx) {
     var debate = session._debate;
     if (!debate || debate.phase === "ended") return;
 
+    debateMateProcessing(debate.moderatorId, false);
     debate.turnInProgress = false;
 
     // Record in debate history
@@ -942,6 +951,7 @@ function attachDebate(ctx) {
     }
     if (!panelistInfo) {
       console.error("[debate] Panelist not found:", mateId);
+      debateMateProcessing(mateId, false);
       debate._currentTurnMateId = null;
       // Feed error back to moderator
       feedBackToModerator(session, mateId, "[This panelist is not part of the debate panel.]");
@@ -949,6 +959,7 @@ function attachDebate(ctx) {
     }
 
     // Notify clients of new turn
+    debateMateProcessing(mateId, true);
     ctx.sendToSession(session.localId, {
       type: "debate_turn",
       mateId: mateId,
@@ -977,6 +988,7 @@ function attachDebate(ctx) {
       },
       onError: function (errMsg) {
         console.error("[debate] Panelist error for " + mateId + ":", errMsg);
+        debateMateProcessing(mateId, false);
         debate.turnInProgress = false;
         // Feed error back to moderator so the debate can continue
         feedBackToModerator(session, mateId, "[" + profile.name + " encountered an error and could not respond. Please continue with other panelists or wrap up.]");
@@ -1037,6 +1049,7 @@ function attachDebate(ctx) {
         }
       }).catch(function (err) {
         console.error("[debate] Failed to create panelist session for " + mateId + ":", err.message || err);
+        debateMateProcessing(mateId, false);
         debate.turnInProgress = false;
         feedBackToModerator(session, mateId, "[" + profile.name + " is unavailable. Please continue with other panelists or wrap up.]");
       });
@@ -1047,6 +1060,7 @@ function attachDebate(ctx) {
     var debate = session._debate;
     if (!debate || debate.phase === "ended") return;
 
+    debateMateProcessing(mateId, false);
     debate.turnInProgress = false;
     debate._currentTurnMateId = null;
     debate._currentTurnText = "";
@@ -1110,6 +1124,7 @@ function attachDebate(ctx) {
     var moderatorProfile = ctx.getMateProfile(debate.mateCtx, debate.moderatorId);
 
     // Notify clients of moderator turn
+    debateMateProcessing(debate.moderatorId, true);
     ctx.sendToSession(session.localId, {
       type: "debate_turn",
       mateId: debate.moderatorId,
@@ -1325,6 +1340,7 @@ function attachDebate(ctx) {
     debate.turnInProgress = true;
     var moderatorProfile = ctx.getMateProfile(debate.mateCtx, debate.moderatorId);
 
+    debateMateProcessing(debate.moderatorId, true);
     ctx.sendToSession(session.localId, {
       type: "debate_turn",
       mateId: debate.moderatorId,
@@ -1514,6 +1530,7 @@ function attachDebate(ctx) {
       ctx.sendToSession(session.localId, resumedMsg);
 
       debate.turnInProgress = true;
+      debateMateProcessing(debate.moderatorId, true);
       ctx.sendToSession(session.localId, {
         type: "debate_turn",
         mateId: debate.moderatorId,
@@ -1586,6 +1603,12 @@ function attachDebate(ctx) {
   function endDebate(session, reason) {
     var debate = session._debate;
     if (!debate || debate.phase === "ended") return;
+
+    // Clear all mate strip processing dots
+    debateMateProcessing(debate.moderatorId, false);
+    for (var ei = 0; ei < debate.panelists.length; ei++) {
+      debateMateProcessing(debate.panelists[ei].mateId, false);
+    }
 
     debate.phase = "ended";
     debate.turnInProgress = false;

--- a/lib/project-debate.js
+++ b/lib/project-debate.js
@@ -157,14 +157,15 @@ function attachDebate(ctx) {
       round: d.round || 1,
       awaitingConcludeConfirm: !!d.awaitingConcludeConfirm,
       awaitingUserFloor: !!d.awaitingUserFloor,
+      ownerId: d.ownerId || null,
     };
     ctx.sm.saveSessionFile(session);
   }
 
-  function restoreDebateFromState(session) {
+  function restoreDebateFromState(session, restoreUserId) {
     var ds = session.debateState;
     if (!ds) return null;
-    var userId = null; // Will be set when WS connects
+    var userId = restoreUserId || ds.ownerId || null;
     var mateCtx = matesModule.buildMateCtx(userId);
     var debate = {
       phase: ds.phase,
@@ -188,6 +189,7 @@ function attachDebate(ctx) {
       briefPath: ds.briefPath || null,
       awaitingConcludeConfirm: !!ds.awaitingConcludeConfirm,
       awaitingUserFloor: !!ds.awaitingUserFloor,
+      ownerId: ds.ownerId || userId,
     };
 
     // Fallback: if awaitingConcludeConfirm was not persisted, detect from history
@@ -334,8 +336,8 @@ function attachDebate(ctx) {
       var phase = session.debateState.phase;
       if (phase !== "preparing" && phase !== "reviewing" && phase !== "live") return;
 
-      // Restore _debate from persisted state
-      var debate = restoreDebateFromState(session);
+      // Restore _debate from persisted state (pass userId for correct mateCtx)
+      var debate = restoreDebateFromState(session, userId);
       if (!debate) return;
 
       // Update mateCtx with the connected user's context
@@ -463,6 +465,7 @@ function attachDebate(ctx) {
         setupSessionId: null,
         debateId: debateId,
         briefPath: briefPath,
+        ownerId: mateCtx.userId || null,
       };
       debate.nameMap = buildDebateNameMap(debate.panelists, mateCtx);
       session._debate = debate;
@@ -550,6 +553,7 @@ function attachDebate(ctx) {
       round: 1,
       history: [],
       setupSessionId: null,
+      ownerId: userId,
     };
     session._debate = debate;
 
@@ -577,7 +581,8 @@ function attachDebate(ctx) {
     var debateId = debate.debateId;
 
     // Create setup session (still needed for session grouping)
-    var setupSession = ctx.sm.createSession();
+    var setupOpts = debate.ownerId ? { ownerId: debate.ownerId } : null;
+    var setupSession = ctx.sm.createSession(setupOpts);
     setupSession.title = "Debate Setup: " + (msg.topic || "Quick").slice(0, 40);
     setupSession.debateSetupMode = true;
     setupSession.loop = { active: true, iteration: 0, role: "crafting", loopId: debateId, name: (msg.topic || "Quick").slice(0, 40), source: "debate", startedAt: Date.now() };
@@ -702,7 +707,8 @@ function attachDebate(ctx) {
     var debateId = debate.debateId;
 
     // Create a new session for the setup skill (like Ralph crafting)
-    var setupSession = ctx.sm.createSession();
+    var skillSetupOpts = debate.ownerId ? { ownerId: debate.ownerId } : null;
+    var setupSession = ctx.sm.createSession(skillSetupOpts);
     setupSession.title = "Debate Setup: " + msg.topic.slice(0, 40);
     setupSession.debateSetupMode = true;
     setupSession.loop = { active: true, iteration: 0, role: "crafting", loopId: debateId, name: msg.topic.slice(0, 40), source: "debate", startedAt: Date.now() };
@@ -776,7 +782,8 @@ function attachDebate(ctx) {
     var moderatorProfile = ctx.getMateProfile(mateCtx, debate.moderatorId);
 
     // Create a dedicated debate session, grouped with the setup session
-    var debateSession = ctx.sm.createSession();
+    var liveOpts = debate.ownerId ? { ownerId: debate.ownerId } : null;
+    var debateSession = ctx.sm.createSession(liveOpts);
     debateSession.title = debate.topic.slice(0, 50);
     debateSession.loop = { active: true, iteration: 1, role: "debate", loopId: debate.debateId, name: debate.topic.slice(0, 40), source: "debate", startedAt: debate.setupStartedAt || Date.now() };
     ctx.sm.saveSessionFile(debateSession);

--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -437,6 +437,39 @@
   font-size: 13px;
   text-align: center;
 }
+.context-picker-ext-notice {
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.context-picker-ext-notice-text {
+  font-size: 12px;
+  color: var(--text-dimmer);
+  line-height: 1.4;
+}
+.context-picker-ext-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--bg-hover, rgba(255,255,255,0.06));
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s;
+  width: fit-content;
+}
+.context-picker-ext-btn:hover {
+  background: var(--bg-active, rgba(255,255,255,0.1));
+}
+.context-picker-ext-btn .lucide {
+  width: 13px;
+  height: 13px;
+}
 
 .context-picker-favicon {
   width: 14px;

--- a/lib/public/modules/context-sources.js
+++ b/lib/public/modules/context-sources.js
@@ -223,12 +223,27 @@ function renderPicker() {
   var tabSection = document.getElementById("context-picker-tabs");
   tabSection.innerHTML = "";
 
-  if (browserTabList.length > 0) {
-    var tabLabel = document.createElement("div");
-    tabLabel.className = "context-picker-section-label";
-    tabLabel.textContent = "Browser Tabs";
-    tabSection.appendChild(tabLabel);
+  var tabLabel = document.createElement("div");
+  tabLabel.className = "context-picker-section-label";
+  tabLabel.textContent = "Browser Tabs";
+  tabSection.appendChild(tabLabel);
 
+  if (browserTabList.length === 0) {
+    // Extension not connected: show notice with setup button
+    var notice = document.createElement("div");
+    notice.className = "context-picker-ext-notice";
+    notice.innerHTML =
+      '<span class="context-picker-ext-notice-text">Chrome extension required to access browser tabs.</span>' +
+      '<button class="context-picker-ext-btn" type="button"><i data-lucide="puzzle"></i> Setup Extension</button>';
+    var setupBtn = notice.querySelector(".context-picker-ext-btn");
+    setupBtn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      closePicker();
+      var extPill = document.getElementById("ext-pill");
+      if (extPill) extPill.click();
+    });
+    tabSection.appendChild(notice);
+  } else {
     for (var j = 0; j < browserTabList.length; j++) {
       var tab = browserTabList[j];
       var tabSourceId = "tab:" + tab.id;


### PR DESCRIPTION
## Summary
- **Debate session visibility**: propagate `ownerId` to all debate sessions (setup, skill setup, live) so they appear in the mate DM conversation list for non-admin users in multi-user mode. Also fix `restoreDebateFromState` to use the correct userId for `buildMateCtx` instead of hardcoded `null`, which caused empty nameMap and broken mention detection on restore.
- **Mate strip active dot**: broadcast `mention_processing` with the correct `mateId` at each debate turn boundary so the speaking mate's dot lights up (not always the moderator's). Clears all participant dots on debate end.
- **Context sources extension prompt**: always show the "Browser Tabs" section in the context sources picker. When the extension is not connected, display a notice with a "Setup Extension" button that opens the extension popover.

## Test plan
- [ ] Start a debate in multi-user mode as a non-admin user, verify setup and live sessions appear in the mate DM sidebar
- [ ] During a debate, verify the correct mate's strip dot lights up when they speak
- [ ] Restart the server mid-debate, reconnect, verify nameMap is populated and mentions work
- [ ] Open context sources picker without the Chrome extension installed, verify the notice and button appear
- [ ] Click "Setup Extension" button, verify the extension popover opens