### PR TITLE
fix(mates): prevent stale mate DM state from hijacking project navigation

### DIFF
--- a/docs/REFACTORING_ROADMAP.md
+++ b/docs/REFACTORING_ROADMAP.md
@@ -597,7 +597,7 @@ app.js is 8,066 lines with 90+ WebSocket message types in a single `processMessa
 - `handleMateCreatedInApp`, `renderAvailableBuiltins`, `buildMateInterviewPrompt`
 - `updateMateIconStatus`, `connectMateProject`, `disconnectMateProject`
 - DM state: `dmMode`, `dmKey`, `dmTargetUser`, `dmMessageCache`, `dmUnread`, `cachedAllUsers`, `cachedOnlineIds`, `cachedDmFavorites`, `cachedDmConversations`, `cachedMatesList`
-- Mate project state: `mateProjectSlug`, `savedMainSlug`, `returningFromMateDm`
+- Mate project state: `mateProjectSlug`, `savedMainSlug`, `pendingMateDmClears`
 
 **Interface**: `initDm(ctx)` returns `{ openDm, exitDmMode, isDmMode, ... }`.
 

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -36,7 +36,7 @@ import { initMessages, processMessage as _msgProcessMessage } from './modules/ap
 import { initHomeHub, showHomeHub as _hubShowHomeHub, hideHomeHub as _hubHideHomeHub, handleHubSchedules as _hubHandleHubSchedules, renderHomeHub as _hubRenderHomeHub, isHomeHubVisible } from './modules/app-home-hub.js';
 import { initRateLimit, handleRateLimitEvent as _rlHandleRateLimitEvent, updateRateLimitUsage as _rlUpdateRateLimitUsage, addScheduledMessageBubble as _rlAddScheduledMessageBubble, removeScheduledMessageBubble as _rlRemoveScheduledMessageBubble, handleFastModeState as _rlHandleFastModeState, getScheduledMsgEl, resetRateLimitState } from './modules/app-rate-limit.js';
 import { initCursors, handleRemoteCursorMove as _curHandleRemoteCursorMove, handleRemoteCursorLeave as _curHandleRemoteCursorLeave, handleRemoteSelection as _curHandleRemoteSelection, clearRemoteCursors as _curClearRemoteCursors, initCursorToggle } from './modules/app-cursors.js';
-import { initDm, openDm as _dmOpenDm, enterDmMode as _dmEnterDmMode, exitDmMode as _dmExitDmMode, handleMateCreatedInApp as _dmHandleMateCreatedInApp, renderAvailableBuiltins as _dmRenderAvailableBuiltins, buildMateInterviewPrompt as _dmBuildMateInterviewPrompt, updateMateIconStatus as _dmUpdateMateIconStatus, connectMateProject as _dmConnectMateProject, disconnectMateProject as _dmDisconnectMateProject, appendDmMessage as _dmAppendDmMessage, showDmTypingIndicator as _dmShowDmTypingIndicator, handleDmSend as _dmHandleDmSend } from './modules/app-dm.js';
+import { initDm, openDm, enterDmMode, exitDmMode, handleMateCreatedInApp, renderAvailableBuiltins, buildMateInterviewPrompt, updateMateIconStatus, connectMateProject, disconnectMateProject, appendDmMessage, showDmTypingIndicator, handleDmSend } from './modules/app-dm.js';
 import { initMention, handleMentionStart, handleMentionStream, handleMentionDone, handleMentionError, handleMentionActivity, renderMentionUser, renderMentionResponse } from './modules/mention.js';
 import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateResumed, handleDebateTurn, handleDebateActivity, handleDebateStream, handleDebateTurnDone, handleDebateCommentQueued, handleDebateCommentInjected, handleDebateEnded, handleDebateError, renderDebateStarted, renderDebateTurnDone, renderDebateEnded, renderDebateCommentInjected, renderDebateUserResume, openDebateModal, closeDebateModal, handleDebateBriefReady, renderDebateBriefReady, isDebateActive, resetDebateState, exportDebateAsPdf, renderMcpDebateProposal } from './modules/debate.js';
 
@@ -89,7 +89,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   // --- Mate project switching ---
   var mateProjectSlug = null;
   var savedMainSlug = null; // main project slug saved during mate DM
-  var returningFromMateDm = false; // suppress restore_mate_dm after intentional exit
+  var pendingMateDmClears = {}; // slug → true: suppress restore_mate_dm and clear server state
   var pendingMateInterview = null;
 
 
@@ -5069,6 +5069,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     isSchedulerOpen: isSchedulerOpen,
     closeScheduler: closeScheduler,
     requireClayMateInterview: requireClayMateInterview,
+    pendingMateDmClears: pendingMateDmClears,
     // DOM refs
     messagesEl: messagesEl,
     inputEl: inputEl,
@@ -5091,7 +5092,6 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     cachedProjects: function() { return cachedProjects; },
     mateProjectSlug: function() { return mateProjectSlug; }, _mateProjectSlug: function(v) { mateProjectSlug = v; },
     savedMainSlug: function() { return savedMainSlug; }, _savedMainSlug: function(v) { savedMainSlug = v; },
-    returningFromMateDm: function() { return returningFromMateDm; }, _returningFromMateDm: function(v) { returningFromMateDm = v; },
     pendingMateInterview: function() { return pendingMateInterview; }, _pendingMateInterview: function(v) { pendingMateInterview = v; },
     currentSlug: function() { return currentSlug; }, _currentSlug: function(v) { currentSlug = v; },
     wsPath: function() { return wsPath; }, _wsPath: function(v) { wsPath = v; },
@@ -5366,6 +5366,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     prependOlderHistory: prependOlderHistory,
     // Functions - builtinCommands
     builtinCommands: builtinCommands,
+    pendingMateDmClears: pendingMateDmClears,
   };
   // Add mutable state with live get/set accessors
   var _msgStateProps = {
@@ -5390,7 +5391,6 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     currentThinking: function() { return currentThinking; }, _currentThinking: function(v) { currentThinking = v; },
     currentThinkingBudget: function() { return currentThinkingBudget; }, _currentThinkingBudget: function(v) { currentThinkingBudget = v; },
     slashCommands: function() { return slashCommands; }, _slashCommands: function(v) { slashCommands = v; },
-    returningFromMateDm: function() { return returningFromMateDm; }, _returningFromMateDm: function(v) { returningFromMateDm = v; },
     processing: function() { return processing; }, _processing: function(v) { processing = v; },
     loopActive: function() { return loopActive; }, _loopActive: function(v) { loopActive = v; },
     loopAvailable: function() { return loopAvailable; }, _loopAvailable: function(v) { loopAvailable = v; },
@@ -5489,13 +5489,13 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
       // Session restore is now server-driven (user-presence.json).
       // Mate DM restore is also server-driven via "restore_mate_dm" message.
-      // Fallback: if server doesn't restore DM within 2s, try localStorage
+      // Fallback: if server doesn't restore DM within 2s, check sessionStorage
       var savedDm = null;
-      try { savedDm = localStorage.getItem("clay-active-dm"); } catch (e) {}
-      if (savedDm && !dmMode && !mateProjectSlug) {
+      try { savedDm = sessionStorage.getItem("clay-active-dm"); } catch (e) {}
+      if (savedDm && !dmMode && !mateProjectSlug && !pendingMateDmClears[currentSlug]) {
         var dmFallbackTimer = setTimeout(function () {
           if (!dmMode && savedDm) {
-            console.log("[dm-restore] Server did not restore DM, using localStorage fallback:", savedDm);
+            console.log("[dm-restore] Server did not restore DM, using sessionStorage fallback:", savedDm);
             openDm(savedDm);
           }
         }, 2000);
@@ -5513,13 +5513,14 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
         ws.addEventListener("message", checkRestore);
         setTimeout(function () { ws.removeEventListener("message", checkRestore); }, 3000);
       }
-      // Safety: clear returningFromMateDm after initial messages settle
-      if (returningFromMateDm) {
-        setTimeout(function () {
-          if (returningFromMateDm) {
-            returningFromMateDm = false;
-          }
-        }, 2000);
+      // Safety: clear pendingMateDmClears entries after initial messages settle
+      var _pendingKeys = Object.keys(pendingMateDmClears);
+      for (var _pk = 0; _pk < _pendingKeys.length; _pk++) {
+        (function (slug) {
+          setTimeout(function () {
+            delete pendingMateDmClears[slug];
+          }, 5000);
+        })(_pendingKeys[_pk]);
       }
     },
   });

--- a/lib/public/modules/app-dm.js
+++ b/lib/public/modules/app-dm.js
@@ -37,7 +37,7 @@ export function initDm(ctx) {
 export function openDm(targetUserId) {
   if (!_ctx.ws || _ctx.ws.readyState !== 1) return;
   // Persist DM state for refresh recovery
-  try { localStorage.setItem("clay-active-dm", targetUserId); } catch (e) {}
+  try { sessionStorage.setItem("clay-active-dm", targetUserId); } catch (e) {}
   // Check mate skill updates before opening mate DM
   if (typeof targetUserId === "string" && targetUserId.indexOf("mate_") === 0) {
     showMateOnboarding(function () {
@@ -95,7 +95,6 @@ function showMateOnboarding(callback) {
 }
 
 export function enterDmMode(key, targetUser, messages) {
-  console.log("[DEBUG enterDmMode] key=" + key, "isMate=" + (targetUser && targetUser.isMate), "messages=" + (messages ? messages.length : 0));
   // Clean up previous DM/mate state before entering new one
   if (_ctx.dmMode) {
     _ctx.hideMateSidebar();
@@ -287,7 +286,7 @@ export function exitDmMode(skipProjectSwitch) {
   _ctx.dmMode = false;
   _ctx.dmKey = null;
   _ctx.dmTargetUser = null;
-  try { localStorage.removeItem("clay-active-dm"); } catch (e) {}
+  try { sessionStorage.removeItem("clay-active-dm"); } catch (e) {}
   _ctx.setCurrentDmUser(null);
 
   var mainCol = document.getElementById("main-column");
@@ -342,7 +341,7 @@ export function exitDmMode(skipProjectSwitch) {
     disconnectMateProject();
   } else if (wasMate && skipProjectSwitch) {
     // Just clean up mate state, caller will handle project switch
-    _ctx.returningFromMateDm = true;
+    if (_ctx.savedMainSlug) _ctx.pendingMateDmClears[_ctx.savedMainSlug] = true;
     _ctx.mateProjectSlug = null;
     _ctx.savedMainSlug = null;
     _ctx.showDebateSticky("hide", null);
@@ -497,7 +496,7 @@ export function disconnectMateProject() {
   if (debateFloat) { debateFloat.classList.add("hidden"); debateFloat.innerHTML = ""; }
   // Switch back to main project
   if (_ctx.savedMainSlug) {
-    _ctx.returningFromMateDm = true;
+    _ctx.pendingMateDmClears[_ctx.savedMainSlug] = true;
     _ctx.currentSlug = _ctx.savedMainSlug;
     _ctx.basePath = "/p/" + _ctx.savedMainSlug + "/";
     _ctx.wsPath = "/p/" + _ctx.savedMainSlug + "/ws";

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -12,11 +12,6 @@ export function processMessage(msg) {
     _ctx.currentMsgTs = msg._ts || null;
     var isMateDm = _ctx.dmMode && _ctx.dmTargetUser && _ctx.dmTargetUser.isMate;
 
-    // DEBUG: trace session/history loading
-    if (msg.type === "session_switched" || msg.type === "history_meta" || msg.type === "history_done" || msg.type === "mention_user" || msg.type === "mention_response") {
-      console.log("[DEBUG msg]", msg.type, msg.type === "session_switched" ? "id=" + msg.id + " cli=" + (msg.cliSessionId || "").substring(0, 8) : "", msg.type === "history_meta" ? "from=" + msg.from + " total=" + msg.total : "", msg.type === "mention_user" ? "mate=" + msg.mateName : "", "dmMode=" + _ctx.dmMode);
-    }
-
     // Mate DM: update mate icon status indicators
     if (isMateDm) _ctx.updateMateIconStatus(msg);
 
@@ -160,7 +155,7 @@ export function processMessage(msg) {
         break;
 
       case "restore_mate_dm":
-        if (msg.mateId && !_ctx.returningFromMateDm) {
+        if (msg.mateId && !_ctx.pendingMateDmClears[_ctx.currentSlug]) {
           // Server-driven mate DM restore on reconnect
           // Note: do NOT remove mate-dm-active here; openDm is async (skill check)
           // and removing the class causes a flash where mate UI is lost.
@@ -171,9 +166,9 @@ export function processMessage(msg) {
           _ctx.messagesEl.innerHTML = "";
           _ctx.openDm(msg.mateId);
         }
-        // Clear the flag and notify server that mate DM is closed
-        if (_ctx.returningFromMateDm) {
-          _ctx.returningFromMateDm = false;
+        // Clear pending flag and notify server that mate DM is closed
+        if (_ctx.pendingMateDmClears[_ctx.currentSlug]) {
+          delete _ctx.pendingMateDmClears[_ctx.currentSlug];
           if (_ctx.ws && _ctx.ws.readyState === 1) {
             try { _ctx.ws.send(JSON.stringify({ type: "set_mate_dm", mateId: null })); } catch(e) {}
           }


### PR DESCRIPTION
## Summary
- Opening a mate DM then closing the tab (or switching projects) caused stale state to auto-open the mate DM when later navigating to a different project
- Root causes: (1) clay-active-dm persisted in localStorage across tab closes, (2) server-side mateDm was never cleared when switching away
- Switches clay-active-dm from localStorage to sessionStorage (dies with tab, survives refresh)
- Replaces racy returningFromMateDm boolean with a pendingMateDmClears slug-keyed map that persists until consumed
- Adds 5s safety cleanup for pendingMateDmClears entries

## Test plan
- [ ] Open a mate DM, close the tab, reopen Clay - verify it does not auto-open the mate DM
- [ ] Open a mate DM, switch to a different project via sidebar - verify no DM hijack
- [ ] Open a mate DM, refresh the page - verify the DM correctly restores (sessionStorage survives F5)