### PR TITLE
fix: pass missing getOsUserInfoForWs to project-user-message

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -886,6 +886,7 @@ function createProjectContext(opts) {
     matesModule: matesModule,
     getSessionForWs: getSessionForWs,
     getLinuxUserForSession: getLinuxUserForSession,
+    getOsUserInfoForWs: getOsUserInfoForWs,
     hydrateImageRefs: hydrateImageRefs,
     saveImageFile: saveImageFile,
     imagesDir: imagesDir,


### PR DESCRIPTION
Terminal creation crashed with `getOsUserInfoForWs is not a function` because the dependency was not passed in the attachUserMessage ctx wiring.