### PR TITLE
fix: open external links in new tab

### DIFF
--- a/lib/public/modules/markdown.js
+++ b/lib/public/modules/markdown.js
@@ -5,6 +5,18 @@ import { getMermaidThemeVars } from './theme.js';
 // Initialize markdown parser
 marked.use({ gfm: true, breaks: false });
 
+// Open external links in a new tab
+marked.use({
+  renderer: {
+    link({ href, title, text }) {
+      var isExternal = href && (href.startsWith('http://') || href.startsWith('https://'));
+      var titleAttr = title ? ' title="' + title + '"' : '';
+      var targetAttr = isExternal ? ' target="_blank" rel="noopener noreferrer"' : '';
+      return '<a href="' + href + '"' + titleAttr + targetAttr + '>' + text + '</a>';
+    }
+  }
+});
+
 // Initialize mermaid
 mermaid.initialize({
   startOnLoad: false,


### PR DESCRIPTION
## Problem

External URLs in chat messages open in the same tab, navigating away from the Clay session. Example: clicking an Indeed job link mid-session loses the conversation.

## Fix

Add a custom `marked` renderer for links. External URLs (`http://`, `https://`) get `target="_blank" rel="noopener noreferrer"`. Internal anchor links (`#section`) are unaffected.

```js
marked.use({
  renderer: {
    link({ href, title, text }) {
      var isExternal = href && (href.startsWith('http://') || href.startsWith('https://'));
      var titleAttr = title ? ' title="' + title + '"' : '';
      var targetAttr = isExternal ? ' target="_blank" rel="noopener noreferrer"' : '';
      return '<a href="' + href + '"' + titleAttr + targetAttr + '>' + text + '</a>';
    }
  }
});
```

One file changed: `lib/public/modules/markdown.js`.