### PR TITLE
fix: pass missing requestTabContext to project-user-message

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -894,6 +894,7 @@ function createProjectContext(opts) {
     _loop: _loop,
     browserState: { _browserTabList: _browserTabList, _extensionWs: _extensionWs, pendingExtensionRequests: pendingExtensionRequests },
     sendExtensionCommandAny: sendExtensionCommandAny,
+    requestTabContext: requestTabContext,
     scheduleMessage: scheduleMessage,
     cancelScheduledMessage: cancelScheduledMessage,
     loadContextSources: loadContextSources,


### PR DESCRIPTION
Context source tab injection crashed with `requestTabContext is not a function` because the dependency was not passed in the attachUserMessage ctx wiring.