### PR TITLE
fix(mates): restore mention indicator across view switches and DOM rebuilds

### DIFF
--- a/lib/project-mate-interaction.js
+++ b/lib/project-mate-interaction.js
@@ -445,6 +445,7 @@ function attachMateInteraction(ctx) {
     }
 
     session._mentionInProgress = true;
+    session._mentionActiveMateId = msg.mateId;
 
     // Send mention start indicator
     sendToSession(session.localId, {
@@ -478,6 +479,7 @@ function attachMateInteraction(ctx) {
       },
       onDone: function (fullText) {
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
 
         // Save mention response to session history
         var mentionResponseEntry = {
@@ -512,6 +514,7 @@ function attachMateInteraction(ctx) {
       },
       onError: function (errMsg) {
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
         // Clean up dead session
         if (session._mentionSessions && session._mentionSessions[msg.mateId]) {
           delete session._mentionSessions[msg.mateId];
@@ -610,6 +613,7 @@ function attachMateInteraction(ctx) {
         }
       }).catch(function (err) {
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
         console.error("[mention] Failed to create session for mate " + msg.mateId + ":", err.message || err);
         sendToSession(session.localId, { type: "mention_error", mateId: msg.mateId, error: "Failed to create mention session." });
       });

--- a/lib/project.js
+++ b/lib/project.js
@@ -624,6 +624,7 @@ function createProjectContext(opts) {
           delete session._mentionSessions[mateId];
         }
         session._mentionInProgress = false;
+        session._mentionActiveMateId = null;
         sendToSession(session.localId, { type: "mention_done", mateId: mateId, stopped: true });
         send({ type: "mention_processing", mateId: mateId, active: false });
       }

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -2,7 +2,7 @@ import { avatarUrl, userAvatarUrl, mateAvatarUrl } from './modules/avatar.js';
 import { showToast, copyToClipboard, escapeHtml } from './modules/utils.js';
 import { refreshIcons, iconHtml } from './modules/icons.js';
 import { renderMarkdown, highlightCodeBlocks, renderMermaidBlocks, closeMermaidModal, parseEmojis } from './modules/markdown.js';
-import { initSidebar, renderSessionList, handleSearchResults, updateSessionPresence, updatePageTitle, populateCliSessionList, renderIconStrip, renderSidebarPresence, initIconStrip, getEmojiCategories, renderUserStrip, setCurrentDmUser, updateDmBadge, updateSessionBadge, updateProjectBadge, closeDmUserPicker, spawnDustParticles, openMobileSheet, setMobileSheetMateData, refreshMobileChatSheet } from './modules/sidebar.js';
+import { initSidebar, renderSessionList, handleSearchResults, updateSessionPresence, updatePageTitle, populateCliSessionList, renderIconStrip, renderSidebarPresence, initIconStrip, getEmojiCategories, renderUserStrip, setCurrentDmUser, updateDmBadge, updateSessionBadge, updateProjectBadge, closeDmUserPicker, spawnDustParticles, openMobileSheet, setMobileSheetMateData, refreshMobileChatSheet, setMentionActive, clearAllMentionActive } from './modules/sidebar.js';
 import { initMateSidebar, showMateSidebar, hideMateSidebar, renderMateSessionList, updateMateSidebarProfile, handleMateSearchResults } from './modules/mate-sidebar.js';
 import { initMateKnowledge, requestKnowledgeList, renderKnowledgeList, handleKnowledgeContent, hideKnowledge } from './modules/mate-knowledge.js';
 import { initMateMemory, renderMemoryList, hideMemory } from './modules/mate-memory.js';
@@ -2332,6 +2332,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     currentFullText = "";
     resetToolState();
     clearPendingImages();
+    clearAllMentionActive();
     activityEl = null;
     processing = false;
     turnCounter = 0;
@@ -5064,6 +5065,8 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     renderUserStrip: renderUserStrip,
     openMobileSheet: openMobileSheet,
     setMobileSheetMateData: setMobileSheetMateData,
+    setMentionActive: setMentionActive,
+    updateCrossProjectBlink: updateCrossProjectBlink,
     closeDmUserPicker: closeDmUserPicker,
     getProfileLang: getProfileLang,
     isSchedulerOpen: isSchedulerOpen,

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -1176,6 +1176,7 @@ export function processMessage(msg) {
       case "mention_processing":
         // Broadcast: show/hide activity dot on mate avatar across all tabs
         if (msg.mateId) {
+          _ctx.setMentionActive(msg.mateId, msg.active);
           var mateContainers = document.querySelectorAll('.icon-strip-mate[data-user-id="' + msg.mateId + '"]');
           for (var mi = 0; mi < mateContainers.length; mi++) {
             var dot = mateContainers[mi].querySelector(".icon-strip-status");
@@ -1187,6 +1188,7 @@ export function processMessage(msg) {
               mateContainers[mi].classList.remove("mention-active");
             }
           }
+          _ctx.updateCrossProjectBlink();
         }
         break;
 

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -4007,6 +4007,16 @@ var dmPickerOpen = false;
 
 var cachedDmRemovedUsers = {};
 var cachedMates = [];
+var activeMentionMateIds = {};
+
+export function setMentionActive(mateId, active) {
+  if (active) { activeMentionMateIds[mateId] = true; }
+  else { delete activeMentionMateIds[mateId]; }
+}
+
+export function clearAllMentionActive() {
+  activeMentionMateIds = {};
+}
 
 export function renderUserStrip(allUsers, onlineUserIds, myUserId, dmFavorites, dmConversations, dmUnread, dmRemovedUsers, matesList) {
   cachedMates = matesList || cachedMates || [];
@@ -4146,7 +4156,9 @@ export function renderUserStrip(allUsers, onlineUserIds, myUserId, dmFavorites, 
       // Processing status dot (IO blink)
       var statusDot = document.createElement("span");
       statusDot.className = "icon-strip-status";
-      if (mateProj.isProcessing) statusDot.classList.add("processing");
+      var isMentionActive = !!activeMentionMateIds[mate.id];
+      if (mateProj.isProcessing || isMentionActive) statusDot.classList.add("processing");
+      if (isMentionActive) el.classList.add("mention-active");
       el.appendChild(statusDot);
 
       // Mate badge (bot icon)

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -409,6 +409,11 @@ function createSessionManager(opts) {
         decisionReason: p.decisionReason,
       });
     }
+
+    // Re-send active mention indicator so returning clients restore the mate avatar state
+    if (session._mentionInProgress && session._mentionActiveMateId) {
+      _send({ type: "mention_processing", mateId: session._mentionActiveMateId, active: true });
+    }
   }
 
   function cleanupMentionSessions(session) {


### PR DESCRIPTION
## Summary
- The mate mention processing indicator (dot + blink animation) was lost when switching sessions or when the sidebar DOM was rebuilt
- Tracks _mentionActiveMateId server-side and re-emits mention_processing on session switch
- Caches mention-active state client-side in activeMentionMateIds map so renderUserStrip DOM rebuilds preserve the indicator

## Test plan
- [ ] Trigger a mate mention - verify processing indicator appears on the mate icon
- [ ] Switch to another session and back - verify indicator persists
- [ ] Trigger a sidebar re-render (e.g. resize) during mention processing - verify indicator survives