### PR TITLE
fix: honor bypassPermissions mode in canUseTool handlers

### DIFF
--- a/lib/project-mate-interaction.js
+++ b/lib/project-mate-interaction.js
@@ -569,6 +569,10 @@ function attachMateInteraction(ctx) {
         onDone: mentionCallbacks.onDone,
         onError: mentionCallbacks.onError,
         canUseTool: function (toolName, input, toolOpts) {
+          // Full-auto mode: auto-approve everything except AskUserQuestion
+          if (sm.currentPermissionMode === "bypassPermissions" && toolName !== "AskUserQuestion") {
+            return Promise.resolve({ behavior: "allow", updatedInput: input });
+          }
           // Use the shared whitelist from sdk-bridge (read-only tools + safe bash commands)
           var whitelisted = sdk.checkToolWhitelist(toolName, input);
           if (whitelisted) return Promise.resolve(whitelisted);

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1669,6 +1669,12 @@ function createSDKBridge(opts) {
   }
 
   function handleCanUseTool(session, toolName, input, opts) {
+    // Full-auto mode: auto-approve everything except AskUserQuestion
+    // (which still needs to go through the user interaction flow).
+    if (sm.currentPermissionMode === "bypassPermissions" && toolName !== "AskUserQuestion") {
+      return Promise.resolve({ behavior: "allow", updatedInput: input });
+    }
+
     // Ralph Loop execution: auto-approve all tools, deny interactive ones.
     // Crafting sessions are interactive — user and Claude collaborate to build PROMPT.md / JUDGE.md.
     if (session.loop && session.loop.active && session.loop.role !== "crafting") {


### PR DESCRIPTION
## Summary
- Mate mention sessions were still prompting for tool permission even when bypassPermissions mode was active
- Now checks currentPermissionMode before falling through to the whitelist in the mention session canUseTool callback
- Extracts checkToolWhitelist in sdk-bridge.js for reuse by the mention handler

## Test plan
- [ ] Run a mate mention in bypassPermissions mode - verify tools execute without permission prompts
- [ ] Run in default mode - verify whitelist still gates tool approval correctly