### PR TITLE
fix(clone): user credentials and directory permissions for multi-user clone

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -258,21 +258,25 @@ var relay = createServer({
     var slugs = config.projects.map(function (p) { return p.slug; });
     var slug = generateSlug(path.join(baseDir, repoName), slugs);
     var targetDir = path.join(baseDir, slug);
-    // Build spawn options
+    // Clone as user to use their git credentials
     var spawnOpts = { cwd: baseDir };
     if (config.osUsers && wsUser && wsUser.linuxUser) {
       try {
         var passwdLine = execSync("id -u " + wsUser.linuxUser + " && id -g " + wsUser.linuxUser, { encoding: "utf8" }).trim().split("\n");
         spawnOpts.uid = parseInt(passwdLine[0], 10);
         spawnOpts.gid = parseInt(passwdLine[1], 10);
+        spawnOpts.env = Object.assign({}, process.env, {
+          HOME: "/home/" + wsUser.linuxUser,
+          USER: wsUser.linuxUser
+        });
       } catch (e) {}
     }
-    // Pre-create target directory and chown to user so git clone can write into it
+    // Pre-create target directory as root and chown to user
+    if (fs.existsSync(targetDir)) {
+      callback({ ok: false, error: "Target directory already exists: " + targetDir });
+      return;
+    }
     if (config.osUsers && wsUser && wsUser.linuxUser && spawnOpts.uid != null) {
-      if (fs.existsSync(targetDir)) {
-        callback({ ok: false, error: "Target directory already exists: " + targetDir });
-        return;
-      }
       try {
         fs.mkdirSync(targetDir, { mode: 0o700 });
         fs.chownSync(targetDir, spawnOpts.uid, spawnOpts.gid);


### PR DESCRIPTION
## Summary
- Set `HOME` and `USER` env vars to the linux user when spawning git clone, so git uses the user's own credential helper and tokens
- Pre-create target directory as root and chown to user before clone, since `/var/clay/projects` (0o711) blocks user writes
- Guard against existing target directory to prevent ownership conflicts

## Test plan
- [ ] Multi-user: clone a private repo that the user has access to via their own `gh auth`
- [ ] Multi-user: clone a public repo
- [ ] Verify cloned directory is owned by the requesting user
- [ ] Verify duplicate slug generates unique directory name