### PR TITLE
fix(scroll): scroll to bottom when returning to app after backgrounding

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -522,6 +522,15 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     forceScrollToBottom();
   });
 
+  // Scroll to bottom when returning to the app (e.g. switching back from another
+  // Android app or tab). Without this the browser restores a stale scroll offset
+  // and leaves the user stranded mid-session instead of at the latest message.
+  document.addEventListener("visibilitychange", function () {
+    if (!document.hidden) {
+      scrollToBottom();
+    }
+  });
+
   // Fork session from a user message
   messagesEl.addEventListener("click", function(e) {
     var btn = e.target.closest(".msg-action-fork");


### PR DESCRIPTION
## Problem

On Android Chrome (PWA / WebAPK), switching back to Clay from another app or tab leaves the user stranded mid-session. The browser restores a stale scroll offset instead of the latest message, so you have to manually scroll to the bottom every time you return.

## Root cause

Clay has no \`visibilitychange\` listener. When the document becomes visible again, no scroll correction is applied, so whatever offset the browser cached (which can be well above the bottom) is what the user sees.

## Fix

Add a \`visibilitychange\` listener that calls \`scrollToBottom()\` when the document becomes visible. This reuses the existing function and respects the \`isUserScrolledUp\` guard — if the user intentionally scrolled up to read history before backgrounding the app, their position is preserved (the "↓ Latest" button will appear as normal).

\`\`\`js
document.addEventListener("visibilitychange", function () {
  if (!document.hidden) {
    scrollToBottom();
  }
});
\`\`\`

9 lines, no new state, no new dependencies.

## Testing

- Open Clay in Android Chrome PWA, send/receive messages so the session has content
- Switch to another app, then switch back — should land at the latest message
- Scroll up intentionally, switch away and back — should stay scrolled up (button appears)