### PR TITLE
fix: use shared checkToolWhitelist for mention session canUseTool

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -2375,9 +2375,9 @@ function createSDKBridge(opts) {
           includePartialMessages: true,
           abortController: abortController,
           canUseTool: opts.canUseTool || function (toolName, input) {
-            var allowed = { Read: true, Glob: true, Grep: true, WebFetch: true, WebSearch: true };
-            if (allowed[toolName]) {
-              return Promise.resolve({ behavior: "allow", updatedInput: input });
+            var whitelisted = checkToolWhitelist(toolName, input);
+            if (whitelisted) {
+              return Promise.resolve(whitelisted);
             }
             return Promise.resolve({
               behavior: "deny",
@@ -2386,7 +2386,7 @@ function createSDKBridge(opts) {
           },
         };
       if (opts.model) mentionQueryOptions.model = opts.model;
-      if (mcpServers) mentionQueryOptions.mcpServers = mcpServers;
+      if (opts.includeMcpServers && mcpServers) mentionQueryOptions.mcpServers = mcpServers;
       query = sdk.query({
         prompt: mq,
         options: mentionQueryOptions,


### PR DESCRIPTION
Debate quick-start brief generation failed because mention sessions used a hardcoded whitelist that excluded MCP tools. Now uses the shared checkToolWhitelist which already auto-approves debate MCP tools and safe bash commands.