### PR TITLE
fix(terminal): dispose WebGL addon before xterm to prevent crash

### DIFF
--- a/lib/public/modules/terminal.js
+++ b/lib/public/modules/terminal.js
@@ -13,6 +13,22 @@ var altActive = false;
 var isTouchDevice = "ontouchstart" in window;
 var viewportHandler = null;
 var resizeObserver = null;
+
+function disposeTab(tab) {
+  if (tab._webglAddon) {
+    try { tab._webglAddon.dispose(); } catch (e) {}
+    tab._webglAddon = null;
+  }
+  if (tab.xterm) {
+    tab.xterm.dispose();
+    tab.xterm = null;
+  }
+  tab.fitAddon = null;
+  if (tab.bodyEl && tab.bodyEl.parentNode) {
+    tab.bodyEl.parentNode.removeChild(tab.bodyEl);
+    tab.bodyEl = null;
+  }
+}
 var toolbarBound = false;
 var termCtxMenu = null;
 
@@ -356,7 +372,13 @@ function createXtermForTab(tab) {
   // Must be loaded after xterm.open() so the rendering context is available.
   if (typeof WebglAddon !== "undefined") {
     try {
-      xterm.loadAddon(new WebglAddon.WebglAddon());
+      var webgl = new WebglAddon.WebglAddon();
+      webgl.onContextLoss(function () {
+        webgl.dispose();
+        tab._webglAddon = null;
+      });
+      xterm.loadAddon(webgl);
+      tab._webglAddon = webgl;
     } catch (e) {
       // WebGL not available, fall back to DOM renderer
     }
@@ -663,12 +685,7 @@ export function handleTermList(msg) {
   for (var id of tabs.keys()) {
     if (!serverIds.has(id)) {
       var removed = tabs.get(id);
-      if (removed.xterm) {
-        removed.xterm.dispose();
-      }
-      if (removed.bodyEl && removed.bodyEl.parentNode) {
-        removed.bodyEl.parentNode.removeChild(removed.bodyEl);
-      }
+      disposeTab(removed);
       tabs.delete(id);
     }
   }
@@ -733,10 +750,7 @@ export function handleTermClosed(msg) {
   if (!msg.id) return;
   var tab = tabs.get(msg.id);
   if (tab) {
-    if (tab.xterm) tab.xterm.dispose();
-    if (tab.bodyEl && tab.bodyEl.parentNode) {
-      tab.bodyEl.parentNode.removeChild(tab.bodyEl);
-    }
+    disposeTab(tab);
     tabs.delete(msg.id);
 
     if (activeTabId === msg.id) {
@@ -760,15 +774,7 @@ export function handleTermClosed(msg) {
 export function resetTerminals() {
   // Dispose all xterm instances (server state survives, client re-syncs via term_list)
   for (var tab of tabs.values()) {
-    if (tab.xterm) {
-      tab.xterm.dispose();
-      tab.xterm = null;
-      tab.fitAddon = null;
-    }
-    if (tab.bodyEl && tab.bodyEl.parentNode) {
-      tab.bodyEl.parentNode.removeChild(tab.bodyEl);
-      tab.bodyEl = null;
-    }
+    disposeTab(tab);
   }
   tabs.clear();
   activeTabId = null;


### PR DESCRIPTION
## Summary
- Dispose WebGL addon before xterm.dispose() to prevent `_isDisposed` TypeError from async render callbacks
- Centralized cleanup into `disposeTab()` helper used in all 3 disposal paths (term_list sync, term_closed, resetTerminals)
- Added `onContextLoss` handler for graceful WebGL context recovery

## Test plan
- [ ] Open and close terminals repeatedly, verify no console errors
- [ ] Reconnect websocket while terminal is open, verify clean reset
- [ ] Switch projects with terminal open, verify no _isDisposed crash