### PR TITLE
fix(auth): add Continue button to resume session after login

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -2217,6 +2217,10 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   var pendingTermCommand = null;
 
   function addAuthRequiredMessage(msg) {
+    // Capture the last user message text so we can resend it after login
+    var lastUserMsg = messagesEl ? messagesEl.querySelectorAll(".msg-user .bubble > span") : [];
+    var lastUserText = lastUserMsg.length > 0 ? lastUserMsg[lastUserMsg.length - 1].textContent : "";
+
     var div = document.createElement("div");
     div.className = "auth-required-msg";
 
@@ -2227,6 +2231,24 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
     var hint = document.createElement("div");
     hint.className = "auth-required-hint";
+
+    // Shared handler: restore input with the failed message text
+    function resumeAfterLogin() {
+      var inputArea = document.getElementById("input-area");
+      if (inputArea) inputArea.classList.remove("hidden");
+      inputEl.disabled = false;
+      inputEl.placeholder = "";
+      sendBtn.disabled = false;
+      div.remove();
+      // Restore the failed message text into the input so the user can resend
+      if (lastUserText) {
+        inputEl.value = lastUserText;
+        autoResize();
+      }
+      if (!("ontouchstart" in window)) {
+        inputEl.focus();
+      }
+    }
 
     if (msg.canAutoLogin) {
       // Auto-open terminal and run claude
@@ -2244,8 +2266,11 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
       var sessionHint = document.createElement("div");
       sessionHint.className = "auth-required-guide";
-      sessionHint.textContent = "After logging in, start a new session to continue.";
+      sessionHint.textContent = "After logging in, click \"Continue\" to proceed.";
       div.appendChild(sessionHint);
+
+      var btnRow = document.createElement("div");
+      btnRow.style.cssText = "display:flex;gap:8px;margin-top:8px;";
 
       var loginBtn = document.createElement("button");
       loginBtn.className = "auth-required-btn";
@@ -2255,12 +2280,20 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
         ws.send(JSON.stringify({ type: "term_create", cols: 80, rows: 24 }));
         openTerminal();
       });
-      div.appendChild(loginBtn);
+      btnRow.appendChild(loginBtn);
+
+      var continueBtn = document.createElement("button");
+      continueBtn.className = "auth-required-btn";
+      continueBtn.textContent = "Continue";
+      continueBtn.addEventListener("click", resumeAfterLogin);
+      btnRow.appendChild(continueBtn);
+
+      div.appendChild(btnRow);
 
       addToMessages(div);
       scrollToBottom();
 
-      // Hide input area on this session since it cannot be used
+      // Hide input area on this session since it cannot be used until login
       var inputArea = document.getElementById("input-area");
       if (inputArea) inputArea.classList.add("hidden");
 
@@ -2274,11 +2307,19 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
       // Multi-user regular user: show message only, no auto-login
       hint.textContent = "Please ask an administrator to log in to Claude Code.";
       div.appendChild(hint);
+
+      var continueBtn2 = document.createElement("button");
+      continueBtn2.className = "auth-required-btn";
+      continueBtn2.textContent = "Continue";
+      continueBtn2.style.marginTop = "8px";
+      continueBtn2.addEventListener("click", resumeAfterLogin);
+      div.appendChild(continueBtn2);
+
       addToMessages(div);
       scrollToBottom();
 
       inputEl.disabled = true;
-      inputEl.placeholder = "Login required. Start a new session after logging in.";
+      inputEl.placeholder = "Login required. Click Continue after logging in.";
       sendBtn.disabled = true;
     }
   }


### PR DESCRIPTION
## Summary
- When a session expires mid-conversation and the user re-authenticates, they were stuck on the auth-required message with no way to continue
- Adds a "Continue" button that restores the input area, re-enables send, removes the auth message, and pastes the failed message text back into the input

## Test plan
- [ ] Start a session, let auth expire, trigger a send → verify auth-required message appears
- [ ] Click "Continue" → verify input area restores with the original message text
- [ ] Verify button appears for both auto-login and non-admin auth paths