### PR TITLE
fix: auth resume, bypassPermissions, stale mate DM, mention indicator

### DIFF
--- a/docs/REFACTORING_ROADMAP.md
+++ b/docs/REFACTORING_ROADMAP.md
@@ -597,7 +597,7 @@ app.js is 8,066 lines with 90+ WebSocket message types in a single `processMessa
 - `handleMateCreatedInApp`, `renderAvailableBuiltins`, `buildMateInterviewPrompt`
 - `updateMateIconStatus`, `connectMateProject`, `disconnectMateProject`
 - DM state: `dmMode`, `dmKey`, `dmTargetUser`, `dmMessageCache`, `dmUnread`, `cachedAllUsers`, `cachedOnlineIds`, `cachedDmFavorites`, `cachedDmConversations`, `cachedMatesList`
-- Mate project state: `mateProjectSlug`, `savedMainSlug`, `returningFromMateDm`
+- Mate project state: `mateProjectSlug`, `savedMainSlug`, `pendingMateDmClears`
 
 **Interface**: `initDm(ctx)` returns `{ openDm, exitDmMode, isDmMode, ... }`.
 

--- a/lib/project-mate-interaction.js
+++ b/lib/project-mate-interaction.js
@@ -569,6 +569,10 @@ function attachMateInteraction(ctx) {
         onDone: mentionCallbacks.onDone,
         onError: mentionCallbacks.onError,
         canUseTool: function (toolName, input, toolOpts) {
+          // Full-auto mode: auto-approve everything except AskUserQuestion
+          if (sm.currentPermissionMode === "bypassPermissions" && toolName !== "AskUserQuestion") {
+            return Promise.resolve({ behavior: "allow", updatedInput: input });
+          }
           // Use the shared whitelist from sdk-bridge (read-only tools + safe bash commands)
           var whitelisted = sdk.checkToolWhitelist(toolName, input);
           if (whitelisted) return Promise.resolve(whitelisted);

--- a/lib/project-mate-interaction.js
+++ b/lib/project-mate-interaction.js
@@ -445,6 +445,7 @@ function attachMateInteraction(ctx) {
     }
 
     session._mentionInProgress = true;
+    session._mentionActiveMateId = msg.mateId;
 
     // Send mention start indicator
     sendToSession(session.localId, {
@@ -478,6 +479,7 @@ function attachMateInteraction(ctx) {
       },
       onDone: function (fullText) {
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
 
         // Save mention response to session history
         var mentionResponseEntry = {
@@ -512,6 +514,7 @@ function attachMateInteraction(ctx) {
       },
       onError: function (errMsg) {
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
         // Clean up dead session
         if (session._mentionSessions && session._mentionSessions[msg.mateId]) {
           delete session._mentionSessions[msg.mateId];
@@ -614,6 +617,7 @@ function attachMateInteraction(ctx) {
         }
       }).catch(function (err) {
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
         console.error("[mention] Failed to create session for mate " + msg.mateId + ":", err.message || err);
         sendToSession(session.localId, { type: "mention_error", mateId: msg.mateId, error: "Failed to create mention session." });
       });

--- a/lib/project.js
+++ b/lib/project.js
@@ -624,6 +624,7 @@ function createProjectContext(opts) {
           delete session._mentionSessions[mateId];
         }
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
         sendToSession(session.localId, { type: "mention_done", mateId: mateId, stopped: true });
         send({ type: "mention_processing", mateId: mateId, active: false });
       }

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -89,15 +89,1206 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   // --- Mate project switching ---
   var mateProjectSlug = null;
   var savedMainSlug = null; // main project slug saved during mate DM
-  var returningFromMateDm = false; // suppress restore_mate_dm after intentional exit
+  var pendingMateDmClears = {}; // slug → true: suppress restore_mate_dm and clear server state
+
+  // --- Home Hub ---
+  var homeHub = $("home-hub");
+  var homeHubVisible = false;
+  var hubSchedules = [];
+
+  var hubTips = [
+    "Sticky notes let you pin important info that persists across sessions.",
+    "You can run terminal commands directly from the terminal tab — no need to switch windows.",
+    "Rename your sessions to keep conversations organized and easy to find later.",
+    "The file browser lets you explore and open any file in your project.",
+    "Paste images from your clipboard into the chat to include them in your message.",
+    "Use /commands (slash commands) for quick access to common actions.",
+    "You can resize the sidebar by dragging its edge.",
+    "Click the session info button in the header to see token usage and costs.",
+    "You can switch between projects without losing your conversation history.",
+    "The status dot on project icons shows whether Claude is currently processing.",
+    "Right-click on a project icon for quick actions like rename or delete.",
+    "Push notifications can alert you when Claude finishes a long task.",
+    "You can search through your conversation history within a session.",
+    "Session history is preserved — come back anytime to continue where you left off.",
+    "Use the rewind feature to go back to an earlier point in your conversation.",
+    "You can open multiple terminal tabs for parallel command execution.",
+    "Clay works offline as a PWA — install it from your browser for quick access.",
+    "Schedule recurring tasks with cron expressions to automate your workflow.",
+    "Use Ralph Loops to run autonomous coding sessions while you're away.",
+    "Right-click a project icon to set a custom emoji — make each project instantly recognizable.",
+    "Multiple people can connect to the same project at once — great for pair programming.",
+    "Drag and drop project icons to reorder them in the sidebar.",
+    "Drag a project icon to the trash to delete it.",
+    "Honey never spoils. 🍯",
+    "The Earth is round. 🌍",
+    "Computers use electricity. 🔌",
+    "Christmas is in summer in some countries. 🎄",
+  ];
+  // Fisher-Yates shuffle
+  for (var _si = hubTips.length - 1; _si > 0; _si--) {
+    var _sj = Math.floor(Math.random() * (_si + 1));
+    var _tmp = hubTips[_si];
+    hubTips[_si] = hubTips[_sj];
+    hubTips[_sj] = _tmp;
+  }
+  var hubTipIndex = 0;
+  var hubTipTimer = null;
+
+  var DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  var MONTH_NAMES = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+  var WEEKDAY_NAMES = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+  // --- Weather (hidden detail) ---
+  var weatherEmoji = null;   // null = not yet fetched, "" = failed
+  var weatherCondition = "";  // e.g. "Light rain, Auckland"
+  var weatherFetchedAt = 0;
+  var WEATHER_CACHE_MS = 60 * 60 * 1000; // 1 hour
+  // WMO weather code → emoji + description
+  var WMO_MAP = {
+    0: ["☀️", "Clear sky"], 1: ["🌤", "Mainly clear"], 2: ["⛅", "Partly cloudy"], 3: ["☁️", "Overcast"],
+    45: ["🌫", "Fog"], 48: ["🌫", "Depositing rime fog"],
+    51: ["🌦", "Light drizzle"], 53: ["🌦", "Moderate drizzle"], 55: ["🌧", "Dense drizzle"],
+    56: ["🌧", "Light freezing drizzle"], 57: ["🌧", "Dense freezing drizzle"],
+    61: ["🌧", "Slight rain"], 63: ["🌧", "Moderate rain"], 65: ["🌧", "Heavy rain"],
+    66: ["🌧", "Light freezing rain"], 67: ["🌧", "Heavy freezing rain"],
+    71: ["🌨", "Slight snow"], 73: ["🌨", "Moderate snow"], 75: ["❄️", "Heavy snow"],
+    77: ["🌨", "Snow grains"],
+    80: ["🌦", "Slight rain showers"], 81: ["🌧", "Moderate rain showers"], 82: ["🌧", "Violent rain showers"],
+    85: ["🌨", "Slight snow showers"], 86: ["❄️", "Heavy snow showers"],
+    95: ["⛈", "Thunderstorm"], 96: ["⛈", "Thunderstorm with slight hail"], 99: ["⛈", "Thunderstorm with heavy hail"],
+  };
+
+  function fetchWeather() {
+    // Use cache if we have a successful result within the last hour
+    if (weatherEmoji && weatherFetchedAt && (Date.now() - weatherFetchedAt < WEATHER_CACHE_MS)) return;
+    // Try localStorage cache
+    if (!weatherEmoji) {
+      try {
+        var cached = JSON.parse(localStorage.getItem("clay-weather") || "null");
+        if (cached && cached.emoji && (Date.now() - cached.ts < WEATHER_CACHE_MS)) {
+          weatherEmoji = cached.emoji;
+          weatherCondition = cached.condition || "";
+          weatherFetchedAt = cached.ts;
+          if (homeHubVisible) updateGreetingWeather();
+          return;
+        }
+      } catch (e) {}
+    }
+    if (weatherFetchedAt && (Date.now() - weatherFetchedAt < 30000)) return; // don't retry within 30s
+    weatherFetchedAt = Date.now();
+    // Step 1: IP geolocation → lat/lon + city
+    fetch("https://ipapi.co/json/", { signal: AbortSignal.timeout(4000) })
+      .then(function (res) { return res.ok ? res.json() : Promise.reject(); })
+      .then(function (geo) {
+        var lat = geo.latitude;
+        var lon = geo.longitude;
+        var city = geo.city || geo.region || "";
+        var country = geo.country_name || "";
+        var locationStr = city + (country ? ", " + country : "");
+        // Step 2: Open-Meteo → current weather
+        var meteoUrl = "https://api.open-meteo.com/v1/forecast?latitude=" + lat + "&longitude=" + lon + "&current=weather_code&timezone=auto";
+        return fetch(meteoUrl, { signal: AbortSignal.timeout(4000) })
+          .then(function (res) { return res.ok ? res.json() : Promise.reject(); })
+          .then(function (data) {
+            var code = data && data.current && data.current.weather_code;
+            if (code === undefined || code === null) return;
+            var mapped = WMO_MAP[code] || WMO_MAP[0];
+            weatherEmoji = mapped[0];
+            weatherCondition = mapped[1] + (locationStr ? " in " + locationStr : "");
+            weatherFetchedAt = Date.now();
+            try {
+              localStorage.setItem("clay-weather", JSON.stringify({
+                emoji: weatherEmoji, condition: weatherCondition, ts: weatherFetchedAt
+              }));
+            } catch (e) {}
+            if (homeHubVisible) updateGreetingWeather();
+          });
+      })
+      .catch(function () {
+        if (!weatherEmoji) weatherEmoji = "";
+      });
+  }
+
+  var SLOT_EMOJIS = ["☀️", "🌤", "⛅", "☁️", "🌧", "🌦", "⛈", "🌨", "❄️", "🌫", "🌙", "✨"];
+  var weatherSlotPlayed = false;
+
+  function updateGreetingWeather() {
+    var greetEl = $("hub-greeting-text");
+    if (!greetEl) return;
+    // If we have real weather and haven't played the slot yet, do the reel
+    if (weatherEmoji && !weatherSlotPlayed && homeHubVisible) {
+      weatherSlotPlayed = true;
+      playWeatherSlot(greetEl);
+      return;
+    }
+    // Normal update (no animation)
+    greetEl.textContent = getGreeting();
+
+    applyWeatherTooltip(greetEl);
+  }
+
+  function applyWeatherTooltip(greetEl) {
+    if (!weatherCondition) return;
+    var emojis = greetEl.querySelectorAll("img.emoji");
+    var lastEmoji = emojis.length > 0 ? emojis[emojis.length - 1] : null;
+    if (lastEmoji) {
+      lastEmoji.title = weatherCondition;
+      lastEmoji.style.cursor = "default";
+    }
+  }
+
+  function playWeatherSlot(greetEl) {
+    var h = new Date().getHours();
+    var prefix;
+    if (h < 6) prefix = "Good night";
+    else if (h < 12) prefix = "Good morning";
+    else if (h < 18) prefix = "Good afternoon";
+    else prefix = "Good evening";
+
+    // Build schedule: fast ticks → slow ticks → land (~3s total)
+    var intervals = [50, 50, 50, 60, 70, 80, 100, 120, 150, 190, 240, 300, 370, 450, 530, 640];
+    var totalSteps = intervals.length;
+    var step = 0;
+    var startIdx = Math.floor(Math.random() * SLOT_EMOJIS.length);
+
+    function tick() {
+      if (step < totalSteps) {
+        var idx = (startIdx + step) % SLOT_EMOJIS.length;
+        greetEl.textContent = prefix + " " + SLOT_EMOJIS[idx];
+    
+        step++;
+        setTimeout(tick, intervals[step - 1]);
+      } else {
+        // Final: land on actual weather
+        greetEl.textContent = prefix + " " + weatherEmoji;
+    
+        applyWeatherTooltip(greetEl);
+      }
+    }
+    tick();
+  }
+
+  function getGreeting() {
+    var h = new Date().getHours();
+    var emoji = weatherEmoji || "";
+    // Fallback to time-based emoji if weather not available
+    if (!emoji) {
+      if (h < 6) emoji = "✨";
+      else if (h < 12) emoji = "☀️";
+      else if (h < 18) emoji = "🌤";
+      else emoji = "🌙";
+    }
+    var prefix;
+    if (h < 6) prefix = "Good night";
+    else if (h < 12) prefix = "Good morning";
+    else if (h < 18) prefix = "Good afternoon";
+    else prefix = "Good evening";
+    return prefix + " " + emoji;
+  }
+
+  function getFormattedDate() {
+    var now = new Date();
+    return WEEKDAY_NAMES[now.getDay()] + ", " + MONTH_NAMES[now.getMonth()] + " " + now.getDate() + ", " + now.getFullYear();
+  }
+
+  function formatScheduleTime(ts) {
+    var d = new Date(ts);
+    var now = new Date();
+    var todayStr = now.getFullYear() + "-" + String(now.getMonth() + 1).padStart(2, "0") + "-" + String(now.getDate()).padStart(2, "0");
+    var schedStr = d.getFullYear() + "-" + String(d.getMonth() + 1).padStart(2, "0") + "-" + String(d.getDate()).padStart(2, "0");
+    var h = d.getHours();
+    var m = String(d.getMinutes()).padStart(2, "0");
+    var ampm = h >= 12 ? "PM" : "AM";
+    var h12 = h % 12 || 12;
+    var timeStr = h12 + ":" + m + " " + ampm;
+    if (schedStr === todayStr) return timeStr;
+    // Tomorrow check
+    var tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    var tomStr = tomorrow.getFullYear() + "-" + String(tomorrow.getMonth() + 1).padStart(2, "0") + "-" + String(tomorrow.getDate()).padStart(2, "0");
+    if (schedStr === tomStr) return "Tomorrow";
+    return DAY_NAMES[d.getDay()] + " " + timeStr;
+  }
+
+  function renderHomeHub(projects) {
+    // Greeting + weather tooltip
+    updateGreetingWeather();
+
+    // Date
+    var dateEl = $("hub-greeting-date");
+    if (dateEl) dateEl.textContent = getFormattedDate();
+
+    // --- Upcoming tasks ---
+    var upcomingList = $("hub-upcoming-list");
+    var upcomingCount = $("hub-upcoming-count");
+    if (upcomingList) {
+      var now = Date.now();
+      var upcoming = hubSchedules.filter(function (s) {
+        return s.enabled && s.nextRunAt && s.nextRunAt > now;
+      }).sort(function (a, b) {
+        return a.nextRunAt - b.nextRunAt;
+      });
+      // Show up to next 48 hours
+      var cutoff = now + 48 * 60 * 60 * 1000;
+      var filtered = upcoming.filter(function (s) { return s.nextRunAt <= cutoff; });
+
+      if (upcomingCount) {
+        upcomingCount.textContent = filtered.length > 0 ? filtered.length : "";
+      }
+
+      upcomingList.innerHTML = "";
+      if (filtered.length === 0) {
+        // Empty state with CTA
+        var emptyDiv = document.createElement("div");
+        emptyDiv.className = "hub-upcoming-empty";
+        emptyDiv.innerHTML = '<div class="hub-upcoming-empty-icon">📋</div>' +
+          '<div class="hub-upcoming-empty-text">No upcoming tasks</div>' +
+          '<button class="hub-upcoming-cta" id="hub-upcoming-cta">' +
+          '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>' +
+          'Create a schedule</button>';
+        upcomingList.appendChild(emptyDiv);
+        var ctaBtn = emptyDiv.querySelector("#hub-upcoming-cta");
+        if (ctaBtn) {
+          ctaBtn.addEventListener("click", function () {
+            hideHomeHub();
+            openSchedulerToTab("calendar");
+          });
+        }
+      } else {
+        var maxShow = 5;
+        var shown = filtered.slice(0, maxShow);
+        for (var i = 0; i < shown.length; i++) {
+          (function (sched) {
+            var item = document.createElement("div");
+            item.className = "hub-upcoming-item";
+            var dotColor = sched.color || "";
+            item.innerHTML = '<span class="hub-upcoming-dot"' + (dotColor ? ' style="background:' + dotColor + '"' : '') + '></span>' +
+              '<span class="hub-upcoming-time">' + formatScheduleTime(sched.nextRunAt) + '</span>' +
+              '<span class="hub-upcoming-name">' + escapeHtml(sched.name || "Untitled") + '</span>' +
+              '<span class="hub-upcoming-project">' + escapeHtml(sched.projectTitle || "") + '</span>';
+            item.addEventListener("click", function () {
+              if (sched.projectSlug) {
+                switchProject(sched.projectSlug);
+                setTimeout(function () {
+                  openSchedulerToTab("library");
+                }, 300);
+              }
+            });
+            upcomingList.appendChild(item);
+          })(shown[i]);
+        }
+        if (filtered.length > maxShow) {
+          var moreEl = document.createElement("div");
+          moreEl.className = "hub-upcoming-more";
+          moreEl.textContent = "+" + (filtered.length - maxShow) + " more";
+          upcomingList.appendChild(moreEl);
+        }
+      }
+    }
+
+    // --- Projects summary (exclude mate projects) ---
+    var projectsList = $("hub-projects-list");
+    if (projectsList && projects) {
+      projectsList.innerHTML = "";
+      var hubProjects = projects.filter(function (p) { return !p.isMate; });
+      for (var p = 0; p < hubProjects.length; p++) {
+        (function (proj) {
+          var item = document.createElement("div");
+          item.className = "hub-project-item";
+          var dotClass = "hub-project-dot" + (proj.isProcessing ? " processing" : "");
+          var iconHtml = '';
+          if (proj.icon && proj.icon.indexOf("img:") === 0) {
+            iconHtml = '<span class="hub-project-icon"><img src="' + escapeHtml(proj.icon.substring(4)) + '" style="width:18px;height:18px;object-fit:cover;border-radius:3px;vertical-align:middle;"></span>';
+          } else if (proj.icon) {
+            iconHtml = '<span class="hub-project-icon">' + proj.icon + '</span>';
+          }
+          var sessionsLabel = typeof proj.sessions === "number" ? proj.sessions : "";
+          item.innerHTML = '<span class="' + dotClass + '"></span>' +
+            iconHtml +
+            '<span class="hub-project-name">' + escapeHtml(proj.title || proj.project || proj.slug) + '</span>' +
+            (sessionsLabel !== "" ? '<span class="hub-project-sessions">' + sessionsLabel + '</span>' : '');
+          item.addEventListener("click", function () {
+            switchProject(proj.slug);
+          });
+          projectsList.appendChild(item);
+        })(hubProjects[p]);
+      }
+      // Render emoji icons
+
+    }
+
+    // --- Week strip ---
+    var weekStrip = $("hub-week-strip");
+    if (weekStrip) {
+      weekStrip.innerHTML = "";
+      var today = new Date();
+      var todayDate = today.getDate();
+      var todayMonth = today.getMonth();
+      var todayYear = today.getFullYear();
+      // Find Monday of current week
+      var dayOfWeek = today.getDay();
+      var mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+      var monday = new Date(today);
+      monday.setDate(today.getDate() + mondayOffset);
+
+      // Build set of dates that have events
+      var eventDates = {};
+      for (var si = 0; si < hubSchedules.length; si++) {
+        var sched = hubSchedules[si];
+        if (!sched.enabled) continue;
+        if (sched.nextRunAt) {
+          var sd = new Date(sched.nextRunAt);
+          var key = sd.getFullYear() + "-" + sd.getMonth() + "-" + sd.getDate();
+          eventDates[key] = (eventDates[key] || 0) + 1;
+        }
+        if (sched.date) {
+          var parts = sched.date.split("-");
+          var dateKey = parseInt(parts[0], 10) + "-" + (parseInt(parts[1], 10) - 1) + "-" + parseInt(parts[2], 10);
+          eventDates[dateKey] = (eventDates[dateKey] || 0) + 1;
+        }
+      }
+
+      for (var d = 0; d < 7; d++) {
+        var dayDate = new Date(monday);
+        dayDate.setDate(monday.getDate() + d);
+        var isToday = dayDate.getDate() === todayDate && dayDate.getMonth() === todayMonth && dayDate.getFullYear() === todayYear;
+        var dateKey = dayDate.getFullYear() + "-" + dayDate.getMonth() + "-" + dayDate.getDate();
+        var eventCount = eventDates[dateKey] || 0;
+
+        var cell = document.createElement("div");
+        cell.className = "hub-week-day" + (isToday ? " today" : "");
+        var dotsHtml = '<div class="hub-week-dots">';
+        var dotCount = Math.min(eventCount, 3);
+        for (var di = 0; di < dotCount; di++) {
+          dotsHtml += '<span class="hub-week-dot"></span>';
+        }
+        dotsHtml += '</div>';
+        cell.innerHTML = '<span class="hub-week-label">' + DAY_NAMES[(dayDate.getDay())] + '</span>' +
+          '<span class="hub-week-num">' + dayDate.getDate() + '</span>' +
+          dotsHtml;
+        weekStrip.appendChild(cell);
+      }
+    }
+
+    // --- Playbooks ---
+    var pbGrid = $("hub-playbooks-grid");
+    var pbSection = $("hub-playbooks");
+    if (pbGrid) {
+      var pbs = getPlaybooks();
+      if (pbs.length === 0) {
+        if (pbSection) pbSection.style.display = "none";
+      } else {
+        if (pbSection) pbSection.style.display = "";
+        pbGrid.innerHTML = "";
+        for (var pi = 0; pi < pbs.length; pi++) {
+          (function (pb) {
+            var card = document.createElement("div");
+            card.className = "hub-playbook-card" + (pb.completed ? " completed" : "");
+            card.innerHTML = '<span class="hub-playbook-card-icon">' + pb.icon + '</span>' +
+              '<div class="hub-playbook-card-body">' +
+              '<div class="hub-playbook-card-title">' + escapeHtml(pb.title) + '</div>' +
+              '<div class="hub-playbook-card-desc">' + escapeHtml(pb.description) + '</div>' +
+              '</div>' +
+              (pb.completed ? '<span class="hub-playbook-card-check">✓</span>' : '');
+            card.addEventListener("click", function () {
+              openPlaybook(pb.id, function () {
+                // Re-render hub after playbook closes to update completion state
+                renderHomeHub(cachedProjects);
+              });
+            });
+            pbGrid.appendChild(card);
+          })(pbs[pi]);
+        }
+
+      }
+    }
+
+
+    // --- Tip ---
+    var currentTip = hubTips[hubTipIndex % hubTips.length];
+    var tipEl = $("hub-tip-text");
+    if (tipEl) tipEl.textContent = currentTip;
+
+    // "Try it" button if tip has a linked playbook
+    var existingTry = homeHub.querySelector(".hub-tip-try");
+    if (existingTry) existingTry.remove();
+    var linkedPb = getPlaybookForTip(currentTip);
+    if (linkedPb && tipEl) {
+      var tryBtn = document.createElement("button");
+      tryBtn.className = "hub-tip-try";
+      tryBtn.textContent = "Try it →";
+      tryBtn.addEventListener("click", function () {
+        openPlaybook(linkedPb, function () {
+          renderHomeHub(cachedProjects);
+        });
+      });
+      tipEl.appendChild(tryBtn);
+    }
+
+    // Tip prev/next buttons
+    var prevBtn = $("hub-tip-prev");
+    if (prevBtn && !prevBtn._hubWired) {
+      prevBtn._hubWired = true;
+      prevBtn.addEventListener("click", function () {
+        hubTipIndex = (hubTipIndex - 1 + hubTips.length) % hubTips.length;
+        renderHomeHub(cachedProjects);
+        startTipRotation();
+      });
+    }
+    var nextBtn = $("hub-tip-next");
+    if (nextBtn && !nextBtn._hubWired) {
+      nextBtn._hubWired = true;
+      nextBtn.addEventListener("click", function () {
+        hubTipIndex = (hubTipIndex + 1) % hubTips.length;
+        renderHomeHub(cachedProjects);
+        startTipRotation();
+      });
+    }
+
+    // Render twemoji for all emoji in the hub
+
+  }
+
+  function handleHubSchedules(msg) {
+    if (msg.schedules) {
+      hubSchedules = msg.schedules;
+      if (homeHubVisible) renderHomeHub(cachedProjects);
+    }
+  }
+
+  function startTipRotation() {
+    stopTipRotation();
+    hubTipTimer = setInterval(function () {
+      hubTipIndex = (hubTipIndex + 1) % hubTips.length;
+      renderHomeHub(cachedProjects);
+    }, 15000);
+  }
+
+  function stopTipRotation() {
+    if (hubTipTimer) {
+      clearInterval(hubTipTimer);
+      hubTipTimer = null;
+    }
+  }
+
+  // --- DM Mode Functions ---
+  function openDm(targetUserId) {
+    if (!ws || ws.readyState !== 1) return;
+    // Persist DM state for refresh recovery
+    try { sessionStorage.setItem("clay-active-dm", targetUserId); } catch (e) {}
+    // Check mate skill updates before opening mate DM
+    if (typeof targetUserId === "string" && targetUserId.indexOf("mate_") === 0) {
+      showMateOnboarding(function () {
+        requireClayMateInterview(function () {
+          ws.send(JSON.stringify({ type: "dm_open", targetUserId: targetUserId }));
+        });
+      });
+      return;
+    }
+    ws.send(JSON.stringify({ type: "dm_open", targetUserId: targetUserId }));
+  }
+
+  var MATE_ONBOARDING_KEY = "clay-mate-onboarding-shown";
+
+  function showMateOnboarding(callback) {
+    try {
+      if (localStorage.getItem(MATE_ONBOARDING_KEY)) { callback(); return; }
+    } catch (e) {}
+
+    var overlay = document.createElement("div");
+    overlay.className = "mate-onboarding-overlay";
+    overlay.innerHTML =
+      '<div class="mate-onboarding-card">' +
+        '<h2 class="mate-onboarding-title">Meet your Mates</h2>' +
+        '<p class="mate-onboarding-desc">' +
+          'Mates are AI teammates powered by your Claude Code.<br>Each one has a distinct role, builds its own knowledge, and gets sharper over time.' +
+        '</p>' +
+        '<ul class="mate-onboarding-features">' +
+          '<li><span class="mate-onboarding-bullet">\uD83C\uDFAD</span><div><strong>Specialized personas</strong><br><span class="mate-onboarding-sub">Architect, reviewer, researcher, chief of staff, and more</span></div></li>' +
+          '<li><span class="mate-onboarding-bullet">\uD83D\uDD04</span><div><strong>Persistent memory</strong><br><span class="mate-onboarding-sub">Every conversation makes them smarter about you and your work</span></div></li>' +
+          '<li><span class="mate-onboarding-bullet">\uD83D\uDCAC</span><div><strong>Shared context across the team</strong><br><span class="mate-onboarding-sub">What one mate learns, the others can reference</span></div></li>' +
+          '<li><span class="mate-onboarding-bullet">\uD83D\uDCDA</span><div><strong>Self-growing knowledge base</strong><br><span class="mate-onboarding-sub">They accumulate notes, decisions, and observations on their own</span></div></li>' +
+        '</ul>' +
+        '<button class="mate-onboarding-btn">Let\u2019s go</button>' +
+      '</div>';
+
+    document.body.appendChild(overlay);
+
+    // Animate in
+    requestAnimationFrame(function () {
+      overlay.classList.add("visible");
+    });
+
+    function dismissOnboarding() {
+      try { localStorage.setItem(MATE_ONBOARDING_KEY, "1"); } catch (e) {}
+      fetch("/api/user/mate-onboarded", { method: "POST" }).catch(function () {});
+      overlay.classList.remove("visible");
+      setTimeout(function () { overlay.remove(); callback(); }, 200);
+    }
+
+    overlay.querySelector(".mate-onboarding-btn").addEventListener("click", dismissOnboarding);
+
+    // Click outside to dismiss
+    overlay.addEventListener("click", function (e) {
+      if (e.target === overlay) dismissOnboarding();
+    });
+  }
+
+  function enterDmMode(key, targetUser, messages) {
+    // Clean up previous DM/mate state before entering new one
+    if (dmMode) {
+      hideMateSidebar();
+      hideKnowledge();
+      hideMemory();
+      // Reset dm-header-bar
+      var prevHeader = document.getElementById("dm-header-bar");
+      if (prevHeader) {
+        prevHeader.style.display = "";
+        prevHeader.style.background = "";
+        var prevTag = prevHeader.querySelector(".dm-header-mate-tag");
+        if (prevTag) prevTag.remove();
+      }
+      // Restore terminal button
+      var prevTermBtn = document.getElementById("terminal-toggle-btn");
+      if (prevTermBtn) prevTermBtn.style.display = "";
+      // Remove dm-mode classes
+      var prevMain = document.getElementById("main-column");
+      if (prevMain) prevMain.classList.remove("dm-mode");
+      var prevSidebar = document.getElementById("sidebar-column");
+      if (prevSidebar) prevSidebar.classList.remove("dm-mode");
+      var prevResize = document.getElementById("sidebar-resize-handle");
+      if (prevResize) prevResize.classList.remove("dm-mode");
+      // Reset chat title bar
+      var prevTitleBar = document.querySelector(".title-bar-content");
+      if (prevTitleBar) {
+        prevTitleBar.style.background = "";
+        prevTitleBar.classList.remove("mate-dm-active");
+      }
+    }
+
+    dmMode = true;
+    dmKey = key;
+    dmTargetUser = targetUser;
+
+    // Notify server of active mate DM (server-side presence tracking)
+    // IMPORTANT: set_mate_dm must go to the MAIN project, not a mate project WS.
+    // When switching between mates, ws points to the current mate project,
+    // so we defer sending set_mate_dm until we reconnect to the main project's context.
+    // The server will also receive it via the mate project's onDmMessage handler,
+    // but the presence should only be stored on the main project slug.
+    if (targetUser && targetUser.isMate) {
+      // Send to the current WS only if it's the main project (not another mate)
+      if (!mateProjectSlug && ws && ws.readyState === 1) {
+        try { ws.send(JSON.stringify({ type: "set_mate_dm", mateId: targetUser.id })); } catch(e) {}
+      }
+    }
+
+    // Clear unread for this user
+    if (targetUser) {
+      dmUnread[targetUser.id] = 0;
+      updateDmBadge(targetUser.id, 0);
+    }
+
+    // Update icon strip active state
+    setCurrentDmUser(targetUser ? targetUser.id : null);
+    var activeProj = document.querySelector("#icon-strip-projects .icon-strip-item.active");
+    if (activeProj) activeProj.classList.remove("active");
+    var homeIcon = document.querySelector(".icon-strip-home");
+    if (homeIcon) homeIcon.classList.remove("active");
+    // Re-render user strip to show active state
+    if (cachedProjects && cachedProjects.length > 0) {
+      renderProjectList();
+    }
+
+    // Hide home hub if visible
+    hideHomeHub();
+
+    // Hide sticky notes if visible
+    hideNotes();
+
+    var isMate = targetUser && targetUser.isMate;
+
+    // Hide project UI + sidebar, show DM UI
+    var mainCol = document.getElementById("main-column");
+    if (mainCol && !isMate) mainCol.classList.add("dm-mode");
+    var sidebarCol = document.getElementById("sidebar-column");
+    if (sidebarCol) sidebarCol.classList.add("dm-mode");
+    var resizeHandle = document.getElementById("sidebar-resize-handle");
+    if (resizeHandle) resizeHandle.classList.add("dm-mode");
+    if (isMate && targetUser.projectSlug) {
+      // Mate DM: switch to mate's project (same as project switching)
+      showMateSidebar(targetUser.id, targetUser);
+      // Close file viewer and terminal panel BEFORE switching WS (needs old WS still open)
+      try { closeFileViewer(); } catch(e) {}
+      closeTerminal();
+      var termBtn = document.getElementById("terminal-toggle-btn");
+      if (termBtn) termBtn.style.display = "none";
+      // Apply mate color to chat title bar and panels
+      var mateColor = (targetUser.profile && targetUser.profile.avatarColor) || targetUser.avatarColor || "#7c3aed";
+      document.body.style.setProperty("--mate-color", mateColor);
+      document.body.style.setProperty("--mate-color-tint", mateColor + "0a");
+      document.body.classList.add("mate-dm-active");
+      // Build mate avatar URL for DM bubble injection
+      var mp = targetUser.profile || {};
+      var mateAvUrlDm = mateAvatarUrl(targetUser, 36);
+      var myUser = cachedAllUsers.find(function (u) { return u.id === myUserId; });
+      if (!myUser) {
+        try { var cached = JSON.parse(localStorage.getItem("clay_my_user") || "null"); if (cached) myUser = cached; } catch(e) {}
+      }
+      var myAvatarUrl = userAvatarUrl(myUser || { id: myUserId }, 36);
+      var myDisplayName = (myUser && myUser.displayName) || "";
+      document.body.dataset.mateAvatarUrl = mateAvUrlDm;
+      document.body.dataset.mateName = mp.displayName || targetUser.displayName || targetUser.name || "";
+      document.body.dataset.myAvatarUrl = myAvatarUrl;
+      document.body.dataset.myDisplayName = myDisplayName;
+      // Cache my info for restore after hard refresh
+      if (myUser) {
+        try { localStorage.setItem("clay_my_user", JSON.stringify({ displayName: myUser.displayName, avatarStyle: myUser.avatarStyle, avatarSeed: myUser.avatarSeed, avatarCustom: myUser.avatarCustom, username: myUser.username })); } catch(e) {}
+      }
+      var titleBarContent = document.querySelector(".title-bar-content");
+      if (titleBarContent) {
+        titleBarContent.style.background = mateColor;
+        titleBarContent.classList.add("mate-dm-active");
+      }
+      // Populate mobile title bar for mate DM (CSS handles visibility via media query)
+      var mateMobileTitle = document.getElementById("mate-mobile-title");
+      if (mateMobileTitle) {
+        var mateMobileAvatar = document.getElementById("mate-mobile-avatar");
+        var mateMobileName = document.getElementById("mate-mobile-name");
+        var mateMobileStatus = document.getElementById("mate-mobile-status");
+        if (mateMobileAvatar) mateMobileAvatar.src = mateAvUrlDm;
+        if (mateMobileName) mateMobileName.textContent = (mp.displayName || targetUser.displayName || targetUser.name || "");
+        if (mateMobileStatus) mateMobileStatus.textContent = "online";
+        mateMobileTitle.classList.remove("hidden");
+        // Store mate data for profile sheet
+        setMobileSheetMateData({
+            id: targetUser.id,
+            displayName: mp.displayName || targetUser.displayName || targetUser.name || "",
+            description: mp.description || targetUser.description || "",
+            avatarUrl: mateAvUrlDm,
+            color: mateColor
+          });
+      }
+      // Switch to mate project WS LAST, after all UI setup is complete.
+      // Must be last because connect() changes ws to CONNECTING state,
+      // and earlier code (closeFileViewer etc.) needs the old WS still open.
+      connectMateProject(targetUser.projectSlug);
+    }
+
+    // Hide user-island in human DM, keep visible in Mate DM
+    var userIsland = document.getElementById("user-island");
+    if (userIsland && !isMate) userIsland.classList.add("dm-hidden");
+
+    // Render DM messages
+    dmMessageCache = messages ? messages.slice() : [];
+    messagesEl.innerHTML = "";
+    if (messages && messages.length > 0) {
+      for (var i = 0; i < messages.length; i++) {
+        appendDmMessage(messages[i]);
+      }
+    }
+    scrollToBottom();
+
+    // Focus input
+    if (inputEl) {
+      var targetName = targetUser ? ((targetUser.profile && targetUser.profile.displayName) || targetUser.displayName || targetUser.name || "") : "";
+      inputEl.placeholder = "Message " + targetName;
+      inputEl.focus();
+    }
+
+    // Populate DM header bar with user avatar, name, and personal color
+    if (targetUser) {
+      var dmHeaderBar = document.getElementById("dm-header-bar");
+      var dmAvatar = document.getElementById("dm-header-avatar");
+      var dmName = document.getElementById("dm-header-name");
+      if (isMate) {
+        // Mate uses project chat title bar, hide DM header
+        if (dmHeaderBar) dmHeaderBar.style.display = "none";
+      } else {
+        if (dmHeaderBar) dmHeaderBar.style.display = "";
+        if (dmAvatar) {
+          dmAvatar.src = userAvatarUrl(targetUser, 28);
+        }
+        if (dmName) dmName.textContent = targetUser.displayName;
+        if (dmHeaderBar && targetUser.avatarColor) {
+          dmHeaderBar.style.background = targetUser.avatarColor;
+        }
+        // Remove mate tag for regular DM
+        var existingTag = dmHeaderBar ? dmHeaderBar.querySelector(".dm-header-mate-tag") : null;
+        if (existingTag) existingTag.remove();
+      }
+    }
+  }
+
+  function exitDmMode(skipProjectSwitch) {
+    if (!dmMode) return;
+    var wasMate = dmTargetUser && dmTargetUser.isMate;
+    dmMode = false;
+    dmKey = null;
+    dmTargetUser = null;
+    try { sessionStorage.removeItem("clay-active-dm"); } catch (e) {}
+    setCurrentDmUser(null);
+
+    var mainCol = document.getElementById("main-column");
+    if (mainCol) mainCol.classList.remove("dm-mode");
+    var sidebarCol = document.getElementById("sidebar-column");
+    if (sidebarCol) sidebarCol.classList.remove("dm-mode");
+    var resizeHandle = document.getElementById("sidebar-resize-handle");
+    if (resizeHandle) resizeHandle.classList.remove("dm-mode");
+    hideMateSidebar();
+    hideKnowledge();
+    hideMemory();
+    if (isSchedulerOpen()) closeScheduler();
+    // Restore terminal button
+    var termBtn = document.getElementById("terminal-toggle-btn");
+    if (termBtn) termBtn.style.display = "";
+
+    // Reset DM header
+    var dmHeaderBar = document.getElementById("dm-header-bar");
+    if (dmHeaderBar) {
+      dmHeaderBar.style.display = "";
+      dmHeaderBar.style.background = "";
+      var mateTag = dmHeaderBar.querySelector(".dm-header-mate-tag");
+      if (mateTag) mateTag.remove();
+    }
+    // Reset chat title bar and mate color
+    document.body.style.removeProperty("--mate-color");
+    document.body.style.removeProperty("--mate-color-tint");
+    document.body.classList.remove("mate-dm-active");
+    delete document.body.dataset.mateAvatarUrl;
+    delete document.body.dataset.mateName;
+    delete document.body.dataset.myAvatarUrl;
+    // Remove injected DM bubble avatars
+    var bubbleAvatars = messagesEl.querySelectorAll(".dm-bubble-avatar");
+    for (var ba = 0; ba < bubbleAvatars.length; ba++) bubbleAvatars[ba].remove();
+    var titleBarContent = document.querySelector(".title-bar-content");
+    if (titleBarContent) {
+      titleBarContent.style.background = "";
+      titleBarContent.classList.remove("mate-dm-active");
+    }
+    // Hide mobile mate title bar
+    var mateMobileTitle = document.getElementById("mate-mobile-title");
+    if (mateMobileTitle) mateMobileTitle.classList.add("hidden");
+
+    // Restore user-island (covers my avatar again)
+    var userIsland = document.getElementById("user-island");
+    if (userIsland) userIsland.classList.remove("dm-hidden");
+
+    if (inputEl) inputEl.placeholder = "";
+
+    // Switch back to main project (same as project switching)
+    if (wasMate && !skipProjectSwitch) {
+      disconnectMateProject();
+    } else if (wasMate && skipProjectSwitch) {
+      // Just clean up mate state, caller will handle project switch
+      if (savedMainSlug) pendingMateDmClears[savedMainSlug] = true;
+      mateProjectSlug = null;
+      savedMainSlug = null;
+      showDebateSticky("hide", null);
+      var debateFloat = document.getElementById("debate-info-float");
+      if (debateFloat) { debateFloat.classList.add("hidden"); debateFloat.innerHTML = ""; }
+    } else {
+      // Human DM: just re-request state from main project
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: "switch_session", id: activeSessionId }));
+        ws.send(JSON.stringify({ type: "note_list_request" }));
+      }
+    }
+    renderProjectList();
+  }
+
+  // --- Mobile mate title bar click handlers ---
+  (function () {
+    var mobileBack = document.getElementById("mate-mobile-back");
+    var mobileTitle = document.getElementById("mate-mobile-title");
+    var mobileMore = document.getElementById("mate-mobile-more");
+    if (mobileBack) {
+      mobileBack.addEventListener("click", function (e) {
+        e.stopPropagation();
+        exitDmMode();
+      });
+    }
+    if (mobileMore) {
+      mobileMore.addEventListener("click", function (e) {
+        e.stopPropagation();
+        openMobileSheet("mate-profile");
+      });
+    }
+    if (mobileTitle) {
+      mobileTitle.addEventListener("click", function () {
+        openMobileSheet("mate-profile");
+      });
+    }
+  })();
+
+  function handleMateCreatedInApp(mate, msg) {
+    if (!mate) return;
+    cachedMatesList.push(mate);
+    if (msg && msg.availableBuiltins) cachedAvailableBuiltins = msg.availableBuiltins;
+    if (msg && msg.dmFavorites) cachedDmFavorites = msg.dmFavorites;
+    renderUserStrip(cachedAllUsers, cachedOnlineIds, myUserId, cachedDmFavorites, cachedDmConversations, dmUnread, dmRemovedUsers, cachedMatesList);
+    // Built-in mates handle their own onboarding via CLAUDE.md, skip auto-interview
+    if (!mate.builtinKey) {
+      pendingMateInterview = mate;
+    }
+    openDm(mate.id);
+  }
+
+  function renderAvailableBuiltins(builtins) {
+    // Append deleted built-in mates to the mates list in the picker
+    var matesList = document.querySelector(".dm-mates-list");
+    if (!matesList) return;
+    if (!builtins || builtins.length === 0) return;
+
+    for (var i = 0; i < builtins.length; i++) {
+      (function (b) {
+        var item = document.createElement("div");
+        item.className = "dm-user-picker-item dm-user-picker-builtin-item";
+        item.style.opacity = "0.5";
+
+        var av = document.createElement("img");
+        av.className = "dm-user-picker-avatar";
+        av.src = b.avatarCustom || "";
+        av.alt = b.displayName;
+        item.appendChild(av);
+
+        var nameWrap = document.createElement("div");
+        nameWrap.style.cssText = "flex:1;min-width:0;";
+        var nameEl = document.createElement("span");
+        nameEl.className = "dm-user-picker-name";
+        nameEl.textContent = b.displayName;
+        nameWrap.appendChild(nameEl);
+        var bioEl = document.createElement("div");
+        bioEl.style.cssText = "font-size:11px;color:var(--text-dimmer);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;";
+        bioEl.textContent = "Deleted";
+        nameWrap.appendChild(bioEl);
+        item.appendChild(nameWrap);
+
+        var addBtn = document.createElement("button");
+        addBtn.style.cssText = "border:none;background:none;cursor:pointer;padding:2px 6px;color:var(--accent, #6366f1);font-size:12px;font-weight:600;";
+        addBtn.textContent = "+ Add";
+        addBtn.title = "Re-add " + b.displayName;
+        addBtn.addEventListener("click", function (e) {
+          e.stopPropagation();
+          if (ws && ws.readyState === 1) {
+            ws.send(JSON.stringify({ type: "mate_readd_builtin", builtinKey: b.key }));
+          }
+          closeDmUserPicker();
+        });
+        item.appendChild(addBtn);
+
+        item.addEventListener("click", function () {
+          if (ws && ws.readyState === 1) {
+            ws.send(JSON.stringify({ type: "mate_readd_builtin", builtinKey: b.key }));
+          }
+          closeDmUserPicker();
+        });
+
+        matesList.appendChild(item);
+      })(builtins[i]);
+    }
+  }
+
   var pendingMateInterview = null;
 
 
-  // --- Home Hub (delegated to app-home-hub.js) ---
-  function showHomeHub() { _hubShowHomeHub(); }
-  function hideHomeHub() { _hubHideHomeHub(); }
-  function handleHubSchedules(msg) { _hubHandleHubSchedules(msg); }
-  function renderHomeHub(projects) { _hubRenderHomeHub(projects); }
+    return "Use the /clay-mate-interview skill to start the interview.\n\n" +
+      "Mate ID: " + mate.id + "\n" +
+      "Mate Directory: .claude/mates/" + mate.id + "\n\n" +
+      "Seed Data:\n" + parts.join("\n");
+  }
+
+  // --- Mate icon IO blink ---
+  var bgMateIoTimers = {};
+
+  function updateMateIconStatus(msg) {
+    if (!mateProjectSlug) return;
+    var slug = mateProjectSlug;
+    if (msg.type === "content" || msg.type === "tool" || msg.type === "tool_use" || msg.type === "thinking") {
+      var ioDot = document.querySelector('.icon-strip-mate[data-mate-slug="' + slug + '"] .icon-strip-status');
+      if (ioDot) {
+        ioDot.classList.add("io");
+        clearTimeout(bgMateIoTimers[slug]);
+        bgMateIoTimers[slug] = setTimeout(function () { ioDot.classList.remove("io"); }, 80);
+      }
+    }
+    if (msg.type === "status" && msg.status === "processing") {
+      var dot = document.querySelector('.icon-strip-mate[data-mate-slug="' + slug + '"] .icon-strip-status');
+      if (dot) dot.classList.add("processing");
+      var mateSessionDot = document.querySelector(".mate-session-item.active .session-processing");
+      if (mateSessionDot) mateSessionDot.style.display = "";
+    }
+    if (msg.type === "done") {
+      var dot = document.querySelector('.icon-strip-mate[data-mate-slug="' + slug + '"] .icon-strip-status');
+      if (dot) dot.classList.remove("processing");
+      var mateSessionDot = document.querySelector(".mate-session-item.active .session-processing");
+      if (mateSessionDot) mateSessionDot.style.display = "none";
+    }
+  }
+
+  function connectMateProject(slug) {
+    mateProjectSlug = slug;
+    // Only save the main slug on the FIRST mate switch (preserve original main project)
+    if (!savedMainSlug) savedMainSlug = currentSlug;
+    currentSlug = slug;
+    wsPath = "/p/" + slug + "/ws";
+    resetClientState();
+    connect();
+  }
+
+  function disconnectMateProject() {
+    mateProjectSlug = null;
+    // Hide debate sticky when leaving mate DM
+    showDebateSticky("hide", null);
+    // Hide debate info float
+    var debateFloat = document.getElementById("debate-info-float");
+    if (debateFloat) { debateFloat.classList.add("hidden"); debateFloat.innerHTML = ""; }
+    // Switch back to main project
+    if (savedMainSlug) {
+      pendingMateDmClears[savedMainSlug] = true;
+      currentSlug = savedMainSlug;
+      basePath = "/p/" + savedMainSlug + "/";
+      wsPath = "/p/" + savedMainSlug + "/ws";
+      savedMainSlug = null;
+      resetClientState();
+      connect();
+    }
+  }
+
+  function appendDmMessage(msg) {
+    if (dmMode) dmMessageCache.push(msg);
+    var isMe = msg.from === myUserId;
+    var d = new Date(msg.ts);
+    var timeStr = d.getHours().toString().padStart(2, "0") + ":" + d.getMinutes().toString().padStart(2, "0");
+
+    // Check if we can compact (same sender as previous, within 5 min)
+    var prev = messagesEl.lastElementChild;
+    var compact = false;
+    if (prev && prev.dataset.from === msg.from) {
+      var prevTs = parseInt(prev.dataset.ts || "0", 10);
+      if (msg.ts - prevTs < 300000) compact = true;
+    }
+
+    var div = document.createElement("div");
+    div.className = "dm-msg" + (compact ? " dm-msg-compact" : "");
+    div.dataset.from = msg.from;
+    div.dataset.ts = msg.ts;
+
+    if (compact) {
+      // Compact: just hover-time + text, no avatar/name
+      var hoverTime = document.createElement("span");
+      hoverTime.className = "dm-msg-hover-time";
+      hoverTime.textContent = timeStr;
+      div.appendChild(hoverTime);
+
+      var body = document.createElement("div");
+      body.className = "dm-msg-body";
+      body.textContent = msg.text;
+      div.appendChild(body);
+    } else {
+      // Full: avatar + header(name, time) + text
+      var avatar = document.createElement("img");
+      avatar.className = "dm-msg-avatar";
+      if (isMe) {
+        var myUser = cachedAllUsers.find(function (u) { return u.id === myUserId; });
+        avatar.src = userAvatarUrl(myUser || { id: myUserId }, 36);
+      } else if (dmTargetUser) {
+        avatar.src = userAvatarUrl(dmTargetUser, 36);
+      }
+      div.appendChild(avatar);
+
+      var content = document.createElement("div");
+      content.className = "dm-msg-content";
+
+      var header = document.createElement("div");
+      header.className = "dm-msg-header";
+
+      var name = document.createElement("span");
+      name.className = "dm-msg-name";
+      if (isMe) {
+        var mu = cachedAllUsers.find(function (u) { return u.id === myUserId; });
+        name.textContent = mu ? mu.displayName : "Me";
+      } else {
+        name.textContent = dmTargetUser ? dmTargetUser.displayName : "User";
+      }
+      header.appendChild(name);
+
+      var time = document.createElement("span");
+      time.className = "dm-msg-time";
+      time.textContent = timeStr;
+      header.appendChild(time);
+
+      content.appendChild(header);
+
+      var body = document.createElement("div");
+      body.className = "dm-msg-body";
+      body.textContent = msg.text;
+      content.appendChild(body);
+
+      div.appendChild(content);
+    }
+
+    messagesEl.appendChild(div);
+  }
+
+  var dmTypingTimer = null;
+
+  function showDmTypingIndicator(typing) {
+    var existing = document.getElementById("dm-typing-indicator");
+    if (!typing) {
+      if (existing) existing.remove();
+      return;
+    }
+    if (existing) return; // already showing
+    if (!dmTargetUser) return;
+
+    var div = document.createElement("div");
+    div.id = "dm-typing-indicator";
+    div.className = "dm-msg dm-typing-indicator";
+
+    var avatar = document.createElement("img");
+    avatar.className = "dm-msg-avatar";
+    avatar.src = userAvatarUrl(dmTargetUser, 36);
+    div.appendChild(avatar);
+
+    var dots = document.createElement("div");
+    dots.className = "dm-typing-dots";
+    dots.innerHTML = "<span></span><span></span><span></span>";
+    div.appendChild(dots);
+
+    messagesEl.appendChild(div);
+    scrollToBottom();
+
+    // Auto-hide after 5s in case stop signal is missed
+    clearTimeout(dmTypingTimer);
+    dmTypingTimer = setTimeout(function () {
+      showDmTypingIndicator(false);
+    }, 5000);
+  }
+
+  function handleDmSend() {
+    if (!dmMode || !dmKey || !inputEl) return false;
+    var text = inputEl.value.trim();
+    if (!text) return false;
+    ws.send(JSON.stringify({ type: "dm_send", dmKey: dmKey, text: text }));
+    inputEl.value = "";
+    autoResize();
+    return true;
+  }
+
+  var hubCloseBtn = document.getElementById("home-hub-close");
+
+  function renderHomeHubMates() {
+    var container = document.getElementById("home-hub-mates");
+    if (!container) return;
+    container.innerHTML = "";
+    if (!cachedMatesList || cachedMatesList.length === 0) {
+      container.classList.add("hidden");
+      return;
+    }
+    container.classList.remove("hidden");
+    for (var i = 0; i < cachedMatesList.length; i++) {
+      (function (mate) {
+        var item = document.createElement("div");
+        item.className = "home-hub-mate-item" + (mate.primary ? " home-hub-mate-primary" : "");
+
+        var avatarWrap = document.createElement("div");
+        avatarWrap.className = "home-hub-mate-avatar-wrap";
+
+        var mp = mate.profile || {};
+        var mateAvUrl = mateAvatarUrl(mate, 48);
+        var avatar = document.createElement("img");
+        avatar.className = "home-hub-mate-avatar";
+        avatar.src = mateAvUrl;
+        avatar.alt = mp.displayName || mate.displayName || mate.name || "";
+        avatarWrap.appendChild(avatar);
+
+        var dot = document.createElement("span");
+        dot.className = "home-hub-mate-dot";
+        avatarWrap.appendChild(dot);
+
+        item.appendChild(avatarWrap);
+
+        var nameEl = document.createElement("span");
+        nameEl.className = "home-hub-mate-name";
+        nameEl.textContent = mp.displayName || mate.displayName || mate.name || "";
+        if (mate.primary) {
+          var starEl = document.createElement("span");
+          starEl.className = "home-hub-mate-primary-star";
+          starEl.title = "System Agent: code-managed, auto-updated, sees across all mates";
+          starEl.textContent = "\u2605";
+          nameEl.appendChild(starEl);
+        }
+        item.appendChild(nameEl);
+
+        item.addEventListener("click", function () {
+          openDm(mate.id);
+        });
+
+        container.appendChild(item);
+      })(cachedMatesList[i]);
+    }
+  }
+
+  function showHomeHub() {
+    if (dmMode) exitDmMode();
+    homeHubVisible = true;
+    homeHub.classList.remove("hidden");
+    // Show close button only if there's a project to return to
+    if (hubCloseBtn) {
+      if (currentSlug) hubCloseBtn.classList.remove("hidden");
+      else hubCloseBtn.classList.add("hidden");
+    }
+    // Fetch weather silently (once)
+    fetchWeather();
+    // Request cross-project schedules
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: "hub_schedules_list" }));
+    }
+    renderHomeHub(cachedProjects);
+    renderHomeHubMates();
+    startTipRotation();
+    if (document.documentElement.classList.contains("pwa-standalone")) {
+      history.replaceState(null, "", "/");
+    } else {
+      history.pushState(null, "", "/");
+    }
+    // Update icon strip active state
+    var homeIcon = document.querySelector(".icon-strip-home");
+    if (homeIcon) homeIcon.classList.add("active");
+    var activeProj = document.querySelector("#icon-strip-projects .icon-strip-item.active");
+    if (activeProj) activeProj.classList.remove("active");
+    // Mobile home button active
+    var mobileHome = document.getElementById("mobile-home-btn");
+    if (mobileHome) mobileHome.classList.add("active");
+  }
+
+  if (hubCloseBtn) {
+    hubCloseBtn.addEventListener("click", function () {
+      hideHomeHub();
+      if (currentSlug) {
+        if (document.documentElement.classList.contains("pwa-standalone")) {
+          history.replaceState(null, "", "/p/" + currentSlug + "/");
+        } else {
+          history.pushState(null, "", "/p/" + currentSlug + "/");
+        }
+        // Restore icon strip active state
+        var homeIcon = document.querySelector(".icon-strip-home");
+        if (homeIcon) homeIcon.classList.remove("active");
+        renderProjectList();
+      }
+    });
+  }
+
+  function hideHomeHub() {
+    if (!homeHubVisible) return;
+    homeHubVisible = false;
+    homeHub.classList.add("hidden");
+    stopTipRotation();
+    var mobileHome = document.getElementById("mobile-home-btn");
+    if (mobileHome) mobileHome.classList.remove("active");
+  }
 
   // --- Project List ---
   var projectListSection = $("project-list-section");
@@ -2460,9 +3651,160 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     }
   });
 
-  // --- WebSocket (delegated to app-connection.js) ---
-  function connect() { _connConnect(); }
-  function scheduleReconnect() { _connScheduleReconnect(); }
+  // --- WebSocket ---
+  var connectTimeoutId = null;
+
+  function connect() {
+    if (ws) { ws.onclose = null; ws.close(); }
+    if (connectTimeoutId) { clearTimeout(connectTimeoutId); connectTimeoutId = null; }
+
+    var protocol = location.protocol === "https:" ? "wss:" : "ws:";
+    ws = new WebSocket(protocol + "//" + location.host + wsPath);
+
+
+    // If not connected within 3s, force retry
+    connectTimeoutId = setTimeout(function () {
+      if (!connected) {
+        ws.onclose = null;
+        ws.onerror = null;
+        ws.close();
+        connect();
+      }
+    }, 3000);
+
+    ws.onopen = function () {
+      if (connectTimeoutId) { clearTimeout(connectTimeoutId); connectTimeoutId = null; }
+      // Cancel pending "connection lost" notification if reconnected quickly
+      if (disconnectNotifTimer) {
+        clearTimeout(disconnectNotifTimer);
+        disconnectNotifTimer = null;
+      }
+      // Only show "restored" notification if "lost" was actually shown
+      var isMobileDevice = /Mobi|Android|iPad|iPhone|iPod/.test(navigator.userAgent) ||
+        (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+      if (wasConnected && disconnectNotifShown && !isMobileDevice && isNotifAlertEnabled() && !document.hasFocus() && "serviceWorker" in navigator) {
+        navigator.serviceWorker.ready.then(function (reg) {
+          reg.showNotification("Clay", {
+            body: "Server connection restored",
+            tag: "claude-disconnect",
+          });
+        }).catch(function () {});
+      }
+      disconnectNotifShown = false;
+      wasConnected = true;
+      setStatus("connected");
+      reconnectDelay = 1000;
+      if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+
+      // Wrap ws.send to blink LED on outgoing traffic
+      var _origSend = ws.send.bind(ws);
+      ws.send = function (data) {
+        blinkIO();
+        return _origSend(data);
+      };
+
+      // Reset terminal xterm instances (server will send fresh term_list)
+      resetTerminals();
+
+      // Re-send push subscription on reconnect
+      if (window._pushSubscription) {
+        try {
+          ws.send(JSON.stringify({
+            type: "push_subscribe",
+            subscription: window._pushSubscription.toJSON(),
+          }));
+        } catch(e) {}
+      }
+
+      // Request mates list
+      try {
+        ws.send(JSON.stringify({ type: "mate_list" }));
+      } catch(e) {}
+
+      // If connecting to a mate project, request knowledge list for badge
+      if (mateProjectSlug) {
+        try { ws.send(JSON.stringify({ type: "knowledge_list" })); } catch(e) {}
+      }
+
+      // Session restore is now server-driven (user-presence.json).
+      // Mate DM restore is also server-driven via "restore_mate_dm" message.
+      // Fallback: if server doesn't restore DM within 2s, try sessionStorage
+      var savedDm = null;
+      try { savedDm = sessionStorage.getItem("clay-active-dm"); } catch (e) {}
+      if (savedDm && !dmMode && !mateProjectSlug && !pendingMateDmClears[currentSlug]) {
+        var dmFallbackTimer = setTimeout(function () {
+          if (!dmMode && savedDm) {
+            console.log("[dm-restore] Server did not restore DM, using sessionStorage fallback:", savedDm);
+            openDm(savedDm);
+          }
+        }, 2000);
+        // Cancel fallback if server restores DM first
+        var origHandler = ws.onmessage;
+        var patchedOnce = false;
+        var checkRestore = function (evt) {
+          try {
+            var d = JSON.parse(evt.data);
+            if (d.type === "restore_mate_dm" && !patchedOnce) {
+              patchedOnce = true;
+              clearTimeout(dmFallbackTimer);
+            }
+          } catch (e) {}
+        };
+        ws.addEventListener("message", checkRestore);
+        setTimeout(function () { ws.removeEventListener("message", checkRestore); }, 3000);
+      }
+      // Clean up pending mate DM clear after messages settle
+      // (server either sent restore_mate_dm or didn't — don't block future restores)
+      if (pendingMateDmClears[currentSlug]) {
+        (function (slug) {
+          setTimeout(function () { delete pendingMateDmClears[slug]; }, 5000);
+        })(currentSlug);
+      }
+    };
+
+    ws.onclose = function (e) {
+      if (connectTimeoutId) { clearTimeout(connectTimeoutId); connectTimeoutId = null; }
+      closeDmUserPicker();
+      setStatus("disconnected");
+      processing = false;
+      setActivity(null);
+      // Delay "connection lost" notification by 5s to suppress brief disconnects
+      if (!disconnectNotifTimer) {
+        disconnectNotifTimer = setTimeout(function () {
+          disconnectNotifTimer = null;
+          disconnectNotifShown = true;
+          var isMobileDevice = /Mobi|Android|iPad|iPhone|iPod/.test(navigator.userAgent) ||
+            (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+          if (!isMobileDevice && isNotifAlertEnabled() && !document.hasFocus() && "serviceWorker" in navigator) {
+            navigator.serviceWorker.ready.then(function (reg) {
+              reg.showNotification("Clay", {
+                body: "Server connection lost",
+                tag: "claude-disconnect",
+              });
+            }).catch(function () {});
+          }
+        }, 5000);
+      }
+      scheduleReconnect();
+    };
+
+    ws.onerror = function () {};
+
+    ws.onmessage = function (event) {
+      // If this WS is stashed while in mate DM, only allow skill_installed through
+      // Backup: if we're receiving messages, we're connected
+      if (!connected) {
+        setStatus("connected");
+        reconnectDelay = 1000;
+        if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+      }
+
+      blinkIO();
+      var msg;
+      try { msg = JSON.parse(event.data); } catch (e) { return; }
+      processMessage(msg);
+    };
+  }
 
   function showUpdateAvailable(msg) {
       var updatePillWrap = $("update-pill-wrap");
@@ -2508,8 +3850,1485 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
   function processMessage(msg) { _msgProcessMessage(msg); }
 
-  // processMessage body moved to modules/app-messages.js (PR-23)
 
+      // Mate DM: update mate icon status indicators
+      if (isMateDm) updateMateIconStatus(msg);
+
+      // Mate DM: intercept mate-specific messages
+      if (isMateDm) {
+        if (msg.type === "session_list") {
+          renderMateSessionList(msg.sessions || []);
+          refreshMobileChatSheet();
+          // Override title bar with mate name and re-apply color
+          var _mdn = (dmTargetUser.displayName || "New Mate");
+          if (headerTitleEl) headerTitleEl.textContent = _mdn;
+          var _tbpn = document.getElementById("title-bar-project-name");
+          if (_tbpn) _tbpn.textContent = _mdn;
+          var _mc2 = (dmTargetUser.profile && dmTargetUser.profile.avatarColor) || dmTargetUser.avatarColor || "#7c3aed";
+          var _tbc2 = document.querySelector(".title-bar-content");
+          if (_tbc2) { _tbc2.style.background = _mc2; _tbc2.classList.add("mate-dm-active"); }
+          document.body.classList.add("mate-dm-active");
+          // Still let normal session_list handler run below
+        }
+        if (msg.type === "transcript_turns") {
+          showTranscriptModal(msg);
+          return;
+        }
+        if (msg.type === "search_results") {
+          handleMateSearchResults(msg);
+          return;
+        }
+        if (msg.type === "knowledge_list") {
+          renderKnowledgeList(msg.files);
+          return;
+        }
+        if (msg.type === "knowledge_content") {
+          handleKnowledgeContent(msg);
+          return;
+        }
+        if (msg.type === "knowledge_saved" || msg.type === "knowledge_deleted" || msg.type === "knowledge_promoted" || msg.type === "knowledge_depromoted") {
+          return;
+        }
+        if (msg.type === "memory_list") {
+          renderMemoryList(msg.entries, msg.summary);
+          return;
+        }
+        if (msg.type === "memory_deleted") {
+          return;
+        }
+        // On done: scan DOM for [[MATE_READY: name]], update name, strip marker
+        if (msg.type === "done") {
+          setTimeout(function () { scrollToBottom(); }, 100);
+          setTimeout(function () { scrollToBottom(); }, 400);
+          setTimeout(function () {
+            var fullText = messagesEl ? messagesEl.textContent : "";
+            var readyMatch = fullText.match(/\[\[MATE_READY:\s*(.+?)\]\]/);
+            if (readyMatch) {
+              var newName = readyMatch[1].trim();
+              dmTargetUser.displayName = newName;
+              updateMateSidebarProfile({ profile: { displayName: newName, avatarColor: dmTargetUser.avatarColor, avatarStyle: dmTargetUser.avatarStyle, avatarSeed: dmTargetUser.avatarSeed } });
+              if (ws && ws.readyState === 1) {
+                ws.send(JSON.stringify({
+                  type: "mate_update",
+                  mateId: dmTargetUser.id,
+                  updates: { name: newName, status: "ready", profile: { displayName: newName } },
+                }));
+              }
+            }
+            var walker = document.createTreeWalker(messagesEl, NodeFilter.SHOW_TEXT, null, false);
+            var node;
+            while (node = walker.nextNode()) {
+              if (node.nodeValue.indexOf("[[MATE_READY:") !== -1) {
+                node.nodeValue = node.nodeValue.replace(/\[\[MATE_READY:\s*.+?\]\]/g, "").trim();
+              }
+            }
+          }, 100);
+        }
+      }
+
+      switch (msg.type) {
+        case "history_meta":
+          historyFrom = msg.from;
+          historyTotal = msg.total;
+          replayingHistory = true;
+          updateHistorySentinel();
+          break;
+
+        case "history_prepend":
+          prependOlderHistory(msg.items, msg.meta);
+          break;
+
+        case "history_done":
+          replayingHistory = false;
+          // Restore cached rich context usage BEFORE updateContextPanel runs
+          if (msg.contextUsage) {
+            richContextUsage = msg.contextUsage;
+          }
+          // Restore accurate context data from the last result in full history
+          if (msg.lastUsage || msg.lastModelUsage) {
+            accumulateContext(msg.lastCost, msg.lastUsage, msg.lastModelUsage, msg.lastStreamInputTokens);
+          }
+          updateContextPanel();
+          updateUsagePanel();
+          // Render + finalize any incomplete turn from the replayed history
+          if (currentMsgEl && currentFullText) {
+            var replayContentEl = currentMsgEl.querySelector(".md-content");
+            if (replayContentEl) {
+              replayContentEl.innerHTML = renderMarkdown(currentFullText);
+            }
+          }
+          markAllToolsDone();
+          finalizeAssistantBlock();
+          stopUrgentBlink();
+          // Clean up debate UI if debate is not active after replay
+          if (!isDebateActive()) {
+            var dbBar = document.getElementById("debate-bottom-bar");
+            if (dbBar) dbBar.remove();
+            var dhBar = document.getElementById("debate-hand-raise-bar");
+            if (dhBar) dhBar.remove();
+            var dbBadges = document.querySelectorAll(".debate-header-badge");
+            for (var dbi = 0; dbi < dbBadges.length; dbi++) dbBadges[dbi].remove();
+            // Clean up all debate mode banners if debate is not active on this session
+            if (debateFloorMode) exitDebateFloorMode();
+            if (debateConcludeMode) exitDebateConcludeMode();
+            if (debateEndedMode) exitDebateEndedMode();
+            var dbBanner = document.getElementById("debate-floor-banner");
+            if (dbBanner) dbBanner.remove();
+          }
+          scrollToBottom();
+          // Scroll to tool element if navigating from file edit history
+          var nav = getPendingNavigate();
+          if (nav && (nav.toolId || nav.assistantUuid)) {
+            requestAnimationFrame(function() {
+              // Prefer scrolling to the exact tool element
+              var target = nav.toolId ? messagesEl.querySelector('[data-tool-id="' + nav.toolId + '"]') : null;
+              if (!target && nav.assistantUuid) {
+                target = messagesEl.querySelector('[data-uuid="' + nav.assistantUuid + '"]');
+              }
+              if (target) {
+                // Auto-expand parent tool group if collapsed
+                var parentGroup = target.closest(".tool-group");
+                if (parentGroup) parentGroup.classList.remove("collapsed");
+                target.scrollIntoView({ behavior: "smooth", block: "center" });
+                target.classList.add("message-blink");
+                setTimeout(function() { target.classList.remove("message-blink"); }, 2000);
+              }
+            });
+          }
+          break;
+
+        case "restore_mate_dm":
+          if (pendingMateDmClears[currentSlug]) {
+            // User intentionally left this DM — clear stale server state, don't restore
+            delete pendingMateDmClears[currentSlug];
+            if (ws && ws.readyState === 1) {
+              try { ws.send(JSON.stringify({ type: "set_mate_dm", mateId: null })); } catch(e) {}
+            }
+          } else if (msg.mateId) {
+            // Server-driven mate DM restore on reconnect
+            // Note: do NOT remove mate-dm-active here; openDm is async (skill check)
+            // and removing the class causes a flash where mate UI is lost.
+            // enterDmMode will properly set/reset the class when DM is entered.
+            if (dmMode) {
+              dmMode = false;
+            }
+            messagesEl.innerHTML = "";
+            openDm(msg.mateId);
+          }
+          break;
+
+        case "info":
+          if (msg.text && !msg.project && !msg.cwd) {
+            addSystemMessage(msg.text, false);
+            break;
+          }
+          projectName = msg.project || msg.cwd;
+          if (msg.slug) currentSlug = msg.slug;
+          try { localStorage.setItem("clay-project-name-" + (currentSlug || "default"), projectName); } catch (e) {}
+          // In mate DM, keep title as mate name and re-apply mate color
+          if (dmMode && dmTargetUser && dmTargetUser.isMate) {
+            var _mateDN = dmTargetUser.displayName || "New Mate";
+            headerTitleEl.textContent = _mateDN;
+            var tbProjectName = $("title-bar-project-name");
+            if (tbProjectName) tbProjectName.textContent = _mateDN;
+            // Re-apply mate title bar styling (may be lost during project switch)
+            var _mc = (dmTargetUser.profile && dmTargetUser.profile.avatarColor) || dmTargetUser.avatarColor || "#7c3aed";
+            var _tbc = document.querySelector(".title-bar-content");
+            if (_tbc) { _tbc.style.background = _mc; _tbc.classList.add("mate-dm-active"); }
+            document.body.classList.add("mate-dm-active");
+          } else {
+            headerTitleEl.textContent = projectName;
+            var tbProjectName = $("title-bar-project-name");
+            if (tbProjectName) tbProjectName.textContent = msg.title || projectName;
+          }
+          updatePageTitle();
+          if (msg.version) {
+            setPaletteVersion(msg.version);
+            var serverVersionEl = document.getElementById("settings-server-version");
+            if (serverVersionEl) serverVersionEl.textContent = msg.version;
+          }
+          if (msg.projectOwnerId !== undefined) currentProjectOwnerId = msg.projectOwnerId;
+          if (msg.osUsers !== undefined) isOsUsers = !!msg.osUsers;
+          if (msg.lanHost) window.__lanHost = msg.lanHost;
+          if (msg.dangerouslySkipPermissions) {
+            skipPermsEnabled = true;
+            var spBanner = $("skip-perms-pill");
+            if (spBanner) spBanner.classList.remove("hidden");
+          }
+          updateProjectList(msg);
+          break;
+
+        case "update_available":
+          // In multi-user mode, only show update UI to admins
+          if (isMultiUserMode) {
+            checkAdminAccess().then(function (isAdmin) {
+              if (!isAdmin) return;
+              showUpdateAvailable(msg);
+            });
+          } else {
+            showUpdateAvailable(msg);
+          }
+          break;
+
+        case "up_to_date":
+          var utdBtn = $("settings-update-check");
+          if (utdBtn) {
+            utdBtn.innerHTML = "";
+            var utdIcon = document.createElement("i");
+            utdIcon.setAttribute("data-lucide", "check");
+            utdBtn.appendChild(utdIcon);
+            utdBtn.appendChild(document.createTextNode(" Up to date (v" + msg.version + ")"));
+            utdBtn.disabled = true;
+            refreshIcons();
+            setTimeout(function () {
+              utdBtn.innerHTML = "";
+              var rwIcon = document.createElement("i");
+              rwIcon.setAttribute("data-lucide", "refresh-cw");
+              utdBtn.appendChild(rwIcon);
+              utdBtn.appendChild(document.createTextNode(" Check for updates"));
+              utdBtn.disabled = false;
+              utdBtn.classList.remove("settings-btn-update-available");
+              refreshIcons();
+            }, 3000);
+          }
+          break;
+
+        case "update_started":
+          var updNowBtn = $("update-now");
+          if (updNowBtn) {
+            updNowBtn.innerHTML = '<i data-lucide="loader"></i> Updating...';
+            updNowBtn.disabled = true;
+            refreshIcons();
+            var spinIcon = updNowBtn.querySelector(".lucide");
+            if (spinIcon) spinIcon.classList.add("icon-spin-inline");
+          }
+          // Block the entire screen with the connect overlay
+          connectOverlay.classList.remove("hidden");
+          break;
+
+        case "slash_commands":
+          var reserved = new Set(builtinCommands.map(function (c) { return c.name; }));
+          slashCommands = (msg.commands || []).filter(function (name) {
+            return !reserved.has(name);
+          }).map(function (name) {
+            return { name: name, desc: "Skill" };
+          });
+          break;
+
+        case "model_info":
+          currentModel = msg.model || currentModel;
+          currentModels = msg.models || [];
+          updateConfigChip();
+          updateSettingsModels(msg.model, msg.models || []);
+          break;
+
+        case "config_state":
+          if (msg.model) currentModel = msg.model;
+          if (msg.mode) currentMode = msg.mode;
+          if (msg.effort) currentEffort = msg.effort;
+          if (msg.betas) currentBetas = msg.betas;
+          if (msg.thinking) currentThinking = msg.thinking;
+          if (msg.thinkingBudget) currentThinkingBudget = msg.thinkingBudget;
+          // Validate effort against current model's supported levels
+          if (currentModels.length > 0) {
+            var levels = getModelEffortLevels();
+            var effortValid = false;
+            for (var ei = 0; ei < levels.length; ei++) {
+              if (levels[ei] === currentEffort) { effortValid = true; break; }
+            }
+            if (!effortValid) currentEffort = "medium";
+          }
+          updateConfigChip();
+          break;
+
+        case "client_count":
+          // Sidebar presence: current project's online users
+          if (msg.users) {
+            renderSidebarPresence(msg.users);
+          }
+          // Non-multi-user mode: simple count in topbar
+          if (!msg.users) {
+            var countEl = document.getElementById("client-count");
+            var countTextEl = document.getElementById("client-count-text");
+            if (countEl && countTextEl) {
+              if (msg.count > 1) {
+                countTextEl.textContent = msg.count + " connected";
+                countEl.classList.remove("hidden");
+              } else {
+                countEl.classList.add("hidden");
+              }
+            }
+          }
+          break;
+
+        case "toast":
+          showToast(msg.message, msg.level, msg.detail);
+          break;
+
+        case "plugins_reloaded": {
+          var parts = [];
+          if (msg.plugins && msg.plugins.length) parts.push(msg.plugins.length + " plugin" + (msg.plugins.length === 1 ? "" : "s"));
+          if (msg.commandCount) parts.push(msg.commandCount + " command" + (msg.commandCount === 1 ? "" : "s"));
+          if (msg.agentCount) parts.push(msg.agentCount + " agent" + (msg.agentCount === 1 ? "" : "s"));
+          if (msg.mcpServers && msg.mcpServers.length) parts.push(msg.mcpServers.length + " MCP server" + (msg.mcpServers.length === 1 ? "" : "s"));
+          var reloadMsg = "Plugins reloaded: " + (parts.length ? parts.join(", ") : "no changes");
+          if (msg.errorCount > 0) reloadMsg += " (" + msg.errorCount + " error" + (msg.errorCount === 1 ? "" : "s") + ")";
+          addSystemMessage(reloadMsg, true);
+          break;
+        }
+
+        case "skill_installed":
+          handleSkillInstalled(msg);
+          if (msg.success) knownInstalledSkills[msg.skill] = true;
+          handleSkillInstallWs(msg);
+          break;
+
+        case "skill_uninstalled":
+          handleSkillUninstalled(msg);
+          if (msg.success) delete knownInstalledSkills[msg.skill];
+          break;
+
+        case "loop_registry_updated":
+          handleLoopRegistryUpdated(msg);
+          break;
+
+        case "schedule_run_started":
+          handleScheduleRunStarted(msg);
+          break;
+
+        case "schedule_run_finished":
+          handleScheduleRunFinished(msg);
+          break;
+
+        case "loop_scheduled":
+          handleLoopScheduled(msg);
+          break;
+
+        case "schedule_move_result":
+          if (msg.ok) {
+            showToast("Task moved", "success");
+          } else {
+            showToast(msg.error || "Failed to move task", "error");
+          }
+          break;
+
+        case "remove_project_check_result":
+          handleRemoveProjectCheckResult(msg);
+          break;
+
+        case "hub_schedules":
+          handleHubSchedules(msg);
+          break;
+
+        case "input_sync":
+          if (!dmMode) handleInputSync(msg.text);
+          break;
+
+        case "transcript_turns":
+          showTranscriptModal(msg);
+          break;
+
+        case "session_list":
+          renderMateSessionList(msg.sessions || []);
+          renderSessionList(msg.sessions || []);
+          handlePaletteSessionSwitch();
+          break;
+
+        case "session_presence":
+          updateSessionPresence(msg.presence || {});
+          break;
+
+        case "cursor_move":
+          handleRemoteCursorMove(msg);
+          break;
+
+        case "cursor_leave":
+          handleRemoteCursorLeave(msg);
+          break;
+
+        case "text_select":
+          handleRemoteSelection(msg);
+          break;
+
+        case "session_io":
+          blinkSessionDot(msg.id);
+          break;
+
+        case "session_unread":
+          updateSessionBadge(msg.id, msg.count);
+          break;
+
+        case "search_results":
+          handleSearchResults(msg);
+          break;
+
+        case "search_content_results":
+          if (msg.source === "find_in_session") {
+            handleFindInSessionResults(msg);
+          }
+          break;
+
+        case "cli_session_list":
+          populateCliSessionList(msg.sessions || []);
+          break;
+
+        case "session_switched":
+          hideHomeHub();
+          // Save draft from outgoing session
+          if (activeSessionId && inputEl.value) {
+            sessionDrafts[activeSessionId] = inputEl.value;
+          } else if (activeSessionId) {
+            delete sessionDrafts[activeSessionId];
+          }
+          activeSessionId = msg.id;
+          cliSessionId = msg.cliSessionId || null;
+          // Session presence is now tracked server-side (user-presence.json)
+          clearRemoteCursors();
+          resetClientState();
+          updateRalphBars();
+          updateLoopInputVisibility(msg.loop);
+          // Restore input area visibility (may have been hidden by auth_required)
+          var inputAreaSw = document.getElementById("input-area");
+          if (inputAreaSw) inputAreaSw.classList.remove("hidden");
+          // Restore draft for incoming session
+          var draft = sessionDrafts[activeSessionId] || "";
+          inputEl.value = draft;
+          autoResize();
+          if (!("ontouchstart" in window)) {
+            inputEl.focus();
+          }
+          break;
+
+        case "session_id":
+          cliSessionId = msg.cliSessionId;
+          break;
+
+        case "message_uuid":
+          var uuidTarget;
+          if (msg.messageType === "user") {
+            var allUsers = messagesEl.querySelectorAll(".msg-user:not([data-uuid])");
+            if (allUsers.length > 0) uuidTarget = allUsers[allUsers.length - 1];
+          } else {
+            var allAssistants = messagesEl.querySelectorAll(".msg-assistant:not([data-uuid])");
+            if (allAssistants.length > 0) uuidTarget = allAssistants[allAssistants.length - 1];
+          }
+          if (uuidTarget) {
+            uuidTarget.dataset.uuid = msg.uuid;
+            if (msg.messageType === "user") addRewindButton(uuidTarget);
+          }
+          messageUuidMap.push({ uuid: msg.uuid, type: msg.messageType });
+          break;
+
+        case "user_message":
+          if (msg._internal) break;
+          resetThinkingGroup();
+          if (msg.planContent) {
+            setPlanContent(msg.planContent);
+            renderPlanCard(msg.planContent);
+            addUserMessage("Execute the following plan. Do NOT re-enter plan mode — just implement it step by step.", msg.images || null, msg.pastes || null, msg.from, msg.fromName);
+          } else {
+            addUserMessage(msg.text, msg.images || null, msg.pastes || null, msg.from, msg.fromName);
+          }
+          break;
+
+        case "context_preview":
+          // Show a Context Card with tab screenshot between user message and assistant response
+          if (msg.tab) {
+            var card = document.createElement("div");
+            card.className = "context-card";
+
+            // Header
+            var header = document.createElement("div");
+            header.className = "context-card-header";
+            var icon = document.createElement("span");
+            icon.className = "context-card-icon";
+            icon.innerHTML = iconHtml("globe");
+            header.appendChild(icon);
+            var label = document.createElement("span");
+            label.textContent = "Viewing tab";
+            header.appendChild(label);
+            card.appendChild(header);
+
+            // Screenshot
+            if (msg.tab.screenshotUrl) {
+              var img = document.createElement("img");
+              img.className = "context-card-screenshot";
+              img.src = msg.tab.screenshotUrl;
+              img.loading = "lazy";
+              img.addEventListener("click", function () { showImageModal(this.src); });
+              card.appendChild(img);
+            }
+
+            // Meta: title + domain
+            var tabTitle = msg.tab.title || "";
+            var tabDomain = "";
+            try { tabDomain = new URL(msg.tab.url).hostname; } catch (e) {}
+            if (tabTitle || tabDomain) {
+              var meta = document.createElement("div");
+              meta.className = "context-card-meta";
+              if (msg.tab.favIconUrl) {
+                var fav = document.createElement("img");
+                fav.className = "context-card-favicon";
+                fav.src = msg.tab.favIconUrl;
+                fav.width = 14;
+                fav.height = 14;
+                fav.onerror = function () { this.style.display = "none"; };
+                meta.appendChild(fav);
+              }
+              var titleEl = document.createElement("span");
+              titleEl.className = "context-card-title";
+              titleEl.textContent = tabTitle;
+              meta.appendChild(titleEl);
+              if (tabDomain) {
+                var domainEl = document.createElement("span");
+                domainEl.className = "context-card-domain";
+                domainEl.textContent = tabDomain;
+                meta.appendChild(domainEl);
+              }
+              card.appendChild(meta);
+            }
+
+            messagesEl.appendChild(card);
+            scrollToBottom();
+          }
+          break;
+
+        case "status":
+          if (msg.status === "processing") {
+            setStatus("processing");
+            if (!(dmMode && dmTargetUser && dmTargetUser.isMate) && !matePreThinkingEl) {
+              setActivity("thinking");
+            }
+          }
+          break;
+
+        case "compacting":
+          if (msg.active) {
+            setActivity("compacting");
+          } else if (!(dmMode && dmTargetUser && dmTargetUser.isMate)) {
+            setActivity("thinking");
+          }
+          break;
+
+        case "thinking_start":
+          removeMatePreThinking();
+          startThinking();
+          break;
+
+        case "thinking_delta":
+          if (typeof msg.text === "string") appendThinking(msg.text);
+          break;
+
+        case "thinking_stop":
+          stopThinking(msg.duration);
+          if (!(dmMode && dmTargetUser && dmTargetUser.isMate)) {
+            setActivity("thinking");
+          }
+          break;
+
+        case "delta":
+          if (typeof msg.text !== "string") break;
+          removeMatePreThinking();
+          stopThinking();
+          resetThinkingGroup();
+          setActivity(null);
+          appendDelta(msg.text);
+          break;
+
+        case "tool_start":
+          removeMatePreThinking();
+          stopThinking();
+          markAllToolsDone();
+          if (msg.name === "EnterPlanMode") {
+            renderPlanBanner("enter");
+            getTools()[msg.id] = { el: null, name: msg.name, input: null, done: true, hidden: true };
+          } else if (msg.name === "ExitPlanMode") {
+            if (getPlanContent()) {
+              renderPlanCard(getPlanContent());
+            }
+            renderPlanBanner("exit");
+            getTools()[msg.id] = { el: null, name: msg.name, input: null, done: true, hidden: true };
+          } else if (msg.name === "propose_debate" || (msg.name && msg.name.indexOf("propose_debate") !== -1)) {
+            getTools()[msg.id] = { el: null, name: msg.name, input: null, done: true, hidden: true };
+          } else if (getTodoTools()[msg.name]) {
+            getTools()[msg.id] = { el: null, name: msg.name, input: null, done: true, hidden: true };
+          } else {
+            createToolItem(msg.id, msg.name);
+          }
+          break;
+
+        case "tool_executing":
+          if ((msg.name === "propose_debate" || (msg.name && msg.name.indexOf("propose_debate") !== -1)) && msg.input) {
+            var _dpTool = getTools()[msg.id];
+            if (_dpTool) {
+              if (_dpTool.el) _dpTool.el.style.display = "none";
+              _dpTool.done = true;
+              _dpTool.hidden = true;
+              removeToolFromGroup(msg.id);
+            }
+            finalizeAssistantBlock();
+            renderMcpDebateProposal(msg.id, msg.input);
+            startUrgentBlink();
+          } else if (msg.name === "AskUserQuestion" && msg.input && msg.input.questions) {
+            var askTool = getTools()[msg.id];
+            if (askTool) {
+              if (askTool.el) askTool.el.style.display = "none";
+              askTool.done = true;
+              removeToolFromGroup(msg.id);
+            }
+            renderAskUserQuestion(msg.id, msg.input);
+            startUrgentBlink();
+          } else if (msg.name === "Write" && msg.input && isPlanFilePath(msg.input.file_path)) {
+            setPlanContent(msg.input.content || "");
+            updateToolExecuting(msg.id, msg.name, msg.input);
+          } else if (msg.name === "Edit" && msg.input && isPlanFilePath(msg.input.file_path)) {
+            var pc = getPlanContent() || "";
+            if (msg.input.old_string && pc.indexOf(msg.input.old_string) !== -1) {
+              if (msg.input.replace_all) {
+                setPlanContent(pc.split(msg.input.old_string).join(msg.input.new_string || ""));
+              } else {
+                setPlanContent(pc.replace(msg.input.old_string, msg.input.new_string || ""));
+              }
+            }
+            updateToolExecuting(msg.id, msg.name, msg.input);
+          } else if (msg.name === "TodoWrite") {
+            handleTodoWrite(msg.input);
+          } else if (msg.name === "TaskCreate") {
+            handleTaskCreate(msg.input);
+          } else if (msg.name === "TaskUpdate") {
+            handleTaskUpdate(msg.input);
+          } else if (getTodoTools()[msg.name]) {
+            // TaskList, TaskGet - silently skip
+          } else {
+            var t = getTools()[msg.id];
+            if (t && t.hidden) break;
+            updateToolExecuting(msg.id, msg.name, msg.input);
+          }
+          break;
+
+        case "tool_result": {
+            var tr = getTools()[msg.id];
+            if (tr && tr.hidden) break; // skip hidden plan tools
+            // Always call updateToolResult for Edit (to show diff from input), or when content exists
+            if (msg.content != null || msg.images || (tr && tr.name === "Edit" && tr.input && tr.input.old_string)) {
+              updateToolResult(msg.id, msg.content || "", msg.is_error || false, msg.images);
+            }
+            // Refresh file browser if an Edit/Write tool modified the open file
+            if (!msg.is_error && tr && (tr.name === "Edit" || tr.name === "Write") && tr.input && tr.input.file_path) {
+              refreshIfOpen(tr.input.file_path);
+            }
+          }
+          break;
+
+        case "ask_user_answered":
+          markAskUserAnswered(msg.toolId, msg.answers);
+          stopUrgentBlink();
+          break;
+
+        case "permission_request":
+          renderPermissionRequest(msg.requestId, msg.toolName, msg.toolInput, msg.decisionReason, msg.mateId);
+          startUrgentBlink();
+          break;
+
+        case "permission_cancel":
+          markPermissionCancelled(msg.requestId);
+          stopUrgentBlink();
+          break;
+
+        case "permission_resolved":
+          markPermissionResolved(msg.requestId, msg.decision);
+          stopUrgentBlink();
+          break;
+
+        case "permission_request_pending":
+          renderPermissionRequest(msg.requestId, msg.toolName, msg.toolInput, msg.decisionReason, msg.mateId);
+          startUrgentBlink();
+          break;
+
+        case "elicitation_request":
+          renderElicitationRequest(msg);
+          startUrgentBlink();
+          break;
+
+        case "elicitation_resolved":
+          markElicitationResolved(msg.requestId, msg.action);
+          stopUrgentBlink();
+          break;
+
+        case "slash_command_result":
+          finalizeAssistantBlock();
+          var cmdBlock = document.createElement("div");
+          cmdBlock.className = "assistant-block";
+          cmdBlock.style.maxWidth = "var(--content-width)";
+          cmdBlock.style.margin = "12px auto";
+          cmdBlock.style.padding = "0 20px";
+          var pre = document.createElement("pre");
+          pre.style.cssText = "background:var(--code-bg);border:1px solid var(--border-subtle);border-radius:10px;padding:12px 14px;font-family:'SF Mono',Menlo,Monaco,monospace;font-size:12px;line-height:1.55;color:var(--text-secondary);white-space:pre-wrap;word-break:break-word;max-height:400px;overflow-y:auto;margin:0";
+          pre.textContent = msg.text;
+          cmdBlock.appendChild(pre);
+          addToMessages(cmdBlock);
+          scrollToBottom();
+          break;
+
+        case "subagent_activity":
+          updateSubagentActivity(msg.parentToolId, msg.text);
+          break;
+
+        case "subagent_tool":
+          addSubagentToolEntry(msg.parentToolId, msg.toolName, msg.toolId, msg.text);
+          break;
+
+        case "subagent_done":
+          markSubagentDone(msg.parentToolId, msg.status, msg.summary, msg.usage);
+          break;
+
+        case "task_started":
+          initSubagentStop(msg.parentToolId, msg.taskId);
+          break;
+
+        case "task_progress":
+          updateSubagentProgress(msg.parentToolId, msg.usage, msg.lastToolName, msg.summary);
+          break;
+
+        case "result":
+          setActivity(null);
+          stopThinking();
+          markAllToolsDone();
+          closeToolGroup();
+          finalizeAssistantBlock();
+          addTurnMeta(msg.cost, msg.duration);
+          accumulateUsage(msg.cost, msg.usage);
+          accumulateContext(msg.cost, msg.usage, msg.modelUsage, msg.lastStreamInputTokens);
+          break;
+
+        case "context_usage":
+          if (msg.data && !replayingHistory) {
+            richContextUsage = msg.data;
+            if (headerContextEl) headerContextEl.removeAttribute("data-tip");
+            if (ctxPopoverVisible) renderCtxPopover();
+          }
+          break;
+
+        case "done":
+          setActivity(null);
+          stopThinking();
+          markAllToolsDone();
+          closeToolGroup();
+          finalizeAssistantBlock();
+          processing = false;
+          setStatus("connected");
+          if (!loopActive) enableMainInput();
+          resetToolState();
+          stopUrgentBlink();
+          if (document.hidden) {
+            if (isNotifAlertEnabled() && !window._pushSubscription) showDoneNotification();
+            if (isNotifSoundEnabled()) playDoneSound();
+          }
+          break;
+
+        case "stderr":
+          addSystemMessage(msg.text, false);
+          break;
+
+        case "error":
+          setActivity(null);
+          addSystemMessage(msg.text, true);
+          break;
+
+        case "process_conflict":
+          setActivity(null);
+          addConflictMessage(msg);
+          break;
+
+        case "context_overflow":
+          setActivity(null);
+          addContextOverflowMessage(msg);
+          break;
+
+        case "auth_required":
+          setActivity(null);
+          addAuthRequiredMessage(msg);
+          break;
+
+        case "rate_limit":
+          handleRateLimitEvent(msg);
+          break;
+
+        case "rate_limit_usage":
+          updateRateLimitUsage(msg);
+          break;
+
+        case "scheduled_message_queued":
+          addScheduledMessageBubble(msg.text, msg.resetsAt);
+          setScheduleBtnDisabled(true);
+          break;
+
+        case "scheduled_message_sent":
+          removeScheduledMessageBubble();
+          setScheduleBtnDisabled(false);
+          processing = true;
+          setStatus("processing");
+          break;
+
+        case "scheduled_message_cancelled":
+          removeScheduledMessageBubble();
+          setScheduleBtnDisabled(false);
+          break;
+
+        case "auto_continue_scheduled":
+          // Scheduler auto-continue, just show info
+          break;
+
+        case "auto_continue_fired":
+          processing = true;
+          setStatus("processing");
+          break;
+
+        case "prompt_suggestion":
+          showSuggestionChips(msg.suggestion);
+          break;
+
+        case "fast_mode_state":
+          handleFastModeState(msg.state);
+          break;
+
+        case "process_killed":
+          addSystemMessage("Process " + msg.pid + " has been terminated. You can retry your message now.", false);
+          break;
+
+        case "rewind_preview_result":
+          showRewindModal(msg);
+          break;
+
+        case "rewind_complete":
+          onRewindComplete();
+          setRewindMode(false);
+          var rewindText = "Rewound to earlier point. Files have been restored.";
+          if (msg.mode === "chat") rewindText = "Conversation rewound to earlier point.";
+          else if (msg.mode === "files") rewindText = "Files restored to earlier point.";
+          addSystemMessage(rewindText, false);
+          break;
+
+        case "rewind_error":
+          onRewindError();
+          clearPendingRewindUuid();
+          addSystemMessage(msg.text || "Rewind failed.", true);
+          break;
+
+        case "fork_complete":
+          addSystemMessage("Session forked successfully.");
+          break;
+
+        case "fs_list_result":
+          handleFsList(msg);
+          break;
+
+        case "fs_read_result":
+          if (msg.path === "CLAUDE.md" && isProjectSettingsOpen()) {
+            handleInstructionsRead(msg);
+          } else {
+            handleFsRead(msg);
+          }
+          break;
+
+        case "fs_write_result":
+          handleInstructionsWrite(msg);
+          break;
+
+        case "project_env_result":
+          handleProjectEnv(msg);
+          break;
+
+        case "set_project_env_result":
+          handleProjectEnvSaved(msg);
+          break;
+
+        case "global_claude_md_result":
+          handleGlobalClaudeMdRead(msg);
+          break;
+
+        case "write_global_claude_md_result":
+          handleGlobalClaudeMdWrite(msg);
+          break;
+
+        case "shared_env_result":
+          handleSharedEnv(msg);
+          handleProjectSharedEnv(msg);
+          break;
+
+        case "set_shared_env_result":
+          handleSharedEnvSaved(msg);
+          handleProjectSharedEnvSaved(msg);
+          break;
+
+        case "fs_file_changed":
+          handleFileChanged(msg);
+          break;
+
+        case "fs_dir_changed":
+          handleDirChanged(msg);
+          break;
+
+        case "fs_file_history_result":
+          handleFileHistory(msg);
+          break;
+
+        case "fs_git_diff_result":
+          handleGitDiff(msg);
+          break;
+
+        case "fs_file_at_result":
+          handleFileAt(msg);
+          break;
+
+        case "term_list":
+          handleTermList(msg);
+          updateTerminalList(msg.terminals);
+          break;
+
+        case "context_sources_state":
+          handleContextSourcesState(msg);
+          break;
+
+        case "extension_command":
+          sendExtensionCommand(msg.command, msg.args, msg.requestId);
+          break;
+
+        case "term_created":
+          handleTermCreated(msg);
+          if (pendingTermCommand) {
+            var cmd = pendingTermCommand;
+            pendingTermCommand = null;
+            // Small delay to let terminal initialize
+            setTimeout(function() {
+              sendTerminalCommand(cmd);
+            }, 300);
+          }
+          break;
+
+        case "term_output":
+          handleTermOutput(msg);
+          break;
+
+        case "term_resized":
+          handleTermResized(msg);
+          break;
+
+        case "term_exited":
+          handleTermExited(msg);
+          break;
+
+        case "term_closed":
+          handleTermClosed(msg);
+          break;
+
+        case "notes_list":
+          handleNotesList(msg);
+          break;
+
+        case "note_created":
+          handleNoteCreated(msg);
+          break;
+
+        case "note_updated":
+          handleNoteUpdated(msg);
+          break;
+
+        case "note_deleted":
+          handleNoteDeleted(msg);
+          break;
+
+        case "process_stats":
+          updateStatusPanel(msg);
+          updateSettingsStats(msg);
+          break;
+
+        case "browse_dir_result":
+          handleBrowseDirResult(msg);
+          break;
+
+        case "add_project_result":
+          handleAddProjectResult(msg);
+          break;
+
+        case "clone_project_progress":
+          handleCloneProgress(msg);
+          break;
+
+        case "remove_project_result":
+          handleRemoveProjectResult(msg);
+          break;
+
+        case "reorder_projects_result":
+          if (!msg.ok) {
+            showToast(msg.error || "Failed to reorder projects", "error");
+          }
+          break;
+
+        case "set_project_title_result":
+          if (!msg.ok) {
+            showToast(msg.error || "Failed to rename project", "error");
+          }
+          break;
+
+        case "set_project_icon_result":
+          if (!msg.ok) {
+            showToast(msg.error || "Failed to set icon", "error");
+          }
+          break;
+
+        case "projects_updated":
+          updateProjectList(msg);
+          break;
+
+        case "project_owner_changed":
+          currentProjectOwnerId = msg.ownerId;
+          handleProjectOwnerChanged(msg);
+          break;
+
+        // --- DM ---
+        case "dm_history":
+          // Attach projectSlug to targetUser for mate DMs
+          if (msg.projectSlug && msg.targetUser) {
+            msg.targetUser.projectSlug = msg.projectSlug;
+          }
+          enterDmMode(msg.dmKey, msg.targetUser, msg.messages);
+          // Auto-send first interview prompt after mate DM opens
+          if (pendingMateInterview && msg.targetUser && msg.targetUser.isMate && msg.projectSlug) {
+            var interviewMate = pendingMateInterview;
+            pendingMateInterview = null;
+            // Wait for mate project WS to connect, then send interview prompt
+            var checkMateReady = setInterval(function () {
+              if (ws && ws.readyState === 1 && mateProjectSlug) {
+                clearInterval(checkMateReady);
+                var interviewText = buildMateInterviewPrompt(interviewMate);
+                ws.send(JSON.stringify({ type: "message", text: interviewText }));
+              }
+            }, 100);
+            setTimeout(function () { clearInterval(checkMateReady); }, 5000);
+          }
+          break;
+
+        case "dm_message":
+          if (dmMode && msg.dmKey === dmKey) {
+            showDmTypingIndicator(false); // hide typing when message arrives
+            appendDmMessage(msg.message);
+            scrollToBottom();
+          } else if (msg.message) {
+            // DM notification when not in that DM
+            var fromId = msg.message.from;
+            if (fromId && fromId !== myUserId) {
+              dmUnread[fromId] = (dmUnread[fromId] || 0) + 1;
+              // Re-render strip so non-favorited sender appears
+              renderUserStrip(cachedAllUsers, cachedOnlineIds, myUserId, cachedDmFavorites, cachedDmConversations, dmUnread, dmRemovedUsers, cachedMatesList);
+              updateDmBadge(fromId, dmUnread[fromId]);
+            }
+          }
+          break;
+
+        case "dm_typing":
+          if (dmMode && msg.dmKey === dmKey) {
+            showDmTypingIndicator(msg.typing);
+          }
+          break;
+
+        case "dm_list":
+          // Could be used for DM list view later
+          break;
+
+        case "dm_favorites_updated":
+          // Track users explicitly removed from favorites
+          if (cachedDmFavorites && msg.dmFavorites) {
+            for (var ri = 0; ri < cachedDmFavorites.length; ri++) {
+              if (msg.dmFavorites.indexOf(cachedDmFavorites[ri]) === -1) {
+                dmRemovedUsers[cachedDmFavorites[ri]] = true;
+              }
+            }
+          }
+          // Clear removed flag for users being added back
+          if (msg.dmFavorites) {
+            for (var ai = 0; ai < msg.dmFavorites.length; ai++) {
+              delete dmRemovedUsers[msg.dmFavorites[ai]];
+            }
+          }
+          cachedDmFavorites = msg.dmFavorites || [];
+          renderUserStrip(cachedAllUsers, cachedOnlineIds, myUserId, cachedDmFavorites, cachedDmConversations, dmUnread, dmRemovedUsers, cachedMatesList);
+          break;
+
+        case "mate_created":
+          handleMateCreatedInApp(msg.mate, msg);
+          break;
+
+        case "mate_deleted":
+          cachedMatesList = cachedMatesList.filter(function (m) { return m.id !== msg.mateId; });
+          if (msg.availableBuiltins) cachedAvailableBuiltins = msg.availableBuiltins;
+          renderUserStrip(cachedAllUsers, cachedOnlineIds, myUserId, cachedDmFavorites, cachedDmConversations, dmUnread, dmRemovedUsers, cachedMatesList);
+          // If currently in DM with this mate, exit DM mode
+          if (dmMode && dmTargetUser && dmTargetUser.id === msg.mateId) {
+            exitDmMode();
+          }
+          break;
+
+        case "mate_updated":
+          if (msg.mate) {
+            for (var mi = 0; mi < cachedMatesList.length; mi++) {
+              if (cachedMatesList[mi].id === msg.mate.id) {
+                cachedMatesList[mi] = msg.mate;
+                break;
+              }
+            }
+            renderUserStrip(cachedAllUsers, cachedOnlineIds, myUserId, cachedDmFavorites, cachedDmConversations, dmUnread, dmRemovedUsers, cachedMatesList);
+            // Update mate sidebar if currently viewing this mate
+            if (dmMode && dmTargetUser && dmTargetUser.isMate && dmTargetUser.id === msg.mate.id) {
+              updateMateSidebarProfile(msg.mate);
+              // Sync dmTargetUser so subsequent renders use fresh data
+              var mp2 = msg.mate.profile || {};
+              dmTargetUser.displayName = mp2.displayName || msg.mate.name || dmTargetUser.displayName;
+              dmTargetUser.avatarStyle = mp2.avatarStyle || dmTargetUser.avatarStyle;
+              dmTargetUser.avatarSeed = mp2.avatarSeed || dmTargetUser.avatarSeed;
+              dmTargetUser.avatarColor = mp2.avatarColor || dmTargetUser.avatarColor;
+              dmTargetUser.avatarCustom = mp2.avatarCustom || "";
+              dmTargetUser.profile = mp2;
+              // Refresh body dataset so new chat bubbles use the updated avatar
+              document.body.dataset.mateAvatarUrl = mateAvatarUrl(dmTargetUser, 36);
+              document.body.dataset.mateName = mp2.displayName || msg.mate.name || "";
+              // Update existing chat bubble avatars
+              var mateAvis = document.querySelectorAll(".dm-bubble-avatar-mate");
+              for (var mbi = 0; mbi < mateAvis.length; mbi++) {
+                mateAvis[mbi].src = document.body.dataset.mateAvatarUrl;
+              }
+            }
+            // Update DM header if currently chatting with this mate
+            if (dmMode && dmTargetUser && dmTargetUser.id === msg.mate.id) {
+              var updatedName = (msg.mate.profile && msg.mate.profile.displayName) || msg.mate.name;
+              if (updatedName) {
+                var dmHeaderName = document.getElementById("dm-header-name");
+                if (dmHeaderName) dmHeaderName.textContent = updatedName;
+                var dmInput = document.getElementById("dm-input");
+                if (dmInput) dmInput.placeholder = "Message " + updatedName;
+              }
+            }
+          }
+          break;
+
+        case "mate_list":
+          cachedMatesList = msg.mates || [];
+          cachedAvailableBuiltins = msg.availableBuiltins || [];
+          renderUserStrip(cachedAllUsers, cachedOnlineIds, myUserId, cachedDmFavorites, cachedDmConversations, dmUnread, dmRemovedUsers, cachedMatesList);
+          break;
+
+        case "mate_available_builtins":
+          // Handled via mate_list.availableBuiltins now
+          break;
+
+        case "mate_error":
+          showToast(msg.error || "Mate operation failed", "error");
+          break;
+
+        // --- @Mention ---
+        case "mention_processing":
+          // Broadcast: show/hide activity dot on mate avatar across all tabs
+          if (msg.mateId) {
+            var mateContainers = document.querySelectorAll('.icon-strip-mate[data-user-id="' + msg.mateId + '"]');
+            for (var mi = 0; mi < mateContainers.length; mi++) {
+              var dot = mateContainers[mi].querySelector(".icon-strip-status");
+              if (msg.active) {
+                if (dot) dot.classList.add("processing");
+                mateContainers[mi].classList.add("mention-active");
+              } else {
+                if (dot) dot.classList.remove("processing");
+                mateContainers[mi].classList.remove("mention-active");
+              }
+            }
+          }
+          break;
+
+        case "mention_start":
+          handleMentionStart(msg);
+          break;
+
+        case "mention_activity":
+          handleMentionActivity(msg);
+          break;
+
+        case "mention_stream":
+          handleMentionStream(msg);
+          break;
+
+        case "mention_done":
+          handleMentionDone(msg);
+          break;
+
+        case "mention_error":
+          handleMentionError(msg);
+          if (msg.error) showToast("@Mention: " + msg.error, "error");
+          break;
+
+        case "mention_user":
+          // Finalize current assistant block so mention renders in correct DOM position
+          finalizeAssistantBlock();
+          renderMentionUser(msg);
+          break;
+
+        case "mention_response":
+          finalizeAssistantBlock();
+          renderMentionResponse(msg);
+          break;
+
+        // --- Debate ---
+        case "debate_preparing":
+          if (!replayingHistory) showDebateSticky("preparing", msg);
+          handleDebatePreparing(msg);
+          break;
+
+        case "debate_brief_ready":
+          if (replayingHistory) {
+            renderDebateBriefReady(msg);
+          } else {
+            handleDebateBriefReady(msg);
+          }
+          break;
+
+        case "debate_started":
+          if (!replayingHistory) showDebateSticky("live", msg);
+          if (replayingHistory) {
+            renderDebateStarted(msg);
+          } else {
+            handleDebateStarted(msg);
+          }
+          break;
+
+        case "debate_turn":
+          handleDebateTurn(msg);
+          if (msg.round) updateDebateRound(msg.round);
+          break;
+
+        case "debate_activity":
+          handleDebateActivity(msg);
+          break;
+
+        case "debate_stream":
+          handleDebateStream(msg);
+          break;
+
+        case "debate_turn_done":
+          if (msg.round) updateDebateRound(msg.round);
+          handleDebateTurnDone(msg);
+          break;
+
+        case "debate_hand_raised":
+          // Visual feedback: hand is raised, waiting for floor
+          break;
+
+        case "debate_comment_queued":
+          handleDebateCommentQueued(msg);
+          break;
+
+        case "debate_comment_injected":
+          if (replayingHistory) {
+            renderDebateCommentInjected(msg);
+          } else {
+            handleDebateCommentInjected(msg);
+          }
+          break;
+
+        case "debate_conclude_confirm":
+          if (!replayingHistory) showDebateConcludeConfirm(msg);
+          break;
+
+        case "debate_user_floor":
+          if (!replayingHistory) showDebateUserFloor(msg);
+          break;
+
+        case "debate_user_floor_done":
+          renderDebateUserFloorDone(msg);
+          break;
+
+        case "debate_user_resume":
+          renderDebateUserResume(msg);
+          break;
+
+        case "debate_resumed":
+          handleDebateResumed(msg);
+          if (!replayingHistory) showDebateSticky("live", msg);
+          break;
+
+        case "debate_ended":
+          if (!replayingHistory) showDebateSticky("ended", msg);
+          if (replayingHistory) {
+            renderDebateEnded(msg);
+          } else {
+            handleDebateEnded(msg);
+          }
+          break;
+
+        case "debate_error":
+          handleDebateError(msg);
+          if (msg.error) showToast("Debate: " + msg.error, "error");
+          break;
+
+        case "daemon_config":
+          if (msg.config && msg.config.headless) isHeadlessMode = true;
+          updateDaemonConfig(msg.config);
+          break;
+
+        case "set_pin_result":
+          handleSetPinResult(msg);
+          break;
+
+        case "set_keep_awake_result":
+          handleKeepAwakeChanged(msg);
+          break;
+
+        case "keep_awake_changed":
+          handleKeepAwakeChanged(msg);
+          break;
+
+        case "set_auto_continue_result":
+        case "auto_continue_changed":
+          handleAutoContinueChanged(msg);
+          break;
+
+        case "restart_server_result":
+          handleRestartResult(msg);
+          break;
+
+        case "shutdown_server_result":
+          handleShutdownResult(msg);
+          break;
+
+        // --- Ralph Loop ---
+        case "loop_available":
+          loopAvailable = msg.available;
+          loopActive = msg.active;
+          loopIteration = msg.iteration || 0;
+          loopMaxIterations = msg.maxIterations || 20;
+          loopBannerName = msg.name || null;
+          updateLoopButton();
+          if (loopActive) {
+            showLoopBanner(true);
+            if (loopIteration > 0) {
+              updateLoopBanner(loopIteration, loopMaxIterations, "running");
+            }
+            inputEl.disabled = true;
+            inputEl.placeholder = (loopBannerName || "Loop") + " is running...";
+          }
+          break;
+
+        case "loop_started":
+          loopActive = true;
+          ralphPhase = "executing";
+          loopIteration = 0;
+          loopMaxIterations = msg.maxIterations;
+          loopBannerName = msg.name || null;
+          showLoopBanner(true);
+          updateLoopButton();
+          addSystemMessage((loopBannerName || "Loop") + " started (max " + msg.maxIterations + " iterations)", false);
+          inputEl.disabled = true;
+          inputEl.placeholder = (loopBannerName || "Loop") + " is running...";
+          break;
+
+        case "loop_iteration":
+          loopIteration = msg.iteration;
+          loopMaxIterations = msg.maxIterations;
+          updateLoopBanner(msg.iteration, msg.maxIterations, "running");
+          updateLoopButton();
+          addSystemMessage((loopBannerName || "Loop") + " iteration #" + msg.iteration + " started", false);
+          inputEl.disabled = true;
+          inputEl.placeholder = (loopBannerName || "Loop") + " is running...";
+          break;
+
+        case "loop_judging":
+          updateLoopBanner(loopIteration, loopMaxIterations, "judging");
+          addSystemMessage("Judging iteration #" + msg.iteration + "...", false);
+          inputEl.disabled = true;
+          inputEl.placeholder = (loopBannerName || "Loop") + " is judging...";
+          break;
+
+        case "loop_verdict":
+          addSystemMessage("Judge: " + msg.verdict.toUpperCase() + " - " + (msg.summary || ""), false);
+          break;
+
+        case "loop_stopping":
+          updateLoopBanner(loopIteration, loopMaxIterations, "stopping");
+          break;
+
+        case "loop_finished":
+          loopActive = false;
+          ralphPhase = "done";
+          loopBannerName = null;
+          showLoopBanner(false);
+          updateLoopButton();
+          enableMainInput();
+          var loopLabel = loopBannerName || "Loop";
+          var finishMsg = msg.reason === "pass"
+            ? loopLabel + " completed successfully after " + msg.iterations + " iteration(s)."
+            : msg.reason === "max_iterations"
+              ? loopLabel + " reached maximum iterations (" + msg.iterations + ")."
+              : msg.reason === "stopped"
+                ? loopLabel + " stopped."
+                : loopLabel + " ended with error.";
+          addSystemMessage(finishMsg, false);
+          break;
+
+        case "loop_error":
+          addSystemMessage((loopBannerName || "Loop") + " error: " + msg.text, true);
+          break;
+
+        // --- Ralph Wizard / Crafting ---
+        case "ralph_phase":
+          ralphPhase = msg.phase || "idle";
+          if (msg.craftingSessionId) ralphCraftingSessionId = msg.craftingSessionId;
+          if (msg.source !== undefined) ralphCraftingSource = msg.source;
+          updateLoopButton();
+          updateRalphBars();
+          break;
+
+        case "ralph_crafting_started":
+          ralphPhase = "crafting";
+          ralphCraftingSessionId = msg.sessionId || activeSessionId;
+          ralphCraftingSource = msg.source || null;
+          updateLoopButton();
+          updateRalphBars();
+          if (msg.source !== "ralph") {
+            // Task sessions open in the scheduler calendar window
+            enterCraftingMode(msg.sessionId, msg.taskId);
+          }
+          // Ralph crafting sessions show in session list as part of the loop group
+          break;
+
+        case "ralph_files_status":
+          ralphFilesReady = {
+            promptReady: msg.promptReady,
+            judgeReady: msg.judgeReady,
+            bothReady: msg.bothReady,
+          };
+          if (msg.bothReady && (ralphPhase === "crafting" || ralphPhase === "approval")) {
+            ralphPhase = "approval";
+            if (ralphCraftingSource !== "ralph" || isSchedulerOpen()) {
+              // Task crafting in scheduler: switch from crafting chat to detail view showing files
+              exitCraftingMode(msg.taskId);
+            } else {
+              showRalphApprovalBar(true);
+            }
+          }
+          updateRalphApprovalStatus();
+          break;
+
+        case "loop_registry_files_content":
+          handleLoopRegistryFiles(msg);
+          break;
+
+        case "ralph_files_content":
+          ralphPreviewContent = { prompt: msg.prompt || "", judge: msg.judge || "" };
+          openRalphPreviewModal();
+          break;
+
+        case "loop_registry_error":
+          addSystemMessage("Error: " + msg.text, true);
+          break;
+      }
+  }
 
   // --- Progressive history loading ---
   function updateHistorySentinel() {

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -2,7 +2,7 @@ import { avatarUrl, userAvatarUrl, mateAvatarUrl } from './modules/avatar.js';
 import { showToast, copyToClipboard, escapeHtml } from './modules/utils.js';
 import { refreshIcons, iconHtml } from './modules/icons.js';
 import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, closeMermaidModal, parseEmojis } from './modules/markdown.js';
-import { initSidebar, renderSessionList, handleSearchResults, updateSessionPresence, updatePageTitle, populateCliSessionList, renderIconStrip, renderSidebarPresence, initIconStrip, getEmojiCategories, renderUserStrip, setCurrentDmUser, updateDmBadge, updateSessionBadge, updateProjectBadge, closeDmUserPicker, spawnDustParticles, openMobileSheet, setMobileSheetMateData, refreshMobileChatSheet } from './modules/sidebar.js';
+import { initSidebar, renderSessionList, handleSearchResults, updateSessionPresence, updatePageTitle, populateCliSessionList, renderIconStrip, renderSidebarPresence, initIconStrip, getEmojiCategories, renderUserStrip, setCurrentDmUser, updateDmBadge, updateSessionBadge, updateProjectBadge, closeDmUserPicker, spawnDustParticles, openMobileSheet, setMobileSheetMateData, refreshMobileChatSheet, setMentionActive, clearAllMentionActive } from './modules/sidebar.js';
 import { initMateSidebar, showMateSidebar, hideMateSidebar, renderMateSessionList, updateMateSidebarProfile, handleMateSearchResults } from './modules/mate-sidebar.js';
 import { initMateKnowledge, requestKnowledgeList, renderKnowledgeList, handleKnowledgeContent, hideKnowledge } from './modules/mate-knowledge.js';
 import { initMateMemory, renderMemoryList, hideMemory } from './modules/mate-memory.js';
@@ -3564,6 +3564,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     currentFullText = "";
     resetToolState();
     clearPendingImages();
+    clearAllMentionActive();
     activityEl = null;
     processing = false;
     turnCounter = 0;
@@ -5029,6 +5030,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
         case "mention_processing":
           // Broadcast: show/hide activity dot on mate avatar across all tabs
           if (msg.mateId) {
+            setMentionActive(msg.mateId, msg.active);
             var mateContainers = document.querySelectorAll('.icon-strip-mate[data-user-id="' + msg.mateId + '"]');
             for (var mi = 0; mi < mateContainers.length; mi++) {
               var dot = mateContainers[mi].querySelector(".icon-strip-status");
@@ -5040,6 +5042,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
                 mateContainers[mi].classList.remove("mention-active");
               }
             }
+            updateCrossProjectBlink();
           }
           break;
 

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -2217,6 +2217,10 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   var pendingTermCommand = null;
 
   function addAuthRequiredMessage(msg) {
+    // Capture the last user message text so we can resend it after login
+    var lastUserMsg = messagesEl ? messagesEl.querySelectorAll(".msg-user .bubble > span") : [];
+    var lastUserText = lastUserMsg.length > 0 ? lastUserMsg[lastUserMsg.length - 1].textContent : "";
+
     var div = document.createElement("div");
     div.className = "auth-required-msg";
 
@@ -2227,6 +2231,24 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
     var hint = document.createElement("div");
     hint.className = "auth-required-hint";
+
+    // Shared handler: restore input with the failed message text
+    function resumeAfterLogin() {
+      var inputArea = document.getElementById("input-area");
+      if (inputArea) inputArea.classList.remove("hidden");
+      inputEl.disabled = false;
+      inputEl.placeholder = "";
+      sendBtn.disabled = false;
+      div.remove();
+      // Restore the failed message text into the input so the user can resend
+      if (lastUserText) {
+        inputEl.value = lastUserText;
+        autoResize();
+      }
+      if (!("ontouchstart" in window)) {
+        inputEl.focus();
+      }
+    }
 
     if (msg.canAutoLogin) {
       // Auto-open terminal and run claude
@@ -2244,8 +2266,11 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
       var sessionHint = document.createElement("div");
       sessionHint.className = "auth-required-guide";
-      sessionHint.textContent = "After logging in, start a new session to continue.";
+      sessionHint.textContent = "After logging in, click \"Continue\" to proceed.";
       div.appendChild(sessionHint);
+
+      var btnRow = document.createElement("div");
+      btnRow.style.cssText = "display:flex;gap:8px;margin-top:8px;";
 
       var loginBtn = document.createElement("button");
       loginBtn.className = "auth-required-btn";
@@ -2255,12 +2280,20 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
         ws.send(JSON.stringify({ type: "term_create", cols: 80, rows: 24 }));
         openTerminal();
       });
-      div.appendChild(loginBtn);
+      btnRow.appendChild(loginBtn);
+
+      var continueBtn = document.createElement("button");
+      continueBtn.className = "auth-required-btn";
+      continueBtn.textContent = "Continue";
+      continueBtn.addEventListener("click", resumeAfterLogin);
+      btnRow.appendChild(continueBtn);
+
+      div.appendChild(btnRow);
 
       addToMessages(div);
       scrollToBottom();
 
-      // Hide input area on this session since it cannot be used
+      // Hide input area on this session since it cannot be used until login
       var inputArea = document.getElementById("input-area");
       if (inputArea) inputArea.classList.add("hidden");
 
@@ -2274,11 +2307,19 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
       // Multi-user regular user: show message only, no auto-login
       hint.textContent = "Please ask an administrator to log in to Claude Code.";
       div.appendChild(hint);
+
+      var continueBtn2 = document.createElement("button");
+      continueBtn2.className = "auth-required-btn";
+      continueBtn2.textContent = "Continue";
+      continueBtn2.style.marginTop = "8px";
+      continueBtn2.addEventListener("click", resumeAfterLogin);
+      div.appendChild(continueBtn2);
+
       addToMessages(div);
       scrollToBottom();
 
       inputEl.disabled = true;
-      inputEl.placeholder = "Login required. Start a new session after logging in.";
+      inputEl.placeholder = "Login required. Click Continue after logging in.";
       sendBtn.disabled = true;
     }
   }

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -4007,6 +4007,16 @@ var dmPickerOpen = false;
 
 var cachedDmRemovedUsers = {};
 var cachedMates = [];
+var activeMentionMateIds = {};
+
+export function setMentionActive(mateId, active) {
+  if (active) { activeMentionMateIds[mateId] = true; }
+  else { delete activeMentionMateIds[mateId]; }
+}
+
+export function clearAllMentionActive() {
+  activeMentionMateIds = {};
+}
 
 export function renderUserStrip(allUsers, onlineUserIds, myUserId, dmFavorites, dmConversations, dmUnread, dmRemovedUsers, matesList) {
   cachedMates = matesList || cachedMates || [];
@@ -4146,7 +4156,9 @@ export function renderUserStrip(allUsers, onlineUserIds, myUserId, dmFavorites, 
       // Processing status dot (IO blink)
       var statusDot = document.createElement("span");
       statusDot.className = "icon-strip-status";
-      if (mateProj.isProcessing) statusDot.classList.add("processing");
+      var isMentionActive = !!activeMentionMateIds[mate.id];
+      if (mateProj.isProcessing || isMentionActive) statusDot.classList.add("processing");
+      if (isMentionActive) el.classList.add("mention-active");
       el.appendChild(statusDot);
 
       // Mate badge (bot icon)

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1669,6 +1669,12 @@ function createSDKBridge(opts) {
   }
 
   function handleCanUseTool(session, toolName, input, opts) {
+    // Full-auto mode: auto-approve everything except AskUserQuestion
+    // (which still needs to go through the user interaction flow).
+    if (sm.currentPermissionMode === "bypassPermissions" && toolName !== "AskUserQuestion") {
+      return Promise.resolve({ behavior: "allow", updatedInput: input });
+    }
+
     // Ralph Loop execution: auto-approve all tools, deny interactive ones.
     // Crafting sessions are interactive — user and Claude collaborate to build PROMPT.md / JUDGE.md.
     if (session.loop && session.loop.active && session.loop.role !== "crafting") {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -342,9 +342,8 @@ function createSessionManager(opts) {
 
     for (var i = fromIndex; i < total; i++) {
       var _item = session.history[i];
-      if (_item && (_item.type === "mention_user" || _item.type === "mention_response")) {
-        console.log("[DEBUG replayHistory] sending mention at index=" + i + " from=" + fromIndex + " total=" + total + " type=" + _item.type + " mate=" + (_item.mateName || ""));
-      }
+      // Skip internal bookkeeping entries not meant for the UI
+      if (_item && _item.type === "digest_checkpoint") continue;
       _send(transform ? transform(_item) : _item);
     }
 
@@ -408,6 +407,11 @@ function createSessionManager(opts) {
         toolUseId: p.toolUseId,
         decisionReason: p.decisionReason,
       });
+    }
+
+    // Re-send active mention indicator so returning clients restore the mate avatar state
+    if (session._mentionInProgress && session._mentionActiveMateId) {
+      _send({ type: "mention_processing", mateId: session._mentionActiveMateId, active: true });
     }
   }
 


### PR DESCRIPTION
## Summary
- **fix(auth):** Add "Continue" button so users can resume their session after login instead of being stuck on the auth-required message
- **fix(bypassPermissions):** Honor `bypassPermissions` mode in Clay's `canUseTool` handlers — previously mention sessions still prompted for permission even in full-auto mode
- **fix(mates):** Prevent stale mate DM state from hijacking project navigation — replaced `localStorage` with `sessionStorage` for `clay-active-dm` and added `pendingMateDmClears` guard to suppress stale `restore_mate_dm` on project switch
- **fix(mates):** Restore mention indicator state across view switches and DOM rebuilds — track active mention mateId server-side and re-emit `mention_processing` on session switch

## Test plan
- [ ] Log in from an expired session → verify "Continue" button appears and resumes input
- [ ] Run a mate in bypassPermissions mode → verify tools execute without permission prompts
- [ ] Open a mate DM, close the tab, reopen → verify it doesn't auto-hijack a different project
- [ ] Trigger a mate @mention, switch sessions, switch back → verify processing indicator persists