### PR TITLE
fix: reap idle in-process sessions to prevent Claude child process accumulation

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -1183,10 +1183,14 @@ function createProjectContext(opts) {
     },
     warmup: function () {
       sdk.warmup();
+      sdk.startIdleReaper();
       // Migrate existing relay session titles to SDK format (one-time, async)
       sm.migrateSessionTitles(getSDK, cwd);
     },
-    destroy: destroy,
+    destroy: function () {
+      sdk.stopIdleReaper();
+      destroy();
+    },
   };
 }
 

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -138,6 +138,55 @@ function createSDKBridge(opts) {
   var onProcessingChanged = opts.onProcessingChanged || function () {};
   var onTurnDone = opts.onTurnDone || null;
 
+  // --- Idle session reaper ---
+  // In single-user (in-process) mode, each session's Claude child process stays
+  // alive between turns because the messageQueue push-stream is never ended.
+  // Without a reaper, processes accumulate indefinitely as users switch between
+  // sessions and projects. This reaper ends the messageQueue for sessions that
+  // have been idle for IDLE_TIMEOUT_MS, allowing processQueryStream's finally
+  // block to clean up the child process. Session state on disk is preserved —
+  // the next startQuery() call resumes with a fresh process.
+  var IDLE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+  var IDLE_CHECK_INTERVAL_MS = 60 * 1000; // check every 60 seconds
+  var _idleReaperTimer = null;
+
+  function startIdleReaper() {
+    if (_idleReaperTimer) return;
+    _idleReaperTimer = setInterval(function () {
+      var now = Date.now();
+      sm.sessions.forEach(function (session) {
+        // Skip sessions that are actively processing, have no query, use workers,
+        // or are single-turn (Ralph Loop — managed by onQueryComplete).
+        if (session.isProcessing) return;
+        if (!session.queryInstance) return;
+        if (session.worker) return;
+        if (session.singleTurn) return;
+        if (session.destroying) return;
+
+        var lastActivity = session.lastActivityAt || 0;
+        if (now - lastActivity > IDLE_TIMEOUT_MS) {
+          console.log("[sdk-bridge] Reaping idle session " + session.localId +
+            " (idle " + Math.round((now - lastActivity) / 60000) + "min)" +
+            (session.title ? " title=" + JSON.stringify(session.title) : ""));
+          // End the message queue so the for-await loop in processQueryStream
+          // exits naturally, triggering the finally block cleanup.
+          if (session.messageQueue && typeof session.messageQueue.end === "function") {
+            try { session.messageQueue.end(); } catch (e) {}
+          }
+        }
+      });
+    }, IDLE_CHECK_INTERVAL_MS);
+    // Don't prevent process exit
+    if (_idleReaperTimer.unref) _idleReaperTimer.unref();
+  }
+
+  function stopIdleReaper() {
+    if (_idleReaperTimer) {
+      clearInterval(_idleReaperTimer);
+      _idleReaperTimer = null;
+    }
+  }
+
   // --- Skill discovery helpers ---
 
   function discoverSkillDirs() {
@@ -522,6 +571,7 @@ function createSDKBridge(opts) {
         });
       }
       // Reset for next turn in the same query
+      session.lastActivityAt = Date.now();
       var donePreview = session.responsePreview || "";
       session.responsePreview = "";
       session.streamedText = false;
@@ -2129,6 +2179,7 @@ function createSDKBridge(opts) {
       session.messageQueue.end();
     }
 
+    session.lastActivityAt = Date.now();
     session.streamPromise = processQueryStream(session).catch(function(err) {
     });
   }
@@ -2150,6 +2201,7 @@ function createSDKBridge(opts) {
       type: "user",
       message: { role: "user", content: content },
     };
+    session.lastActivityAt = Date.now();
     // Route through worker if active, otherwise direct to message queue
     if (session.worker) {
       session.worker.send({ type: "push_message", content: userMsg });
@@ -2566,6 +2618,8 @@ function createSDKBridge(opts) {
     warmup: warmup,
     stopTask: stopTask,
     createMentionSession: createMentionSession,
+    startIdleReaper: startIdleReaper,
+    stopIdleReaper: stopIdleReaper,
   };
 }
 


### PR DESCRIPTION
Fixes #309

Adds an idle session reaper for the in-process (single-user) query path. Sessions that haven't received user activity for 30 minutes have their `messageQueue` ended, allowing `processQueryStream`'s existing `finally` block to close the SDK query instance and terminate the child process.

## Changes

- **`sdk-bridge.js`**: Add `startIdleReaper()` / `stopIdleReaper()` with 30min timeout, 60s check interval. Track `session.lastActivityAt` in `startQuery()`, `pushMessage()`, and the result handler. Skip sessions that are processing, use workers, are single-turn, or are being destroyed.
- **`project.js`**: Start reaper on `warmup()`, stop on `destroy()`.

## What it does NOT do

This does not affect worker-mode sessions (`osUsers`), Ralph Loop single-turn sessions, or sessions actively processing a query. It only reaps idle in-process sessions where the user has moved on.

## Testing

- Verified root cause analysis on v2.25.0 (also confirmed unfixed in v2.26.0 and v2.27.0-beta.11)
- Manually killed 28 stale processes from a 24-hour accumulation, recovering 3.9GB RAM + 3.1GB swap
- Patch written against current `main`