### PR TITLE
fix(ui): clear stale status dots from inactive project icons

### DIFF
--- a/lib/public/modules/app-projects.js
+++ b/lib/public/modules/app-projects.js
@@ -311,7 +311,11 @@ export function renderProjectList() {
       }
     }
   }
-  // Re-apply current socket status to the active icon's dot
+  // Clear stale socket status from all project dots, then re-apply to active
+  var allDots = document.querySelectorAll("#icon-strip-projects .icon-strip-status");
+  for (var di = 0; di < allDots.length; di++) {
+    allDots[di].classList.remove("connected", "processing");
+  }
   var dot = _ctx.getStatusDot();
   if (dot) {
     if (_ctx.connected && _ctx.processing) { dot.classList.add("connected"); dot.classList.add("processing"); }

--- a/lib/public/modules/sidebar-projects.js
+++ b/lib/public/modules/sidebar-projects.js
@@ -1198,6 +1198,11 @@ export function renderIconStrip(projects, currentSlug) {
     for (var fi = 0; fi < items.length; fi++) {
       var isNowActive = items[fi].dataset.slug === currentSlug && !currentDmUserId2;
       items[fi].classList.toggle("active", isNowActive);
+      // Clear stale socket status dot from inactive items
+      if (!isNowActive) {
+        var statusDot = items[fi].querySelector(".icon-strip-status");
+        if (statusDot) statusDot.classList.remove("connected", "processing");
+      }
       // Update unread badge visibility (active items hide their badge)
       var badge = items[fi].querySelector(".icon-strip-project-badge");
       if (badge && badge.classList.contains("has-unread") && isNowActive) {


### PR DESCRIPTION
## Summary
- Clear `connected` and `processing` classes from all project dots before re-applying to the active one in `renderProjectList`
- Also clear in `renderIconStrip` fast path when toggling active state without DOM rebuild

## Root cause
The `processing` CSS class has `opacity: 1` regardless of the parent `.active` state, so dots stayed visible on previously active project icons after switching.

## Test plan
- [ ] Switch between projects, verify only the active project shows a status dot
- [ ] Trigger processing (send a message), switch projects mid-processing, verify dot only on active