### PR TITLE
fix(ui,sdk-bridge): 'codex --login' -> 'codex login' in loginCommand prompts

### DIFF
--- a/lib/public/modules/app-rendering.js
+++ b/lib/public/modules/app-rendering.js
@@ -496,7 +496,7 @@ export function addAuthRequiredMessage(msg) {
   div.className = "auth-required-msg";
 
   var vendor = msg.vendor || "claude";
-  var loginCmd = msg.loginCommand || (vendor === "codex" ? "codex --login" : "claude login");
+  var loginCmd = msg.loginCommand || (vendor === "codex" ? "codex login" : "claude login");
   var vendorName = msg.text || "Claude Code is not logged in.";
 
   var header = document.createElement("div");

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -921,7 +921,7 @@ function createSDKBridge(opts) {
         type: "auth_required",
         text: vendorName + " is not logged in.",
         vendor: session.vendor,
-        loginCommand: session.vendor === "codex" ? "codex --login" : session.vendor + " login",
+        loginCommand: session.vendor === "codex" ? "codex login" : session.vendor + " login",
         linuxUser: authLinuxUser,
         canAutoLogin: canAutoLogin,
       });


### PR DESCRIPTION
## Summary

Per #327, Codex CLI uses a subcommand (\`codex login\`), not a flag (\`codex --login\`). Two sites suggested the invalid flag form:

- \`lib/sdk-bridge.js:924\` — \`loginCommand: \"codex --login\"\` (sent to UI)
- \`lib/public/modules/app-rendering.js:499\` — fallback \`loginCmd\` default

Users who followed the suggestion got 'unknown argument --login' and stayed stuck in the auth-required loop.

This PR is **scoped** to the login-command typo. The larger Darwin-only hardcoded binary path issue in the same issue is a separate refactor and left for a follow-up.

Refs #327

## Testing

Two one-word replacements in two JS files; verified no \`codex --login\` references remain.