### PR TITLE
feat(multi-user): project security for clone, existing dir, and ownership

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -267,6 +267,20 @@ var relay = createServer({
         spawnOpts.gid = parseInt(passwdLine[1], 10);
       } catch (e) {}
     }
+    // Pre-create target directory and chown to user so git clone can write into it
+    if (config.osUsers && wsUser && wsUser.linuxUser && spawnOpts.uid != null) {
+      if (fs.existsSync(targetDir)) {
+        callback({ ok: false, error: "Target directory already exists: " + targetDir });
+        return;
+      }
+      try {
+        fs.mkdirSync(targetDir, { mode: 0o700 });
+        fs.chownSync(targetDir, spawnOpts.uid, spawnOpts.gid);
+      } catch (e) {
+        callback({ ok: false, error: "Failed to prepare project directory: " + e.message });
+        return;
+      }
+    }
     var proc = spawn("git", ["clone", cloneUrl, targetDir], spawnOpts);
     var stderrBuf = "";
     proc.stderr.on("data", function (chunk) { stderrBuf += chunk.toString(); });

--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -80,7 +80,8 @@ function attachConnection(ctx) {
     var _filteredProjects = getProjectList(_userId);
     var title = getTitle();
     var project = getProject();
-    sendTo(ws, { type: "info", cwd: cwd, slug: slug, project: title || project, version: currentVersion, debug: !!debug, dangerouslySkipPermissions: dangerouslySkipPermissions, osUsers: osUsers, lanHost: lanHost, projectCount: _filteredProjects.length, projects: _filteredProjects, projectOwnerId: projectOwnerId });
+    var ownerLocked = !!(osUsers && osUsers.length > 0 && /^\/home\/[^/]+\//.test(cwd));
+    sendTo(ws, { type: "info", cwd: cwd, slug: slug, project: title || project, version: currentVersion, debug: !!debug, dangerouslySkipPermissions: dangerouslySkipPermissions, osUsers: osUsers, lanHost: lanHost, projectCount: _filteredProjects.length, projects: _filteredProjects, projectOwnerId: projectOwnerId, ownerLocked: ownerLocked });
     var latestVersion = getLatestVersion();
     if (latestVersion && ws._clayUser && ws._clayUser.role === "admin") {
       sendTo(ws, { type: "update_available", version: latestVersion });

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -112,6 +112,11 @@ function attachSessions(ctx) {
     }
 
     if (msg.type === "transfer_project_owner") {
+      // Home directory projects: ownership is permanently locked
+      if (osUsers && osUsers.length > 0 && /^\/home\/[^/]+\//.test(cwd)) {
+        sendTo(ws, { type: "error", text: "Cannot transfer ownership of home directory projects." });
+        return true;
+      }
       var projectOwnerId = getProjectOwnerId();
       var isAdmin = ws._clayUser && ws._clayUser.role === "admin";
       var isProjectOwner = ws._clayUser && projectOwnerId && ws._clayUser.id === projectOwnerId;
@@ -845,6 +850,14 @@ function attachSessions(ctx) {
     if (msg.type === "browse_dir") {
       var rawPath = (msg.path || "").replace(/^~/, require("./config").REAL_HOME);
       var absTarget = path.resolve(rawPath);
+      // Multi-user mode: non-admins can only browse their home directory
+      if (osUsers && osUsers.length > 0 && ws._clayUser && ws._clayUser.role !== "admin") {
+        var browseHome = ws._clayUser.linuxUser ? "/home/" + ws._clayUser.linuxUser : null;
+        if (!browseHome || (absTarget !== browseHome && (absTarget + "/").indexOf(browseHome + "/") !== 0)) {
+          sendTo(ws, { type: "browse_dir_result", path: msg.path, entries: [], error: "Access restricted to your home directory" });
+          return true;
+        }
+      }
       var parentDir, prefix;
       try {
         var stat = fs.statSync(absTarget);
@@ -884,6 +897,18 @@ function attachSessions(ctx) {
     if (msg.type === "add_project") {
       var addPath = (msg.path || "").replace(/^~/, require("./config").REAL_HOME);
       var addAbs = path.resolve(addPath);
+      // Multi-user mode: normal users restricted to their home directory
+      if (osUsers && osUsers.length > 0 && ws._clayUser && ws._clayUser.role !== "admin") {
+        if (!ws._clayUser.linuxUser) {
+          sendTo(ws, { type: "add_project_result", ok: false, error: "No Linux user assigned" });
+          return true;
+        }
+        var userHome = "/home/" + ws._clayUser.linuxUser;
+        if (addAbs !== userHome && (addAbs + "/").indexOf(userHome + "/") !== 0) {
+          sendTo(ws, { type: "add_project_result", ok: false, error: "Path not allowed. You can only add directories under " + userHome });
+          return true;
+        }
+      }
       try {
         var addStat = fs.statSync(addAbs);
         if (!addStat.isDirectory()) {

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -378,6 +378,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     get multiUser() { return store.getState().isMultiUserMode; },
     get myUserId() { return store.getState().myUserId; },
     get projectOwnerId() { return store.getState().currentProjectOwnerId; },
+    get ownerLocked() { return store.getState().ownerLocked; },
     openDm: function (userId) { openDm(userId); },
     openMateWizard: function () { requireClayMateInterview(function () { openMateWizard(); }); },
     openAddProjectModal: function () { openAddProjectModal(); },

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -274,7 +274,14 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
+.ps-owner-locked-hint {
+  font-size: 12px;
+  color: var(--text-muted);
+  width: 100%;
+}
+.ps-owner-locked-hint.hidden { display: none; }
 
 .ps-transfer-form {
   margin-top: 8px;

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -1012,22 +1012,41 @@ button.top-bar-pill.pill-accent:hover { background: color-mix(in srgb, var(--acc
 
 .add-project-body { margin-bottom: 16px; }
 
-.add-project-input-wrap { position: relative; }
+.add-project-input-wrap { position: relative; display: flex; align-items: center; background: var(--input-bg); border: 1px solid var(--border); border-radius: 8px; transition: border-color 0.2s; }
+.add-project-input-wrap:focus-within { border-color: var(--text-dimmer); }
+
+.add-project-prefix {
+  flex-shrink: 0;
+  padding: 5px 0 5px 8px;
+  font-size: 12px;
+  font-family: "Roboto Mono", monospace;
+  color: var(--accent);
+  background: var(--bg-alt);
+  border-radius: 5px 0 0 5px;
+  white-space: nowrap;
+  user-select: none;
+  pointer-events: none;
+  margin: 4px 0 4px 4px;
+  padding: 3px 6px;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border-radius: 4px;
+}
+.add-project-prefix.hidden { display: none; }
 
 #add-project-input {
-  width: 100%;
-  background: var(--input-bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
   color: var(--text);
   font-size: 13px;
   font-family: "Roboto Mono", monospace;
-  padding: 10px 12px;
+  padding: 10px 12px 10px 6px;
   outline: none;
-  transition: border-color 0.2s;
 }
+.add-project-prefix.hidden + #add-project-input { padding-left: 12px; }
 
-#add-project-input:focus { border-color: var(--text-dimmer); }
+#add-project-input:focus { border-color: transparent; }
 #add-project-input::placeholder { color: var(--text-muted); font-family: "Pretendard", system-ui, sans-serif; }
 
 #add-project-suggestions {

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -639,6 +639,7 @@
                 <div class="ps-owner-row">
                   <span class="settings-value" id="ps-owner-name">-</span>
                   <button class="settings-btn-sm" id="ps-transfer-btn">Transfer</button>
+                  <span class="ps-owner-locked-hint hidden" id="ps-owner-locked-hint">Ownership of home directory projects cannot be transferred.</span>
                 </div>
                 <div class="ps-transfer-form hidden" id="ps-transfer-form">
                   <select class="ps-select" id="ps-transfer-select"></select>
@@ -1459,6 +1460,7 @@
     <div class="add-project-body">
       <div class="add-project-panel active" data-panel="existing">
         <div class="add-project-input-wrap">
+          <span id="add-project-prefix" class="add-project-prefix hidden"></span>
           <input type="text" id="add-project-input" placeholder="/" autocomplete="off" spellcheck="false">
           <div id="add-project-suggestions" class="hidden"></div>
         </div>

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -262,6 +262,7 @@ export function processMessage(msg) {
           if (serverVersionEl) serverVersionEl.textContent = msg.version;
         }
         if (msg.projectOwnerId !== undefined) store.setState({ currentProjectOwnerId: msg.projectOwnerId });
+        if (msg.ownerLocked !== undefined) store.setState({ ownerLocked: !!msg.ownerLocked });
         if (msg.osUsers !== undefined) store.setState({ isOsUsers: !!msg.osUsers });
         if (msg.lanHost) window.__lanHost = msg.lanHost;
         if (msg.dangerouslySkipPermissions) {

--- a/lib/public/modules/app-projects.js
+++ b/lib/public/modules/app-projects.js
@@ -27,6 +27,8 @@ var addProjectCancel = null;
 var addProjectModeBtns = null;
 var addProjectPanels = null;
 var addProjectRemoved = null;
+var addProjectPrefixEl = null;
+var addProjectPrefixValue = "";
 var addProjectDebounce = null;
 var addProjectActiveIdx = -1;
 var addProjectMode = "existing";
@@ -47,6 +49,7 @@ export function initProjects(ctx) {
   addProjectModeBtns = addProjectModal.querySelectorAll(".add-project-mode-btn");
   addProjectPanels = addProjectModal.querySelectorAll(".add-project-panel");
   addProjectRemoved = document.getElementById("add-project-removed");
+  addProjectPrefixEl = document.getElementById("add-project-prefix");
 
   // Mode button click listeners
   for (var mbi = 0; mbi < addProjectModeBtns.length; mbi++) {
@@ -59,7 +62,7 @@ export function initProjects(ctx) {
   // Existing project input listeners
   addProjectInput.addEventListener("focus", function () {
     var val = addProjectInput.value;
-    if (val && addProjectSuggestions.children.length === 0) {
+    if ((val || addProjectPrefixValue) && addProjectSuggestions.children.length === 0) {
       requestBrowseDir(val);
     } else if (addProjectSuggestions.children.length > 0) {
       addProjectSuggestions.classList.remove("hidden");
@@ -109,10 +112,10 @@ export function initProjects(ctx) {
         ? items[addProjectActiveIdx]
         : items.length > 0 ? items[0] : null;
       if (target) {
-        var p = target.dataset.path + "/";
-        addProjectInput.value = p;
+        var fullP = target.dataset.path + "/";
+        addProjectInput.value = stripPrefix(fullP);
         addProjectError.classList.add("hidden");
-        requestBrowseDir(p);
+        requestBrowseDir(addProjectInput.value);
       }
       return;
     }
@@ -120,10 +123,10 @@ export function initProjects(ctx) {
     if (e.key === "Enter") {
       e.preventDefault();
       if (addProjectActiveIdx >= 0 && addProjectActiveIdx < items.length) {
-        var picked = items[addProjectActiveIdx].dataset.path + "/";
-        addProjectInput.value = picked;
+        var fullPicked = items[addProjectActiveIdx].dataset.path + "/";
+        addProjectInput.value = stripPrefix(fullPicked);
         addProjectError.classList.add("hidden");
-        requestBrowseDir(picked);
+        requestBrowseDir(addProjectInput.value);
         return;
       }
       submitAddProject();
@@ -614,7 +617,6 @@ function switchAddProjectMode(mode) {
 
 export function openAddProjectModal() {
   addProjectModal.classList.remove("hidden");
-  addProjectInput.value = "/";
   addProjectCreateInput.value = "";
   addProjectCloneInput.value = "";
   addProjectError.classList.add("hidden");
@@ -626,17 +628,29 @@ export function openAddProjectModal() {
   addProjectOk.disabled = false;
   var existingBtn = addProjectModal.querySelector('.add-project-mode-btn[data-mode="existing"]');
   if (_ctx.isOsUsers) {
-    // Default: disable existing directory for multi-user, but allow for admins
-    existingBtn.disabled = true;
-    switchAddProjectMode("create");
-    if (_ctx.checkAdminAccess) {
-      _ctx.checkAdminAccess().then(function (isAdmin) {
-        if (isAdmin) {
-          existingBtn.disabled = false;
-        }
-      });
+    existingBtn.disabled = false;
+    var myUser = _ctx.cachedAllUsers.find(function (u) { return u.id === _ctx.myUserId; });
+    var isAdmin = myUser && myUser.role === "admin";
+    if (!isAdmin && myUser && myUser.linuxUser) {
+      // Non-admin: lock prefix to home directory
+      addProjectPrefixValue = "/home/" + myUser.linuxUser + "/";
+      addProjectPrefixEl.textContent = addProjectPrefixValue;
+      addProjectPrefixEl.classList.remove("hidden");
+      addProjectInput.value = "";
+      addProjectInput.placeholder = "subdirectory";
+    } else {
+      // Admin: no prefix restriction
+      addProjectPrefixValue = "";
+      addProjectPrefixEl.classList.add("hidden");
+      addProjectInput.value = "/";
+      addProjectInput.placeholder = "/";
     }
+    switchAddProjectMode("existing");
   } else {
+    addProjectPrefixValue = "";
+    addProjectPrefixEl.classList.add("hidden");
+    addProjectInput.value = "/";
+    addProjectInput.placeholder = "/";
     existingBtn.disabled = false;
     switchAddProjectMode("existing");
   }
@@ -693,12 +707,25 @@ export function closeAddProjectModal() {
   addProjectError.classList.add("hidden");
   addProjectCloneProgress.classList.add("hidden");
   addProjectActiveIdx = -1;
+  addProjectPrefixValue = "";
+  addProjectPrefixEl.classList.add("hidden");
   if (addProjectDebounce) { clearTimeout(addProjectDebounce); addProjectDebounce = null; }
+}
+
+function getFullPath(inputVal) {
+  return addProjectPrefixValue + inputVal;
+}
+
+function stripPrefix(fullPath) {
+  if (addProjectPrefixValue && fullPath.indexOf(addProjectPrefixValue) === 0) {
+    return fullPath.slice(addProjectPrefixValue.length);
+  }
+  return fullPath;
 }
 
 function requestBrowseDir(val) {
   if (!_ctx.getWs() || _ctx.getWs().readyState !== 1) return;
-  _ctx.getWs().send(JSON.stringify({ type: "browse_dir", path: val }));
+  _ctx.getWs().send(JSON.stringify({ type: "browse_dir", path: getFullPath(val) }));
 }
 
 export function handleBrowseDirResult(msg) {
@@ -721,11 +748,11 @@ export function handleBrowseDirResult(msg) {
     item.innerHTML = '<i data-lucide="folder"></i><span class="add-project-suggestion-name">' +
       escapeHtml(entry.name) + '</span>';
     item.addEventListener("click", function (e) {
-      var p = this.dataset.path + "/";
-      addProjectInput.value = p;
+      var fullP = this.dataset.path + "/";
+      addProjectInput.value = stripPrefix(fullP);
       addProjectInput.focus();
       addProjectError.classList.add("hidden");
-      requestBrowseDir(p);
+      requestBrowseDir(addProjectInput.value);
     });
     addProjectSuggestions.appendChild(item);
   }
@@ -777,7 +804,7 @@ function submitAddProject() {
   addProjectOk.disabled = true;
 
   if (addProjectMode === "existing") {
-    var val = addProjectInput.value.replace(/\/+$/, "");
+    var val = getFullPath(addProjectInput.value).replace(/\/+$/, "");
     if (!val) { addProjectOk.disabled = false; return; }
     if (_ctx.getWs() && _ctx.getWs().readyState === 1) {
       _ctx.getWs().send(JSON.stringify({ type: "add_project", path: val }));

--- a/lib/public/modules/project-settings.js
+++ b/lib/public/modules/project-settings.js
@@ -250,12 +250,17 @@ function populateProfile() {
   var ownerField = document.getElementById("ps-owner-field");
   if (ownerField) {
     var ownerId = currentProject ? currentProject.projectOwnerId : null;
+    var isOwnerLocked = currentProject ? currentProject.ownerLocked : false;
     var isMultiUser = ctx.multiUser;
     if (isMultiUser) {
       ownerField.style.display = "";
       var ownerNameEl = document.getElementById("ps-owner-name");
       var transferBtn = document.getElementById("ps-transfer-btn");
+      var ownerLockedHint = document.getElementById("ps-owner-locked-hint");
       if (transferBtn) transferBtn.style.display = "none";
+      if (ownerLockedHint) {
+        if (isOwnerLocked) { ownerLockedHint.classList.remove("hidden"); } else { ownerLockedHint.classList.add("hidden"); }
+      }
       // Fetch user list (only succeeds for admin)
       fetch("/api/admin/users").then(function (r) {
         if (!r.ok) throw new Error("not admin");
@@ -272,14 +277,14 @@ function populateProfile() {
         } else {
           if (ownerNameEl) ownerNameEl.textContent = "Not set";
         }
-        // Admin can always transfer
-        if (transferBtn) transferBtn.style.display = "";
+        // Admin can transfer unless ownership is locked (home directory projects)
+        if (transferBtn && !isOwnerLocked) transferBtn.style.display = "";
       }).catch(function () {
         // Not admin, show owner name from limited info
         if (ownerId) {
           if (ownerNameEl) ownerNameEl.textContent = ownerId;
-          // Project owner can also transfer
-          if (ctx.myUserId && ctx.myUserId === ownerId && transferBtn) {
+          // Project owner can also transfer unless locked
+          if (!isOwnerLocked && ctx.myUserId && ctx.myUserId === ownerId && transferBtn) {
             transferBtn.style.display = "";
           }
         } else {

--- a/lib/public/modules/sidebar-mobile.js
+++ b/lib/public/modules/sidebar-mobile.js
@@ -1055,6 +1055,7 @@ function renderSheetSettings(listEl) {
                 }
               }
             }
+            if (proj && _ctx.ownerLocked) proj = Object.assign({}, proj, { ownerLocked: true });
             openProjectSettings(getCachedCurrentSlug(), proj);
           }, 250);
         } else if (item.action === "server-settings") {

--- a/lib/public/modules/sidebar-projects.js
+++ b/lib/public/modules/sidebar-projects.js
@@ -578,7 +578,7 @@ function showProjectCtxMenu(anchorEl, slug, name, icon, position) {
     settingsItem.addEventListener("click", function (e) {
       e.stopPropagation();
       closeProjectCtxMenu();
-      openProjectSettings(slug, { slug: slug, name: name, icon: icon, projectOwnerId: _ctx.projectOwnerId });
+      openProjectSettings(slug, { slug: slug, name: name, icon: icon, projectOwnerId: _ctx.projectOwnerId, ownerLocked: _ctx.ownerLocked });
     });
     menu.appendChild(settingsItem);
   }


### PR DESCRIPTION
## Summary
- **Clone fix**: pre-create target directory with user ownership before git clone to resolve permission denied error on `/var/clay/projects`
- **Existing directory**: non-admins restricted to their home directory with a locked prefix badge in the input. Admins unrestricted. Server enforces path validation for both `browse_dir` and `add_project`.
- **Ownership lock**: home directory projects have permanently locked ownership. Transfer is blocked on both server and UI with an explanation hint.

## Test plan
- [ ] Multi-user mode: clone a repo as a non-admin user
- [ ] Non-admin: verify "Existing directory" shows home path prefix badge
- [ ] Non-admin: verify cannot browse or add directories outside home
- [ ] Admin: verify no prefix restriction on existing directory
- [ ] Home directory project: verify transfer button is hidden with hint text
- [ ] Home directory project: verify WebSocket `transfer_project_owner` is rejected
- [ ] Shared project (`/var/clay/projects`): verify transfer still works normally