### PR TITLE
fix(sdk): preserve mid-session model change across SDK warmup cycles

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1008,7 +1008,7 @@ function createSDKBridge(opts) {
           send({ type: "slash_commands", commands: sm.slashCommands });
         }
         if (result.model) {
-          sm.currentModel = sm._savedDefaultModel || result.model;
+          sm.currentModel = sm.currentModel || sm._savedDefaultModel || result.model;
         }
         sm.availableModels = result.models || [];
         send({ type: "model_info", model: sm.currentModel || "", models: sm.availableModels || [] });

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -132,7 +132,7 @@ function attachMessageProcessor(ctx) {
         send({ type: "slash_commands", commands: sm.slashCommands });
       }
       if (parsed.model) {
-        sm.currentModel = sm._savedDefaultModel || parsed.model;
+        sm.currentModel = sm.currentModel || sm._savedDefaultModel || parsed.model;
         send({ type: "model_info", model: sm.currentModel, models: sm.availableModels || [] });
       }
       if (parsed.fast_mode_state) {


### PR DESCRIPTION
## Problem

When a user changes the model mid-session (via the model picker), the change is stored in `sm.currentModel`. However, on each subsequent SDK warmup — which fires on session reconnect, tab reload, or session resumption — two sites unconditionally overwrite `sm.currentModel` with `sm._savedDefaultModel`, resetting the user's choice back to the project or server default without any action on their part.

The symptom: you switch to `sonnet`, send a message, and Clay silently resets back to `opus` (or whatever the default is). The UI reflects the reset and the actual API calls use the wrong model.

## Root Cause

Two warmup completion paths use the same pattern:

```js
// sdk-message-processor.js:135 (system/init path)
sm.currentModel = sm._savedDefaultModel || parsed.model;

// sdk-bridge.js:1011 (warmup worker result path)
sm.currentModel = sm._savedDefaultModel || result.model;
```

Both ignore any value already in `sm.currentModel`, so a mid-session `set_model` call is always clobbered on the next warmup.

## Fix

Prepend a `sm.currentModel` check in both paths so an already-set in-memory value is preserved:

```js
sm.currentModel = sm.currentModel || sm._savedDefaultModel || parsed.model;
sm.currentModel = sm.currentModel || sm._savedDefaultModel || result.model;
```

Priority order:
1. In-memory current value (set by user this session via `set_model`)
2. Persisted project/server default (`_savedDefaultModel`)
3. SDK-reported model (fallback if nothing is set)

## Testing

1. Set a project or server default model (e.g. `opus`)
2. Start a session — confirm model shows the default
3. Switch model mid-session via the picker (e.g. to `sonnet`)
4. Send a follow-up message
5. Confirm the model does **not** reset to the default
6. Start a fresh session — confirm the default is restored correctly (since `currentModel` starts unset)