### PR TITLE
fix(debate): send brief_ready to setup session in quickStart flow

### DIFF
--- a/lib/project-debate.js
+++ b/lib/project-debate.js
@@ -299,6 +299,10 @@ function attachDebate(ctx) {
             }),
           };
           ctx.sendToSession(session.localId, briefReadyMsg);
+          // Also send to setup session if client switched there (quickStart flow)
+          if (debate.setupSessionId && debate.setupSessionId !== session.localId) {
+            ctx.sendToSession(debate.setupSessionId, briefReadyMsg);
+          }
         } else {
           console.log("[debate] Brief picked up, transitioning to live. Topic:", debate.topic);
           // Transition to live (standard flow via modal/skill)


### PR DESCRIPTION
QuickStart debate setup screen was blank because brief_ready was sent to the DM session while the client was viewing the setup session.