### PR TITLE
fix: pass mcpServers to mention sessions for debate quick-start

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -2386,6 +2386,7 @@ function createSDKBridge(opts) {
           },
         };
       if (opts.model) mentionQueryOptions.model = opts.model;
+      if (mcpServers) mentionQueryOptions.mcpServers = mcpServers;
       query = sdk.query({
         prompt: mq,
         options: mentionQueryOptions,


### PR DESCRIPTION
Debate quick-start setup screen was empty because the moderator mention session had no MCP tools. Added mcpServers to createMentionSession query options.