### PR TITLE
fix(session,permissions): trim migration titles + inherit bypassPermissions in scheduled tasks

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1004,7 +1004,10 @@ function createSDKBridge(opts) {
     if (dangerouslySkipPermissions) {
       claudeOpts.allowDangerouslySkipPermissions = true;
     }
-    var modeToApply = session._loopPermissionMode || (session.acceptEditsAfterStart ? "acceptEdits" : sm.currentPermissionMode);
+    var globalMode = sm.currentPermissionMode || "default";
+    var loopFloor = session.acceptEditsAfterStart ? "acceptEdits" : "default";
+    var effectiveDefault = globalMode === "bypassPermissions" ? globalMode : (loopFloor !== "default" ? loopFloor : globalMode);
+    var modeToApply = session._loopPermissionMode || effectiveDefault;
     if (session.acceptEditsAfterStart) delete session.acceptEditsAfterStart;
     if (modeToApply && modeToApply !== "default") {
       claudeOpts.permissionMode = modeToApply;

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -723,7 +723,9 @@ function createSessionManager(opts) {
         }
       }
       var toMigrate = candidates.filter(function(item) {
-        return sdkTitles[item.cliSessionId] !== item.title;
+        var relayTitle = (item.title || "").trim();
+        var sdkTitle = (sdkTitles[item.cliSessionId] || "").trim();
+        return sdkTitle !== relayTitle;
       });
       if (toMigrate.length === 0) return;
       var migrated = 0;
@@ -732,7 +734,7 @@ function createSessionManager(opts) {
       for (var j = 0; j < toMigrate.length; j++) {
         (function(item) {
           chain = chain.then(function() {
-            return adapter.renameSession(item.cliSessionId, item.title, { dir: migrateCwd }).then(function() {
+            return adapter.renameSession(item.cliSessionId, item.title.trim(), { dir: migrateCwd }).then(function() {
               migrated++;
             }).catch(function(e) {
               failed++;


### PR DESCRIPTION
## Summary

Two fixes for issues affecting scheduled tasks and session management:

### 1. Session title migration resets SDK file timestamps on every restart

- `migrateSessionTitles` compares relay titles against SDK `customTitle` to skip already-migrated sessions
- The SDK's `renameSession` trims whitespace, but the relay stores untrimmed titles (trailing spaces)
- This causes `renameSession` to be called on every daemon restart, appending duplicate `custom-title` lines and resetting mtimes
- **Fix:** Trim both sides of the comparison and the title passed to `renameSession`

### 2. Scheduled tasks ignore server-wide bypassPermissions mode

- Loop sessions set `acceptEditsAfterStart=true`, hardcoding SDK permission mode to `acceptEdits`
- When the server runs with `bypassPermissions`, scheduled tasks still prompt for approval
- **Fix:** Treat `acceptEditsAfterStart` as a minimum floor — use the global mode if it's more permissive

### Impact (title migration bug)

- 446 SDK session files had corrupted mtimes across 8 restart events since March 26
- Some files accumulated 100+ duplicate `custom-title` lines

## Test plan

- [ ] Sessions with trailing-space titles are skipped during migration
- [ ] No duplicate `custom-title` lines accumulate after restarts
- [ ] Scheduled tasks run without prompts when server is in bypassPermissions mode
- [ ] Scheduled tasks still get `acceptEdits` when server is in default mode
- [ ] Per-loop `permissionMode` in LOOP.json still takes priority over global mode