### PR TITLE
fix(yoke): use findCodexPath() instead of hardcoded darwin-arm64 path

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -737,6 +737,24 @@ var relay = createServer({
     console.log("[daemon] Auto-continue on rate limit:", want, "(web)");
     return { ok: true, autoContinueOnRateLimit: want };
   },
+  onGetToolPalettes: function () {
+    return config.toolPalettes || {};
+  },
+  onSetToolPalette: function (paletteName, order, hidden) {
+    if (paletteName !== "session" && paletteName !== "mate") {
+      return { error: "Unknown palette" };
+    }
+    var safeOrder = Array.isArray(order)
+      ? order.filter(function (s) { return typeof s === "string"; })
+      : [];
+    var safeHidden = Array.isArray(hidden)
+      ? hidden.filter(function (s) { return typeof s === "string"; })
+      : [];
+    if (!config.toolPalettes) config.toolPalettes = {};
+    config.toolPalettes[paletteName] = { order: safeOrder, hidden: safeHidden };
+    saveConfig(config);
+    return { ok: true, palette: paletteName, order: safeOrder, hidden: safeHidden };
+  },
   onSetKeepAwake: function (value) {
     var want = !!value;
     config.keepAwake = want;

--- a/lib/project-email.js
+++ b/lib/project-email.js
@@ -405,12 +405,28 @@ function attachEmail(ctx) {
     }
   }
 
+  // Whether any email capability is available for the active user.
+  // Used to gate the clay-email MCP so its tools are hidden from the model
+  // when the user hasn't registered any accounts and the server SMTP isn't
+  // configured (see issue #325 — we don't expose tools the user can't use).
+  function hasEmailCapability() {
+    try {
+      var accounts = emailAccounts.listAccounts(getActiveUserId());
+      if (accounts && accounts.length > 0) return true;
+    } catch (e) { /* fall through to SMTP check */ }
+    try {
+      if (smtp.isSmtpConfigured()) return true;
+    } catch (e) { /* ignore */ }
+    return false;
+  }
+
   return {
     handleEmailMessage: handleEmailMessage,
     getEmailContext: getEmailContext,
     getCheckedEmailAccounts: getCheckedEmailAccounts,
     getEmailDefaults: getEmailDefaults,
     createMcpDeps: createMcpDeps,
+    hasEmailCapability: hasEmailCapability,
     destroy: destroy,
   };
 }

--- a/lib/project.js
+++ b/lib/project.js
@@ -540,6 +540,32 @@ function createProjectContext(opts) {
     return Object.keys(servers).length > 0 ? servers : undefined;
   })();
 
+  // Gate in-app MCP servers on the underlying capability actually being
+  // available. Without this, tools show up in every session's tool list
+  // even when the user can't use them, which wastes context and can cause
+  // the model to pick the wrong MCP when the user has another one
+  // configured (see issue #325).
+  //
+  //   clay-browser -> only when the Chrome extension is connected
+  //   clay-email   -> only when the user has an account or server SMTP
+  function getLocalMcpServers() {
+    if (!mcpServers) return undefined;
+    var extWs = browserState._extensionWs;
+    var extConnected = !!(extWs && extWs.readyState === 1);
+    var emailAvailable = !!(_email && typeof _email.hasEmailCapability === "function" && _email.hasEmailCapability());
+    var keys = Object.keys(mcpServers);
+    var filtered = {};
+    var hasAny = false;
+    for (var i = 0; i < keys.length; i++) {
+      var name = keys[i];
+      if (name === "clay-browser" && !extConnected) continue;
+      if (name === "clay-email" && !emailAvailable) continue;
+      filtered[name] = mcpServers[name];
+      hasAny = true;
+    }
+    return hasAny ? filtered : undefined;
+  }
+
   // --- SDK bridge ---
   var sdk = createSDKBridge({
     cwd: cwd,
@@ -553,7 +579,7 @@ function createProjectContext(opts) {
     mateDisplayName: opts.mateDisplayName || "",
     isMate: isMate,
     dangerouslySkipPermissions: dangerouslySkipPermissions,
-    mcpServers: mcpServers,
+    mcpServers: getLocalMcpServers,
     getRemoteMcpServers: function () { return _mcp.getMcpServers(); },
     clayPort: serverPort,
     clayTls: serverTls,
@@ -1125,11 +1151,14 @@ function createProjectContext(opts) {
           }
         }
 
-        // In-app MCP servers (debate, browser, email)
-        if (mcpServers) {
-          var inAppNames = Object.keys(mcpServers);
+        // In-app MCP servers (debate, browser, email).
+        // Use getLocalMcpServers() so clay-browser is hidden unless the
+        // Chrome extension is currently connected (see issue #325).
+        var localMcp = getLocalMcpServers();
+        if (localMcp) {
+          var inAppNames = Object.keys(localMcp);
           for (var i = 0; i < inAppNames.length; i++) {
-            extractServerTools(inAppNames[i], mcpServers[inAppNames[i]]);
+            extractServerTools(inAppNames[i], localMcp[inAppNames[i]]);
           }
         }
 
@@ -1147,9 +1176,10 @@ function createProjectContext(opts) {
         return Promise.resolve(tools);
       },
       callTool: function (serverName, toolName, args) {
-        // Try in-app servers first
-        if (mcpServers && mcpServers[serverName]) {
-          var server = mcpServers[serverName];
+        // Try in-app servers first (gated by extension connectivity for clay-browser).
+        var localMcp = getLocalMcpServers();
+        if (localMcp && localMcp[serverName]) {
+          var server = localMcp[serverName];
           if (server.instance && server.instance._registeredTools && server.instance._registeredTools[toolName]) {
             var handler = server.instance._registeredTools[toolName].handler;
             if (typeof handler === "function") {

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -41,6 +41,7 @@ import { initSTT } from './modules/stt.js';
 import { initProfile, getProfileLang } from './modules/profile.js';
 import { initUserSettings } from './modules/user-settings.js';
 import { initToolPalettes } from './modules/tool-palette.js';
+import { initProjectSwitcher } from './modules/project-switcher.js';
 import { initAdmin, checkAdminAccess } from './modules/admin.js';
 import { initSessionSearch, toggleSearch, closeSearch, isSearchOpen, handleFindInSessionResults, onHistoryPrepended as onSessionSearchHistoryPrepended } from './modules/session-search.js';
 import { initTooltips, registerTooltip } from './modules/tooltip.js';
@@ -445,6 +446,11 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
       }
     },
   });
+
+  // Project switcher (Cmd/Ctrl+E). Init after command palette so its
+  // keydown listener registers later — capture-phase ordering doesn't
+  // matter here but it keeps related bootstrap steps adjacent.
+  initProjectSwitcher();
 
   // --- Connect overlay (animated ASCII logo) ---
   var asciiLogoCanvas = $("ascii-logo-canvas");

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -40,6 +40,7 @@ import { initPlaybook, openPlaybook, getPlaybooks, getPlaybookForTip, isComplete
 import { initSTT } from './modules/stt.js';
 import { initProfile, getProfileLang } from './modules/profile.js';
 import { initUserSettings } from './modules/user-settings.js';
+import { initToolPalettes } from './modules/tool-palette.js';
 import { initAdmin, checkAdminAccess } from './modules/admin.js';
 import { initSessionSearch, toggleSearch, closeSearch, isSearchOpen, handleFindInSessionResults, onHistoryPrepended as onSessionSearchHistoryPrepended } from './modules/session-search.js';
 import { initTooltips, registerTooltip } from './modules/tooltip.js';
@@ -396,6 +397,10 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     get projectList() { return getCachedProjects() || []; },
     availableBuiltins: function () { return store.get('cachedAvailableBuiltins') || []; },
   };
+  // Render the customizable tool palettes BEFORE initSidebar so the
+  // buttons exist in the DOM when sidebar.js (and later terminal.js /
+  // mcp-ui.js / etc.) attach click handlers by ID.
+  initToolPalettes();
   initSidebar(sidebarCtx);
   var wsGetter = function () { return _getWsRef(); };
   initMateSidebar(wsGetter);

--- a/lib/public/css/command-palette.css
+++ b/lib/public/css/command-palette.css
@@ -371,3 +371,189 @@
     display: none;
   }
 }
+
+/* --- Project switcher (Cmd/Ctrl+E) ---
+   macOS Cmd+Tab-style quick switcher: centered modal with a darker
+   backdrop than the command palette, projects laid out horizontally
+   as icon+label tiles that wrap to multiple rows when there are many.
+   Reuses .cmd-palette shell so positioning/animations stay consistent. */
+.project-switcher .cmd-palette-backdrop {
+  background: rgba(var(--shadow-rgb), 0.55);
+}
+.project-switcher-dialog {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-top: 1px solid var(--border);
+  border-radius: 16px;
+  width: min(820px, 85vw);
+  max-height: 80vh;
+  background: var(--bg-alt);
+  box-shadow: 0 20px 60px rgba(var(--shadow-rgb), 0.5);
+  animation: projSwitcherIn 0.12s ease-out;
+}
+@keyframes projSwitcherIn {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.96); }
+  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+.project-switcher-header {
+  padding: 14px 20px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dimmer);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.project-switcher-dialog .cmd-palette-results {
+  padding: 12px 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-start;
+  overflow-y: auto;
+  max-height: calc(80vh - 110px);
+}
+.project-switcher-item {
+  flex: 0 0 auto;
+  width: 96px;
+  height: 104px;
+  padding: 10px 6px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  border: 2px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  text-align: center;
+}
+/* Icon-strip-style treatment: rounded bg-alt fill that turns accent
+   on hover/active, and a 4-direction drop-shadow + white glow on the
+   emoji img for readability on either background. */
+.project-switcher-item .cmd-palette-item-icon {
+  width: 44px;
+  height: 44px;
+  font-size: 28px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: var(--bg-alt);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+.project-switcher-item .cmd-palette-item-icon .lucide {
+  width: 22px;
+  height: 22px;
+}
+.project-switcher-item .cmd-palette-item-icon img.emoji {
+  width: 26px;
+  height: 26px;
+  vertical-align: middle;
+  margin: 0;
+  filter:
+    drop-shadow(1px 0 0 rgba(0,0,0,0.25))
+    drop-shadow(-1px 0 0 rgba(0,0,0,0.25))
+    drop-shadow(0 1px 0 rgba(0,0,0,0.25))
+    drop-shadow(0 -1px 0 rgba(0,0,0,0.25))
+    drop-shadow(0 0 4px rgba(255,255,255,0.35));
+}
+.project-switcher-item:hover .cmd-palette-item-icon,
+.project-switcher-item.active .cmd-palette-item-icon {
+  background: var(--accent);
+  color: #fff;
+}
+.project-switcher-avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  object-fit: cover;
+}
+.project-switcher-item .cmd-palette-item-body {
+  width: 100%;
+  display: block;
+}
+.project-switcher-item .cmd-palette-item-title-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  width: 100%;
+}
+.project-switcher-item .cmd-palette-item-title {
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--text-secondary);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+}
+.project-switcher-item:hover {
+  background: transparent;
+}
+.project-switcher-item.active {
+  border-color: var(--accent);
+  background: transparent;
+}
+.project-switcher-item.active .cmd-palette-item-title {
+  color: var(--text);
+}
+
+.project-switcher-current {
+  font-size: 9px;
+  font-weight: 600;
+  color: var(--text-dimmer);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Disabled tile (e.g. worktree with worktreeAccessible: false). Not a
+   valid switch target, so skip highlight, skip click, visually dim. */
+.project-switcher-item.disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.project-switcher-item.disabled:hover {
+  background: transparent;
+}
+.project-switcher-item.disabled.active {
+  border-color: transparent;
+  background: transparent;
+}
+.project-switcher-disabled-reason {
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--text-dimmer);
+  font-style: italic;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-switcher-footer {
+  padding: 10px 16px;
+  font-size: 11px;
+  color: var(--text-dimmer);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  justify-content: center;
+}
+.project-switcher-footer kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  margin: 0 1px;
+  background: rgba(var(--overlay-rgb), 0.1);
+  border-radius: 4px;
+  font-size: 10px;
+  font-family: inherit;
+  color: var(--text-muted);
+}

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -70,8 +70,45 @@
   margin: 6px 6px 12px;
   display: flex;
   flex-direction: column;
+  /* Own the scroll: inner file-tree scrolls, titlebar/search/hint stay
+     anchored. Without this the whole panel (inherited overflow-y:auto
+     from .sidebar-panel) scrolled past the search bar. */
+  overflow: hidden;
 }
 #sidebar-panel-files.hidden { display: none; }
+#sidebar-panel-files #file-tree {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* Keyboard hint footer — pinned below the tree, always visible. */
+.fb-kb-hint {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border-subtle);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-dimmer);
+}
+.fb-kb-hint kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  margin: 0 1px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  font-size: 10px;
+  font-family: inherit;
+  color: var(--text-muted);
+}
+.fb-kb-hint span {
+  opacity: 0.9;
+}
 
 /* --- File browser titlebar --- */
 .fb-titlebar {
@@ -222,6 +259,18 @@
 
 .file-tree-item:hover { background: var(--sidebar-hover); color: var(--text); }
 .file-tree-item.active { background: var(--sidebar-active); color: var(--text); }
+/* Keyboard focus ring (arrow-key navigation) — separate from .active
+   so the currently-opened file stays visually marked even while the
+   user is exploring elsewhere with the arrows. */
+.file-tree-item.fb-kb-focus {
+  background: var(--sidebar-hover);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+#file-tree:focus { outline: none; }
+#file-tree:focus .file-tree-item.fb-kb-focus {
+  background: var(--sidebar-active);
+}
 .file-tree-item .lucide { width: 14px; height: 14px; flex-shrink: 0; }
 
 .file-tree-name {

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -2,27 +2,36 @@
    File Browser
    ========================================================================== */
 
-/* --- Session actions --- */
+/* --- Session actions ---
+   Compact icon+caption grid (Launchpad-style) so the tools panel stays
+   small no matter how many tools we add. Keeps the session list — the
+   core of the sidebar — from getting pushed down as features grow (see
+   issue #325 item 3). Each tile shows a small icon above a two-line
+   caption so the tool is recognizable at a glance without a hover. */
 #session-actions {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
   padding: 0 8px 4px;
 }
 
 #session-actions button {
+  position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
+  justify-content: center;
+  gap: 4px;
+  min-height: 58px;
+  padding: 6px 2px;
   border-radius: 10px;
   border: none;
   background: transparent;
   color: var(--text-muted);
   font-family: inherit;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: 500;
   cursor: pointer;
-  margin-bottom: 0;
   transition: background 0.15s, color 0.15s;
 }
 
@@ -30,47 +39,54 @@
 #session-actions button:hover { background: var(--sidebar-hover); color: var(--text-secondary); }
 #session-actions button.active { background: var(--sidebar-hover); color: var(--text); }
 
-.sidebar-badge {
-  background: rgba(var(--overlay-rgb), 0.1);
-  color: var(--text-dimmer);
+/* Tile caption — small, centered, wraps to at most two lines */
+#session-actions .tool-btn-label {
   font-size: 10px;
+  font-weight: 500;
+  line-height: 1.15;
+  text-align: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+
+/* Badge becomes a small corner indicator in icon-only grid */
+.sidebar-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: rgba(var(--overlay-rgb), 0.15);
+  color: var(--text-dimmer);
+  font-size: 9px;
   font-weight: 700;
-  min-width: 16px;
-  height: 16px;
-  border-radius: 8px;
+  min-width: 14px;
+  height: 14px;
+  border-radius: 7px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 4px;
-  margin-left: auto;
+  padding: 0 3px;
   line-height: 1;
+  pointer-events: none;
 }
 .sidebar-badge.hidden { display: none; }
 
+/* Sticky-notes badge stays clickable in the icon grid — it toggles the
+   archive panel. The old inline "Open Archive" expand label doesn't fit
+   a corner dot, so it's gone; the cursor and hover color still signal
+   that the badge itself is interactive. */
 #sticky-notes-sidebar-count {
   cursor: pointer;
-  overflow: hidden;
-  transition: padding 0.2s ease, background 0.15s ease, color 0.15s ease;
-}
-#sticky-notes-sidebar-count::after {
-  content: "Open Archive";
-  display: inline-block;
-  max-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  vertical-align: middle;
-  margin-left: 0;
-  opacity: 0;
-  transition: max-width 0.2s ease, margin-left 0.2s ease, opacity 0.15s ease;
+  pointer-events: auto;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 #sticky-notes-sidebar-count:hover {
   background: var(--accent);
   color: #fff;
-}
-#sticky-notes-sidebar-count:hover::after {
-  max-width: 80px;
-  margin-left: 4px;
-  opacity: 1;
 }
 
 /* --- Panels --- */

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -3,55 +3,14 @@
    ========================================================================== */
 
 /* --- Session actions ---
-   Compact icon+caption grid (Launchpad-style) so the tools panel stays
-   small no matter how many tools we add. Keeps the session list — the
-   core of the sidebar — from getting pushed down as features grow (see
-   issue #325 item 3). Each tile shows a small icon above a two-line
-   caption so the tool is recognizable at a glance without a hover. */
+   Compact icon+caption grid. Tile styles come from .palette-tile in
+   sidebar.css so the same tiles render correctly in both the active
+   grid here and the hidden-grid when edit-mode moves them. */
 #session-actions {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 4px;
   padding: 0 8px 4px;
-}
-
-#session-actions button {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  min-height: 58px;
-  padding: 6px 2px;
-  border-radius: 10px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  font-family: inherit;
-  font-size: 10px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-#session-actions button .lucide { width: 16px; height: 16px; flex-shrink: 0; }
-#session-actions button:hover { background: var(--sidebar-hover); color: var(--text-secondary); }
-#session-actions button.active { background: var(--sidebar-hover); color: var(--text); }
-
-/* Tile caption — small, centered, wraps to at most two lines */
-#session-actions .tool-btn-label {
-  font-size: 10px;
-  font-weight: 500;
-  line-height: 1.15;
-  text-align: center;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  word-break: break-word;
 }
 
 /* Badge becomes a small corner indicator in icon-only grid */

--- a/lib/public/css/icon-strip.css
+++ b/lib/public/css/icon-strip.css
@@ -794,12 +794,23 @@
   height: 22px;
 }
 
-/* --- User avatars (circle, above my-avatar at bottom) --- */
-.icon-strip-users {
+/* Mate section wrapper — pinned just above the user-island at the
+   bottom of the strip. Groups the \u2318M hint pill with the users
+   list so the hint sits directly above the mate avatars rather than
+   floating up in the project section's flex flow. */
+.icon-strip-mate-section {
   position: absolute;
   bottom: 74px; /* above user-island (58px + 8px bottom + 8px gap) */
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+/* --- User avatars (circle, inside the mate section) --- */
+.icon-strip-users {
   width: 56px;
   display: flex;
   flex-direction: column;

--- a/lib/public/css/icon-strip.css
+++ b/lib/public/css/icon-strip.css
@@ -112,6 +112,37 @@
   flex-shrink: 0;
 }
 
+/* Keyboard-shortcut hint above each switchable strip section. Tiny
+   pill with the platform-specific chord; clicking opens the switcher
+   in that mode, same as the keyboard shortcut itself. */
+.icon-strip-hint {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  padding: 2px 4px;
+  margin: 2px 0;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-alt);
+  color: var(--text-dimmer);
+  font-size: 10px;
+  font-weight: 600;
+  font-family: inherit;
+  border-radius: 6px;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+.icon-strip-hint:hover {
+  opacity: 1;
+  color: var(--text-muted);
+  background: var(--bg);
+}
+.icon-strip-hint.hidden {
+  display: none;
+}
+
 /* --- Scrollable project list area --- */
 .icon-strip-projects {
   width: 100%;

--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -885,7 +885,10 @@
 #ask-mate-btn:hover { background: rgba(var(--overlay-rgb), 0.06); color: var(--text); }
 #ask-mate-btn:active { transform: scale(0.95); }
 
-/* Mate avatar overlay on @ button */
+/* Mate avatar overlay on @ button.
+   Rendered desaturated and dim so it sits quietly in the corner of the
+   input area. Regains saturation on hover, so the user only sees the
+   actual mate identity when they're actively reaching for the button. */
 .ask-mate-avatar {
   position: absolute;
   bottom: 0;
@@ -895,12 +898,14 @@
   border-radius: 50%;
   border: 1.5px solid var(--input-bg);
   pointer-events: none;
-  opacity: 0.55;
-  transition: opacity 0.3s, transform 0.3s;
+  opacity: 0.45;
+  filter: grayscale(100%);
+  transition: opacity 0.3s, transform 0.3s, filter 0.3s;
 }
 
 #ask-mate-btn:hover .ask-mate-avatar {
-  opacity: 0.85;
+  opacity: 0.9;
+  filter: grayscale(0%);
 }
 
 .ask-mate-avatar.fade-out {
@@ -909,7 +914,7 @@
 }
 
 .ask-mate-avatar.fade-in {
-  opacity: 0.55;
+  opacity: 0.45;
   transform: scale(1);
 }
 

--- a/lib/public/css/mates.css
+++ b/lib/public/css/mates.css
@@ -588,6 +588,15 @@
   border-right: none;
   overflow: hidden;
   flex-shrink: 0;
+  -webkit-user-select: none;
+  user-select: none;
+}
+/* Inputs inside the mate sidebar remain selectable. */
+#mate-sidebar-column input,
+#mate-sidebar-column textarea,
+#mate-sidebar-column [contenteditable="true"] {
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 #mate-sidebar-column.hidden {
@@ -1015,59 +1024,18 @@ body.mate-dm-active #layout.sidebar-collapsed .mate-collapsed-info {
   text-overflow: ellipsis;
 }
 
-/* Mate sidebar tools: icon+caption grid, matches #session-actions. */
+/* Mate sidebar tools: icon+caption grid, matches #session-actions.
+   Tile styling comes from .palette-tile in sidebar.css. */
+#mate-sidebar-tools-wrap {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 4px;
+}
 #mate-sidebar-tools {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 4px;
-  padding: 8px 8px 4px;
-  flex-shrink: 0;
-  border-bottom: 1px solid var(--border-subtle);
-}
-
-#mate-sidebar-tools button {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  min-height: 58px;
-  padding: 6px 2px;
-  border: none;
-  background: none;
-  color: var(--text-muted);
-  font-size: 10px;
-  font-weight: 500;
-  font-family: inherit;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s;
-}
-
-#mate-sidebar-tools button:hover {
-  background: var(--sidebar-hover);
-  color: var(--text-secondary);
-}
-
-#mate-sidebar-tools button svg {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-
-#mate-sidebar-tools .tool-btn-label {
-  font-size: 10px;
-  font-weight: 500;
-  line-height: 1.15;
-  text-align: center;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  word-break: break-word;
+  padding: 0 8px 4px;
 }
 
 /* Knowledge editor panel (overlays main content) */

--- a/lib/public/css/mates.css
+++ b/lib/public/css/mates.css
@@ -1015,24 +1015,30 @@ body.mate-dm-active #layout.sidebar-collapsed .mate-collapsed-info {
   text-overflow: ellipsis;
 }
 
+/* Mate sidebar tools: icon+caption grid, matches #session-actions. */
 #mate-sidebar-tools {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
   padding: 8px 8px 4px;
   flex-shrink: 0;
   border-bottom: 1px solid var(--border-subtle);
 }
 
 #mate-sidebar-tools button {
+  position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  padding: 6px 10px;
+  justify-content: center;
+  gap: 4px;
+  min-height: 58px;
+  padding: 6px 2px;
   border: none;
   background: none;
   color: var(--text-muted);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: 500;
   font-family: inherit;
   border-radius: 8px;
   cursor: pointer;
@@ -1047,6 +1053,21 @@ body.mate-dm-active #layout.sidebar-collapsed .mate-collapsed-info {
 #mate-sidebar-tools button svg {
   width: 16px;
   height: 16px;
+  flex-shrink: 0;
+}
+
+#mate-sidebar-tools .tool-btn-label {
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.15;
+  text-align: center;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
 }
 
 /* Knowledge editor panel (overlays main content) */

--- a/lib/public/css/notifications-center.css
+++ b/lib/public/css/notifications-center.css
@@ -41,6 +41,38 @@
   width: 340px;
 }
 
+/* "Clear all" pill — appears at the top of the stack when 2+ banners
+   are showing. Small, muted, aligned to the right so it sits above the
+   banners' corner without stealing attention. */
+.notif-banner-clear-all {
+  pointer-events: auto;
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  background: color-mix(in srgb, var(--bg-alt, #1a1a2e) 75%, transparent);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border, #333);
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(var(--shadow-rgb, 0,0,0), 0.2);
+  transition: color 0.15s, background 0.15s;
+}
+.notif-banner-clear-all:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg-alt, #1a1a2e) 90%, transparent);
+}
+.notif-banner-clear-all .lucide {
+  width: 12px;
+  height: 12px;
+}
+
 /* Individual banner (frosted glass) */
 .notif-banner {
   display: flex;

--- a/lib/public/css/overlays.css
+++ b/lib/public/css/overlays.css
@@ -98,30 +98,13 @@ button.top-bar-pill.pill-accent:hover { background: color-mix(in srgb, var(--acc
 .top-bar-install-btn.hidden { display: none; }
 .pwa-standalone .top-bar-install-btn { display: none !important; }
 
-/* Share button — desktop only, same style as install pill */
-.top-bar-share-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  color: var(--accent);
-  border: none;
-  border-radius: 10px;
-  padding: 2px 10px;
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 600;
-  cursor: pointer;
-  white-space: nowrap;
-  line-height: 1;
-  transition: background 0.15s;
-}
-.top-bar-share-btn .lucide { width: 12px; height: 12px; }
-.top-bar-share-btn:hover { background: color-mix(in srgb, var(--accent) 20%, transparent); }
+/* Share button sits in .top-bar-actions with the bell/settings icons
+   and inherits their shared icon-button styling. Hide on mobile and
+   inside PWA standalone (matches previous pill behavior). */
 @media (max-width: 768px) {
-  .top-bar-share-btn { display: none; }
+  #share-pill { display: none; }
 }
-.pwa-standalone .top-bar-share-btn { display: none !important; }
+.pwa-standalone #share-pill { display: none !important; }
 
 /* Extension pill button — same style as share/install pills */
 .ext-pill-wrap {

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -18,6 +18,21 @@
   overflow: hidden;
 }
 
+/* Sidebar items aren't meant to be text-selected — the sidebar is for
+   navigation and drag-reorder. Disabling selection avoids accidental
+   highlights during clicks and drags. Inputs and contenteditables
+   inside the sidebar re-enable selection so users can still edit. */
+#sidebar-column {
+  -webkit-user-select: none;
+  user-select: none;
+}
+#sidebar-column input,
+#sidebar-column textarea,
+#sidebar-column [contenteditable="true"] {
+  -webkit-user-select: text;
+  user-select: text;
+}
+
 #layout.sidebar-collapsed #sidebar-column {
   width: 0 !important;
   min-width: 0 !important;
@@ -273,45 +288,213 @@
   border-bottom: 1px solid var(--border-subtle);
   padding-bottom: 4px;
 }
-#sidebar-tools-toggle {
+
+/* Section header: the "Tools" label was redundant next to a grid of
+   labeled icons, so the header is now just the Edit pill right-aligned
+   above the grid. Kept as its own row instead of overlaying the grid
+   so it never collides with a tile or its badge. */
+.sidebar-tools-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  margin: 0;
-  padding: 8px 8px 4px 0;
-  box-sizing: border-box;
+  justify-content: flex-end;
+  padding: 4px 8px 2px;
+}
+
+/* Edit pill: muted by default, never a primary affordance. */
+.tool-palette-edit-btn {
   background: none;
   border: none;
   cursor: pointer;
+  font-family: inherit;
   font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dimmer);
+  padding: 2px 8px;
+  border-radius: 6px;
+  letter-spacing: 0.2px;
+  transition: background 0.15s, color 0.15s;
+}
+.tool-palette-edit-btn:hover {
+  background: var(--sidebar-hover);
+  color: var(--text-muted);
+}
+.tool-palette-edit-btn.active {
+  background: var(--accent);
+  color: #fff;
+}
+.tool-palette-edit-btn.active:hover {
+  background: var(--accent);
+  color: #fff;
+  filter: brightness(1.1);
+}
+
+/* Hidden-tools section appears only in edit mode when items are hidden. */
+.tool-palette-hidden-section {
+  padding: 4px 8px 8px;
+  border-top: 1px dashed var(--border-subtle);
+  margin-top: 4px;
+}
+.tool-palette-hidden-section.hidden {
+  display: none;
+}
+.tool-palette-hidden-label {
+  font-size: 10px;
   font-weight: 600;
   color: var(--text-dimmer);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  font-family: inherit;
+  padding: 2px 4px 6px;
 }
-#sidebar-tools-toggle:hover {
+.tool-palette-hidden-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+}
+
+/* --- Shared tile style (applies in both active and hidden grids) --- */
+.palette-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-height: 58px;
+  padding: 6px 2px;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
   color: var(--text-muted);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
 }
-.sidebar-tools-chevron {
-  width: 14px;
-  height: 14px;
-  transition: transform 0.15s;
-}
-#sidebar-tools #session-actions {
-  max-height: 300px;
+.palette-tile .lucide { width: 16px; height: 16px; flex-shrink: 0; }
+.palette-tile:hover { background: var(--sidebar-hover); color: var(--text-secondary); }
+.palette-tile.active { background: var(--sidebar-hover); color: var(--text); }
+.palette-tile .tool-btn-label {
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.15;
+  text-align: center;
+  max-width: 100%;
   overflow: hidden;
-  transition: max-height 0.2s ease, opacity 0.2s ease;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  word-break: break-word;
+}
+
+/* --- Edit mode affordances (shared across session + mate palettes) --- */
+
+/* × remove badge on each tile. Hidden in normal mode; shown in edit. */
+.tool-palette-remove {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.6);
+  pointer-events: none;
+  transition: opacity 0.15s, transform 0.15s;
+  z-index: 2;
+  user-select: none;
+}
+.edit-mode .tool-palette-remove {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+.edit-mode .tool-palette-remove:hover {
+  filter: brightness(1.15);
+}
+
+/* Drag-reorder feedback. Tiles are draggable at all times (macOS dock
+   pattern) so users can rearrange without entering a separate mode.
+   -webkit-user-drag is explicit for Safari, which otherwise sometimes
+   ignores draggable when user-select is none on an ancestor. Edit mode
+   adds the outline so the tiles read as mutable during an edit. */
+#session-actions [data-tool-id],
+#mate-sidebar-tools [data-tool-id] {
+  -webkit-user-drag: element;
+}
+.edit-mode [data-tool-id] {
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+}
+[data-tool-id].dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+/* Children shouldn't swallow drag events — the browser starts drag on
+   the element under the pointer, and we want that to always be the
+   draggable button, not the inner icon/label/badge. The × affordance
+   stays interactive (it needs clicks in edit mode). */
+[data-tool-id] > i,
+[data-tool-id] > svg,
+[data-tool-id] > .tool-btn-label,
+[data-tool-id] > .sidebar-badge {
+  pointer-events: none;
+}
+
+/* Hidden-section tiles are dimmed to signal "not active" and get a small
+   + glyph on hover to suggest they can be restored. */
+.tool-palette-hidden-grid [data-tool-id] {
+  opacity: 0.55;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+.tool-palette-hidden-grid [data-tool-id]:hover {
   opacity: 1;
 }
-#sidebar-tools.collapsed .sidebar-tools-chevron {
-  transform: rotate(-90deg);
+.tool-palette-hidden-grid .tool-palette-remove {
+  display: none;
 }
-#sidebar-tools.collapsed #session-actions {
-  max-height: 0;
-  opacity: 0;
-  padding-bottom: 0;
+.tool-palette-hidden-grid .sidebar-badge {
+  display: none;
+}
+
+/* Right-click context menu on palette tiles. Mirrors .session-ctx-menu. */
+.tool-palette-ctx-menu {
+  position: fixed;
+  background: var(--sidebar-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 4px 0;
+  min-width: 180px;
+  box-shadow: 0 4px 16px rgba(var(--shadow-rgb), 0.4);
+  z-index: 9999;
+  font-family: inherit;
+}
+.tool-palette-ctx-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s;
+}
+.tool-palette-ctx-item:hover {
+  background: rgba(var(--overlay-rgb), 0.05);
 }
 /* --- Sessions header (pinned above scroll) --- */
 #sidebar-sessions-header {

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -303,22 +303,35 @@
   padding: 0;
 }
 
-/* Dim inline hint that advertises the Cmd/Ctrl+O keyboard shortcut.
-   Clickable too, so users who read the hint can also act on it. */
+/* Small shortcut-pill for the Cmd/Ctrl+O hotkey overlay. Mirrors the
+   icon-strip hotkey hints so keyboard shortcuts look the same across
+   the sidebar surface. */
 .sidebar-tools-hint {
-  font-size: 10px;
-  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  padding: 2px 4px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-alt);
   color: var(--text-dimmer);
-  letter-spacing: 0.2px;
+  font-size: 10px;
+  font-weight: 600;
+  font-family: inherit;
+  border-radius: 6px;
   cursor: pointer;
   opacity: 0.7;
-  transition: opacity 0.15s;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
 }
 .sidebar-tools-hint:hover {
   opacity: 1;
+  color: var(--text-muted);
+  background: var(--bg);
 }
 
-/* Pencil-icon edit button, far-right of the header. */
+/* Pencil-icon edit button, far-right of the header. Dim by default so
+   it doesn't pull attention; on hover it brightens to signal that
+   it's a real affordance. */
 .tool-palette-edit-btn {
   margin-left: auto;
   display: inline-flex;
@@ -330,8 +343,9 @@
   border: none;
   cursor: pointer;
   color: var(--text-dimmer);
+  opacity: 0.45;
   border-radius: 6px;
-  transition: background 0.15s, color 0.15s;
+  transition: background 0.15s, color 0.15s, opacity 0.15s;
 }
 .tool-palette-edit-btn .lucide,
 .tool-palette-edit-btn svg {
@@ -341,14 +355,17 @@
 .tool-palette-edit-btn:hover {
   background: var(--sidebar-hover);
   color: var(--text-muted);
+  opacity: 1;
 }
 .tool-palette-edit-btn.active {
   background: var(--accent);
   color: #fff;
+  opacity: 1;
 }
 .tool-palette-edit-btn.active:hover {
   background: var(--accent);
   color: #fff;
+  opacity: 1;
   filter: brightness(1.1);
 }
 

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -467,6 +467,33 @@
   display: none;
 }
 
+/* Hotkey badge shown on each active palette tile while Cmd/Ctrl+O pick
+   mode is active. Top-left so it doesn't collide with the × (top-right)
+   or count badges. High-contrast accent so the keystroke is obvious. */
+.tool-palette-hotkey-badge {
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+  pointer-events: none;
+  z-index: 3;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  animation: tool-palette-hotkey-in 0.12s ease-out;
+}
+@keyframes tool-palette-hotkey-in {
+  from { opacity: 0; transform: scale(0.7); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
 /* Right-click context menu on palette tiles. Mirrors .session-ctx-menu. */
 .tool-palette-ctx-menu {
   position: fixed;

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -289,30 +289,54 @@
   padding-bottom: 4px;
 }
 
-/* Section header: the "Tools" label was redundant next to a grid of
-   labeled icons, so the header is now just the Edit pill right-aligned
-   above the grid. Kept as its own row instead of overlaying the grid
-   so it never collides with a tile or its badge. */
+/* Section header: "Tools" label on the left, a dim keyboard-hint next
+   to it explaining the Cmd+O shortcut, and a small pencil icon edit
+   button right-aligned. Three elements but each does just one thing,
+   so nothing reads as pushy. */
 .sidebar-tools-header {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  padding: 4px 8px 2px;
+  gap: 8px;
+  padding: 4px 8px 2px 12px;
+}
+.sidebar-tools-header .sidebar-section-label {
+  padding: 0;
 }
 
-/* Edit pill: muted by default, never a primary affordance. */
+/* Dim inline hint that advertises the Cmd/Ctrl+O keyboard shortcut.
+   Clickable too, so users who read the hint can also act on it. */
+.sidebar-tools-hint {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-dimmer);
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+.sidebar-tools-hint:hover {
+  opacity: 1;
+}
+
+/* Pencil-icon edit button, far-right of the header. */
 .tool-palette-edit-btn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
   background: none;
   border: none;
   cursor: pointer;
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 500;
   color: var(--text-dimmer);
-  padding: 2px 8px;
   border-radius: 6px;
-  letter-spacing: 0.2px;
   transition: background 0.15s, color 0.15s;
+}
+.tool-palette-edit-btn .lucide,
+.tool-palette-edit-btn svg {
+  width: 13px;
+  height: 13px;
 }
 .tool-palette-edit-btn:hover {
   background: var(--sidebar-hover);
@@ -434,10 +458,26 @@
 }
 .edit-mode [data-tool-id] {
   box-shadow: inset 0 0 0 1px var(--border-subtle);
+  animation: tile-wiggle 0.22s ease-in-out infinite;
+  transform-origin: 50% 50%;
 }
+/* Desync the wiggle across tiles so they don't swing in lockstep. */
+.edit-mode [data-tool-id]:nth-child(2n) {
+  animation-delay: -0.11s;
+}
+.edit-mode [data-tool-id]:nth-child(3n) {
+  animation-duration: 0.26s;
+}
+@keyframes tile-wiggle {
+  0%   { transform: rotate(-1.2deg); }
+  50%  { transform: rotate(1.2deg);  }
+  100% { transform: rotate(-1.2deg); }
+}
+/* The dragged tile shouldn't wiggle while under the cursor. */
 [data-tool-id].dragging {
   opacity: 0.4;
   cursor: grabbing;
+  animation: none;
 }
 /* Children shouldn't swallow drag events — the browser starts drag on
    the element under the pointer, and we want that to always be the

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -313,12 +313,6 @@
   opacity: 0;
   padding-bottom: 0;
 }
-.sidebar-tools-divider {
-  height: 1px;
-  background: var(--border-subtle);
-  margin: 4px 12px;
-}
-
 /* --- Sessions header (pinned above scroll) --- */
 #sidebar-sessions-header {
   flex-shrink: 0;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -70,7 +70,6 @@
           </div>
         </div>
       </div>
-      <button id="share-pill" class="top-bar-share-btn" title="Share"><i data-lucide="qr-code"></i> Share</button>
       <div id="update-pill-wrap" class="top-bar-update hidden">
         <button id="update-pill" class="top-bar-update-btn"><i data-lucide="arrow-up-circle"></i> <span id="update-version"></span> is available. Update now</button>
       <div id="update-popover" class="top-bar-popover">
@@ -84,6 +83,7 @@
       <!-- Pill badges -->
       <div id="skip-perms-pill" class="top-bar-pill pill-error hidden"><i data-lucide="shield-off"></i> <span>Skip perms</span></div>
       <div id="client-count" class="top-bar-pill pill-accent hidden"><i data-lucide="users"></i> <span id="client-count-text"></span></div>
+      <button id="share-pill" title="Share"><i data-lucide="share-2"></i></button>
       <button id="notif-center-btn" title="Notifications"><i data-lucide="bell"></i><span id="notif-center-badge" class="notif-badge hidden">0</span></button>
       <button id="server-settings-btn" title="Server settings"><i data-lucide="settings"></i></button>
     </div>

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -238,6 +238,11 @@
             <input id="fb-search-input" type="text" placeholder="Search files..." autocomplete="off" spellcheck="false" />
           </div>
           <div id="file-tree"></div>
+          <div class="fb-kb-hint">
+            <kbd>&#8593;&#8595;</kbd><span>nav</span>
+            <kbd>&#8592;&#8594;</kbd><span>fold</span>
+            <kbd>&#8629;</kbd><span>open</span>
+          </div>
         </div>
       </div>
     </div>

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -184,7 +184,9 @@
       <div id="sidebar">
         <div id="sidebar-tools">
           <div class="sidebar-tools-header">
-            <button type="button" class="tool-palette-edit-btn" data-palette="session" aria-label="Edit tool palette">Edit</button>
+            <span class="sidebar-section-label">Tools</span>
+            <span class="sidebar-tools-hint" data-palette="session" title="Show keyboard hotkeys"></span>
+            <button type="button" class="tool-palette-edit-btn" data-palette="session" aria-label="Edit tool palette" title="Edit palette"><i data-lucide="pencil"></i></button>
           </div>
           <div id="session-actions"></div>
           <div id="session-actions-hidden" class="tool-palette-hidden-section hidden"></div>
@@ -249,7 +251,9 @@
       </div>
       <div id="mate-sidebar-tools-wrap">
         <div class="sidebar-tools-header">
-          <button type="button" class="tool-palette-edit-btn" data-palette="mate" aria-label="Edit tool palette">Edit</button>
+          <span class="sidebar-section-label">Tools</span>
+          <span class="sidebar-tools-hint" data-palette="mate" title="Show keyboard hotkeys"></span>
+          <button type="button" class="tool-palette-edit-btn" data-palette="mate" aria-label="Edit tool palette" title="Edit palette"><i data-lucide="pencil"></i></button>
         </div>
         <div id="mate-sidebar-tools"></div>
         <div id="mate-sidebar-tools-hidden" class="tool-palette-hidden-section hidden"></div>

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -105,8 +105,10 @@
       <div class="skeleton-icon-strip-item"></div>
     </div>
     <button class="icon-strip-add" id="icon-strip-add" title="Add project"><i data-lucide="plus"></i></button>
-    <button type="button" class="icon-strip-hint hidden" id="icon-strip-hint-mate" data-switcher-mode="mate" aria-label="Switch mate"></button>
-    <div class="icon-strip-users hidden" id="icon-strip-users"></div>
+    <div class="icon-strip-mate-section" id="icon-strip-mate-section">
+      <button type="button" class="icon-strip-hint hidden" id="icon-strip-hint-mate" data-switcher-mode="mate" aria-label="Switch mate"></button>
+      <div class="icon-strip-users hidden" id="icon-strip-users"></div>
+    </div>
     <div class="icon-strip-me" id="icon-strip-me"></div>
   </div>
 

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -188,15 +188,13 @@
             <i data-lucide="chevron-down" class="sidebar-tools-chevron"></i>
           </button>
           <div id="session-actions">
-            <button id="file-browser-btn"><i data-lucide="folder-tree"></i> <span>File browser</span></button>
-            <button id="terminal-sidebar-btn"><i data-lucide="square-terminal"></i> <span>Terminal</span><span id="terminal-sidebar-count" class="sidebar-badge hidden"></span></button>
-            <button id="sticky-notes-sidebar-btn"><i data-lucide="sticky-note"></i> <span>Sticky Notes</span><span id="sticky-notes-sidebar-count" class="sidebar-badge hidden"></span></button>
-            <div class="sidebar-tools-divider"></div>
-            <button id="email-sidebar-btn"><i data-lucide="mail"></i> <span>Email</span></button>
-            <button id="mcp-btn"><i data-lucide="cable"></i> <span>MCP Servers</span><span id="mcp-sidebar-count" class="sidebar-badge hidden"></span></button>
-            <button id="skills-btn"><i data-lucide="puzzle"></i> <span>Skills</span></button>
-            <div class="sidebar-tools-divider"></div>
-            <button id="scheduler-btn"><i data-lucide="calendar-clock"></i> <span>Scheduled Tasks</span></button>
+            <button id="file-browser-btn" title="File browser" aria-label="File browser"><i data-lucide="folder-tree"></i><span class="tool-btn-label">File browser</span></button>
+            <button id="terminal-sidebar-btn" title="Terminal" aria-label="Terminal"><i data-lucide="square-terminal"></i><span class="tool-btn-label">Terminal</span><span id="terminal-sidebar-count" class="sidebar-badge hidden"></span></button>
+            <button id="sticky-notes-sidebar-btn" title="Sticky Notes" aria-label="Sticky Notes"><i data-lucide="sticky-note"></i><span class="tool-btn-label">Sticky Notes</span><span id="sticky-notes-sidebar-count" class="sidebar-badge hidden"></span></button>
+            <button id="email-sidebar-btn" title="Email" aria-label="Email"><i data-lucide="mail"></i><span class="tool-btn-label">Email</span></button>
+            <button id="mcp-btn" title="MCP Servers" aria-label="MCP Servers"><i data-lucide="cable"></i><span class="tool-btn-label">MCP Servers</span><span id="mcp-sidebar-count" class="sidebar-badge hidden"></span></button>
+            <button id="skills-btn" title="Skills" aria-label="Skills"><i data-lucide="puzzle"></i><span class="tool-btn-label">Skills</span></button>
+            <button id="scheduler-btn" title="Scheduled Tasks" aria-label="Scheduled Tasks"><i data-lucide="calendar-clock"></i><span class="tool-btn-label">Scheduled Tasks</span></button>
           </div>
         </div>
         <div id="sidebar-sessions-header">
@@ -258,13 +256,13 @@
         <button id="mate-sidebar-toggle-btn" class="sidebar-collapse-btn" title="Collapse sidebar"><i data-lucide="panel-left-close"></i></button>
       </div>
       <div id="mate-sidebar-tools">
-        <button id="mate-memory-btn"><i data-lucide="brain"></i> <span>Memory</span><span id="mate-memory-count" class="sidebar-badge hidden"></span></button>
-        <button id="mate-knowledge-btn"><i data-lucide="book-open"></i> <span>Knowledge</span><span id="mate-knowledge-count" class="sidebar-badge hidden"></span></button>
-        <button id="mate-sticky-notes-btn"><i data-lucide="sticky-note"></i> <span>Sticky Notes</span></button>
-        <button id="mate-email-btn"><i data-lucide="mail"></i> <span>Email</span></button>
-        <button id="mate-mcp-btn"><i data-lucide="cable"></i> <span>MCP Servers</span><span id="mate-mcp-sidebar-count" class="sidebar-badge hidden"></span></button>
-        <button id="mate-skills-btn"><i data-lucide="puzzle"></i> <span>Skills</span></button>
-        <button id="mate-scheduler-btn"><i data-lucide="calendar-clock"></i> <span>Scheduled Tasks</span></button>
+        <button id="mate-memory-btn" title="Memory" aria-label="Memory"><i data-lucide="brain"></i><span class="tool-btn-label">Memory</span><span id="mate-memory-count" class="sidebar-badge hidden"></span></button>
+        <button id="mate-knowledge-btn" title="Knowledge" aria-label="Knowledge"><i data-lucide="book-open"></i><span class="tool-btn-label">Knowledge</span><span id="mate-knowledge-count" class="sidebar-badge hidden"></span></button>
+        <button id="mate-sticky-notes-btn" title="Sticky Notes" aria-label="Sticky Notes"><i data-lucide="sticky-note"></i><span class="tool-btn-label">Sticky Notes</span></button>
+        <button id="mate-email-btn" title="Email" aria-label="Email"><i data-lucide="mail"></i><span class="tool-btn-label">Email</span></button>
+        <button id="mate-mcp-btn" title="MCP Servers" aria-label="MCP Servers"><i data-lucide="cable"></i><span class="tool-btn-label">MCP Servers</span><span id="mate-mcp-sidebar-count" class="sidebar-badge hidden"></span></button>
+        <button id="mate-skills-btn" title="Skills" aria-label="Skills"><i data-lucide="puzzle"></i><span class="tool-btn-label">Skills</span></button>
+        <button id="mate-scheduler-btn" title="Scheduled Tasks" aria-label="Scheduled Tasks"><i data-lucide="calendar-clock"></i><span class="tool-btn-label">Scheduled Tasks</span></button>
       </div>
       <div id="mate-sidebar-conversations">
         <div class="mate-sidebar-sessions-header">

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -183,19 +183,11 @@
       </div>
       <div id="sidebar">
         <div id="sidebar-tools">
-          <button id="sidebar-tools-toggle" type="button">
-            <span class="sidebar-section-label">Tools</span>
-            <i data-lucide="chevron-down" class="sidebar-tools-chevron"></i>
-          </button>
-          <div id="session-actions">
-            <button id="file-browser-btn" title="File browser" aria-label="File browser"><i data-lucide="folder-tree"></i><span class="tool-btn-label">File browser</span></button>
-            <button id="terminal-sidebar-btn" title="Terminal" aria-label="Terminal"><i data-lucide="square-terminal"></i><span class="tool-btn-label">Terminal</span><span id="terminal-sidebar-count" class="sidebar-badge hidden"></span></button>
-            <button id="sticky-notes-sidebar-btn" title="Sticky Notes" aria-label="Sticky Notes"><i data-lucide="sticky-note"></i><span class="tool-btn-label">Sticky Notes</span><span id="sticky-notes-sidebar-count" class="sidebar-badge hidden"></span></button>
-            <button id="email-sidebar-btn" title="Email" aria-label="Email"><i data-lucide="mail"></i><span class="tool-btn-label">Email</span></button>
-            <button id="mcp-btn" title="MCP Servers" aria-label="MCP Servers"><i data-lucide="cable"></i><span class="tool-btn-label">MCP Servers</span><span id="mcp-sidebar-count" class="sidebar-badge hidden"></span></button>
-            <button id="skills-btn" title="Skills" aria-label="Skills"><i data-lucide="puzzle"></i><span class="tool-btn-label">Skills</span></button>
-            <button id="scheduler-btn" title="Scheduled Tasks" aria-label="Scheduled Tasks"><i data-lucide="calendar-clock"></i><span class="tool-btn-label">Scheduled Tasks</span></button>
+          <div class="sidebar-tools-header">
+            <button type="button" class="tool-palette-edit-btn" data-palette="session" aria-label="Edit tool palette">Edit</button>
           </div>
+          <div id="session-actions"></div>
+          <div id="session-actions-hidden" class="tool-palette-hidden-section hidden"></div>
         </div>
         <div id="sidebar-sessions-header">
           <div id="sessions-header-content">
@@ -255,14 +247,12 @@
         <div id="mate-sidebar-seed-tooltip" class="mate-seed-tooltip hidden"></div>
         <button id="mate-sidebar-toggle-btn" class="sidebar-collapse-btn" title="Collapse sidebar"><i data-lucide="panel-left-close"></i></button>
       </div>
-      <div id="mate-sidebar-tools">
-        <button id="mate-memory-btn" title="Memory" aria-label="Memory"><i data-lucide="brain"></i><span class="tool-btn-label">Memory</span><span id="mate-memory-count" class="sidebar-badge hidden"></span></button>
-        <button id="mate-knowledge-btn" title="Knowledge" aria-label="Knowledge"><i data-lucide="book-open"></i><span class="tool-btn-label">Knowledge</span><span id="mate-knowledge-count" class="sidebar-badge hidden"></span></button>
-        <button id="mate-sticky-notes-btn" title="Sticky Notes" aria-label="Sticky Notes"><i data-lucide="sticky-note"></i><span class="tool-btn-label">Sticky Notes</span></button>
-        <button id="mate-email-btn" title="Email" aria-label="Email"><i data-lucide="mail"></i><span class="tool-btn-label">Email</span></button>
-        <button id="mate-mcp-btn" title="MCP Servers" aria-label="MCP Servers"><i data-lucide="cable"></i><span class="tool-btn-label">MCP Servers</span><span id="mate-mcp-sidebar-count" class="sidebar-badge hidden"></span></button>
-        <button id="mate-skills-btn" title="Skills" aria-label="Skills"><i data-lucide="puzzle"></i><span class="tool-btn-label">Skills</span></button>
-        <button id="mate-scheduler-btn" title="Scheduled Tasks" aria-label="Scheduled Tasks"><i data-lucide="calendar-clock"></i><span class="tool-btn-label">Scheduled Tasks</span></button>
+      <div id="mate-sidebar-tools-wrap">
+        <div class="sidebar-tools-header">
+          <button type="button" class="tool-palette-edit-btn" data-palette="mate" aria-label="Edit tool palette">Edit</button>
+        </div>
+        <div id="mate-sidebar-tools"></div>
+        <div id="mate-sidebar-tools-hidden" class="tool-palette-hidden-section hidden"></div>
       </div>
       <div id="mate-sidebar-conversations">
         <div class="mate-sidebar-sessions-header">

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -99,11 +99,13 @@
       <img class="icon-strip-logo" src="icon-banded-76.png" width="38" height="38" alt="Clay">
     </div>
     <div class="icon-strip-separator"></div>
+    <button type="button" class="icon-strip-hint" id="icon-strip-hint-project" data-switcher-mode="project" aria-label="Switch project"></button>
     <div class="icon-strip-projects" id="icon-strip-projects">
       <div class="skeleton-icon-strip-item"></div>
       <div class="skeleton-icon-strip-item"></div>
     </div>
     <button class="icon-strip-add" id="icon-strip-add" title="Add project"><i data-lucide="plus"></i></button>
+    <button type="button" class="icon-strip-hint hidden" id="icon-strip-hint-mate" data-switcher-mode="mate" aria-label="Switch mate"></button>
     <div class="icon-strip-users hidden" id="icon-strip-users"></div>
     <div class="icon-strip-me" id="icon-strip-me"></div>
   </div>

--- a/lib/public/modules/app-notifications.js
+++ b/lib/public/modules/app-notifications.js
@@ -126,6 +126,7 @@ function showBanner(notif, autoDismissMs) {
 
   bannerContainer.appendChild(banner);
   refreshIcons();
+  ensureClearAllButton();
 
   requestAnimationFrame(function () {
     banner.classList.add("show");
@@ -204,9 +205,60 @@ function removeBanner(banner) {
   if (!banner || !banner.parentNode) return;
   banner.classList.remove("show");
   banner.classList.add("hide");
+  // Update the clear-all button right away so it disappears before the
+  // last banner finishes animating out, and again after the node is
+  // actually removed in case the count check depends on DOM presence.
+  ensureClearAllButton();
   setTimeout(function () {
     if (banner.parentNode) banner.parentNode.removeChild(banner);
+    ensureClearAllButton();
   }, 300);
+}
+
+// Count real (non-"_empty", not in hide animation) banners to decide
+// whether a Clear-all affordance is worth showing.
+function countActiveBanners() {
+  if (!bannerContainer) return 0;
+  var banners = bannerContainer.querySelectorAll('.notif-banner');
+  var n = 0;
+  for (var i = 0; i < banners.length; i++) {
+    if (banners[i].classList.contains('hide')) continue;
+    if (banners[i].getAttribute('data-notif-id')) n++;
+  }
+  return n;
+}
+
+function ensureClearAllButton() {
+  if (!bannerContainer) return;
+  var existing = bannerContainer.querySelector('.notif-banner-clear-all');
+  if (countActiveBanners() >= 2) {
+    if (existing) return;
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'notif-banner-clear-all';
+    btn.innerHTML = iconHtml('x') + '<span>Clear all</span>';
+    btn.addEventListener('click', clearAllBanners);
+    bannerContainer.insertBefore(btn, bannerContainer.firstChild);
+    refreshIcons();
+  } else if (existing && existing.parentNode) {
+    existing.parentNode.removeChild(existing);
+  }
+}
+
+function clearAllBanners() {
+  var ws = getWs();
+  if (ws && ws.readyState === 1) {
+    ws.send(JSON.stringify({ type: 'notification_dismiss_all' }));
+  }
+  // Dismiss visually right away — the server will broadcast
+  // notification_dismissed_all too, but doing it optimistically makes
+  // the click feel instant.
+  if (bannerContainer) {
+    var banners = bannerContainer.querySelectorAll('.notif-banner[data-notif-id]');
+    for (var i = 0; i < banners.length; i++) removeBanner(banners[i]);
+  }
+  var btn = bannerContainer && bannerContainer.querySelector('.notif-banner-clear-all');
+  if (btn && btn.parentNode) btn.parentNode.removeChild(btn);
 }
 
 function sendPermissionResponse(requestId, decision, slug) {

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -35,6 +35,38 @@ export function initFileBrowser(_ctx) {
     }
   });
 
+  // --- Keyboard navigation ---
+  // Arrow keys move a "keyboard focus" ring through visible tree items,
+  // Enter activates (opens a file or toggles a folder), Left/Right
+  // collapses/expands folders and ascends/descends into them. The tree
+  // gets a tabindex so it can receive focus and keydown events.
+  if (ctx.fileTreeEl) {
+    ctx.fileTreeEl.setAttribute('tabindex', '0');
+    ctx.fileTreeEl.addEventListener('keydown', handleTreeKeyDown);
+    // When the user clicks any tree row, promote it to keyboard focus
+    // as well so subsequent arrow keys continue from that position.
+    ctx.fileTreeEl.addEventListener('click', function (e) {
+      var row = e.target && e.target.closest && e.target.closest('.file-tree-item');
+      if (row) setKbFocus(row);
+    });
+  }
+
+  // Search input <-> tree keyboard bridge:
+  //   Enter in the search box drops focus back onto the tree and
+  //   highlights the first visible result so the user can keep
+  //   navigating with arrows. ArrowDown does the same for convenience.
+  var searchInput = document.getElementById('fb-search-input');
+  if (searchInput) {
+    searchInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        focusFileTree();
+        var items = getVisibleTreeItems();
+        if (items.length) setKbFocus(items[0]);
+      }
+    });
+  }
+
   // --- Drag-and-drop file paths into message input ---
   var inputEl = document.getElementById("input");
   var dropHintEl = null;
@@ -208,6 +240,145 @@ export function initFileBrowser(_ctx) {
       }
     });
   }
+}
+
+// --- Keyboard navigation helpers ---
+
+var _kbFocused = null;
+
+export function focusFileTree() {
+  if (!ctx || !ctx.fileTreeEl) return;
+  ctx.fileTreeEl.focus();
+  if (!_kbFocused) {
+    var first = ctx.fileTreeEl.querySelector('.file-tree-item');
+    if (first) setKbFocus(first);
+  }
+}
+
+function setKbFocus(el) {
+  if (_kbFocused && _kbFocused !== el) _kbFocused.classList.remove('fb-kb-focus');
+  _kbFocused = el || null;
+  if (el) {
+    el.classList.add('fb-kb-focus');
+    if (el.scrollIntoView) el.scrollIntoView({ block: 'nearest' });
+  }
+}
+
+function isDirRow(row) {
+  // Folder rows carry the chevron; file rows use a spacer instead.
+  return !!(row && row.querySelector && row.querySelector('.file-tree-chevron'));
+}
+
+function getVisibleTreeItems() {
+  if (!ctx || !ctx.fileTreeEl) return [];
+  var all = ctx.fileTreeEl.querySelectorAll('.file-tree-item');
+  var out = [];
+  for (var i = 0; i < all.length; i++) {
+    var el = all[i];
+    // Skip anything nested inside a hidden .file-tree-children subtree.
+    var hidden = false;
+    var p = el.parentNode;
+    while (p && p !== ctx.fileTreeEl) {
+      if (p.classList && p.classList.contains('file-tree-children') && p.classList.contains('hidden')) {
+        hidden = true;
+        break;
+      }
+      p = p.parentNode;
+    }
+    if (!hidden) out.push(el);
+  }
+  return out;
+}
+
+function moveKbFocus(delta) {
+  var items = getVisibleTreeItems();
+  if (items.length === 0) return;
+  var idx = _kbFocused ? items.indexOf(_kbFocused) : -1;
+  if (idx === -1) {
+    idx = delta > 0 ? 0 : items.length - 1;
+  } else {
+    idx = Math.max(0, Math.min(items.length - 1, idx + delta));
+  }
+  setKbFocus(items[idx]);
+}
+
+function kbExpandOrDescend() {
+  if (!_kbFocused) return;
+  if (!isDirRow(_kbFocused)) return;
+  if (!_kbFocused.classList.contains('expanded')) {
+    _kbFocused.click(); // triggers the existing expand handler
+    return;
+  }
+  // Already expanded — move focus to first child.
+  var children = _kbFocused.nextElementSibling;
+  if (children && children.classList.contains('file-tree-children')) {
+    var first = children.querySelector('.file-tree-item');
+    if (first) setKbFocus(first);
+  }
+}
+
+function kbCollapseOrAscend() {
+  if (!_kbFocused) return;
+  if (isDirRow(_kbFocused) && _kbFocused.classList.contains('expanded')) {
+    _kbFocused.click(); // triggers existing collapse handler
+    return;
+  }
+  // On a file or a collapsed folder — move focus to the parent folder.
+  var container = _kbFocused.parentNode;
+  if (container && container.classList && container.classList.contains('file-tree-children')) {
+    var parentRow = container.previousElementSibling;
+    if (parentRow && parentRow.classList && parentRow.classList.contains('file-tree-item')) {
+      setKbFocus(parentRow);
+    }
+  }
+}
+
+function kbActivate() {
+  if (_kbFocused) _kbFocused.click();
+}
+
+function handleTreeKeyDown(e) {
+  // Any arrow key with an empty tree (e.g. "No files found" for a
+  // search query) hands focus back to the search input so the user
+  // can fix the query without clicking.
+  var isArrow = e.key === 'ArrowDown' || e.key === 'ArrowUp'
+             || e.key === 'ArrowLeft' || e.key === 'ArrowRight';
+  if (isArrow && getVisibleTreeItems().length === 0) {
+    e.preventDefault();
+    var emptySearch = document.getElementById('fb-search-input');
+    if (emptySearch) {
+      if (_kbFocused) _kbFocused.classList.remove('fb-kb-focus');
+      _kbFocused = null;
+      emptySearch.focus();
+      try { emptySearch.select(); } catch (err) { /* ignore */ }
+    }
+    return;
+  }
+
+  if (e.key === 'ArrowDown') { e.preventDefault(); moveKbFocus(1); return; }
+  if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    // At the top of the visible tree, pressing Up hands focus to the
+    // search box — a natural escape upward. Enter there brings focus
+    // back to the tree (handled by the search input's keydown below).
+    var items = getVisibleTreeItems();
+    if (items.length && _kbFocused === items[0]) {
+      var searchInput = document.getElementById('fb-search-input');
+      if (searchInput) {
+        if (_kbFocused) _kbFocused.classList.remove('fb-kb-focus');
+        searchInput.focus();
+        try { searchInput.select(); } catch (err) { /* ignore */ }
+        return;
+      }
+    }
+    moveKbFocus(-1);
+    return;
+  }
+  if (e.key === 'ArrowRight'){ e.preventDefault(); kbExpandOrDescend(); return; }
+  if (e.key === 'ArrowLeft') { e.preventDefault(); kbCollapseOrAscend(); return; }
+  if (e.key === 'Enter')     { e.preventDefault(); kbActivate(); return; }
+  if (e.key === 'Home')      { e.preventDefault(); var items3 = getVisibleTreeItems(); if (items3.length) setKbFocus(items3[0]); return; }
+  if (e.key === 'End')       { e.preventDefault(); var items4 = getVisibleTreeItems(); if (items4.length) setKbFocus(items4[items4.length - 1]); return; }
 }
 
 // --- File watch helpers ---

--- a/lib/public/modules/input.js
+++ b/lib/public/modules/input.js
@@ -816,9 +816,14 @@ export function initInput(_ctx) {
       inputEl.dispatchEvent(new Event("input", { bubbles: true }));
     });
 
-    // Mate avatar overlay on @ button — rotate random mate faces
+    // Mate avatar overlay on @ button.
+    // The overlay is a quiet hint that you can @-mention a Mate for advice
+    // on the current session. To keep it from feeling like constant motion
+    // in the user's peripheral vision (see issue #325 item 2), the avatar
+    // is picked once per session entry and does NOT rotate on a timer.
+    // The avatar is rendered desaturated in CSS and only regains color on
+    // hover, so the change moment itself stays visually quiet too.
     var _lastOverlayIdx = -1;
-    var _overlayInterval = null;
 
     function getAvailableMates() {
       var mates = store.get('cachedMatesList') || [];
@@ -861,21 +866,17 @@ export function initInput(_ctx) {
       }, 300);
     }
 
-    function rotateMateOverlay() {
+    function refreshMateOverlay() {
       var available = getAvailableMates();
       setOverlayAvatar(pickNextMate(available));
     }
 
-    function startOverlayRotation() {
-      if (_overlayInterval) clearInterval(_overlayInterval);
-      rotateMateOverlay();
-      _overlayInterval = setInterval(rotateMateOverlay, 10000);
-    }
-
-    // Update overlay when mate list changes
+    // Refresh on initial mate list load and on session transition only.
     store.subscribe(function (state, prev) {
       if (state.cachedMatesList !== prev.cachedMatesList) {
-        startOverlayRotation();
+        refreshMateOverlay();
+      } else if (state.activeSessionId !== prev.activeSessionId) {
+        refreshMateOverlay();
       }
     });
   }

--- a/lib/public/modules/project-switcher.js
+++ b/lib/public/modules/project-switcher.js
@@ -84,10 +84,11 @@ export function initProjectSwitcher() {
     mateHint.addEventListener('click', function () { openSwitcherForMode('mate'); });
   }
 
-  // Mate hint piggybacks on the users-strip visibility: show when the
-  // mate list has any entries, hide otherwise. cachedMatesList is the
-  // source of truth; we also listen for changes to keep the hint in
-  // sync without touching sidebar-mates.js.
+  // Mate hint visibility piggybacks on cachedMatesList: show the pill
+  // whenever the mate list has any entries, hide otherwise. The users
+  // strip inside the same wrapper also hides itself (sidebar-mates.js
+  // toggles that), and the wrapper shrinks to nothing when both are
+  // hidden — no extra visibility bookkeeping needed on the wrapper.
   function refreshMateHintVisibility() {
     if (!mateHint) return;
     var mates = store.get('cachedMatesList') || [];

--- a/lib/public/modules/project-switcher.js
+++ b/lib/public/modules/project-switcher.js
@@ -1,0 +1,403 @@
+// project-switcher.js — macOS Cmd+Tab-style quick switcher.
+//
+// Two modes share the same overlay:
+//   Cmd/Ctrl+E  → projects only (non-Mate), activates via switchProject
+//   Cmd/Ctrl+M  → Mates only, activates via openDm
+//
+// While the modifier is still held, repeating the same shortcut cycles
+// forward and Shift cycles back. Releasing the modifier commits —
+// matching Cmd+Tab semantics. Enter commits explicitly; Escape cancels.
+//
+// Each mode has its own in-memory MRU list so the ordering stays
+// mode-specific (visiting projects shouldn't reorder the mate list,
+// and vice versa). No persistence — MRU is a transient hint and
+// project rule forbids localStorage for preferences.
+
+import { store } from './store.js';
+import { refreshIcons } from './icons.js';
+import { getCachedProjects, switchProject } from './app-projects.js';
+import { openDm } from './app-dm.js';
+import { mateAvatarUrl } from './avatar.js';
+import { parseEmojis } from './markdown.js';
+
+var _projectMru = [];   // project slugs, most recent first
+var _mateMru = [];      // mate ids (mate_XXX), most recent first
+var _overlay = null;
+var _list = null;
+var _headerEl = null;
+var _open = false;
+var _mode = 'project';  // 'project' | 'mate'
+var _highlightedIndex = 0;
+var _entries = [];
+
+export function openSwitcherForMode(mode) {
+  if (mode !== 'project' && mode !== 'mate') return;
+  if (_open) closeSwitcher(false);
+  openSwitcher(mode);
+}
+
+export function initProjectSwitcher() {
+  buildOverlayIfMissing();
+  _list = _overlay.querySelector('.cmd-palette-results');
+  _headerEl = _overlay.querySelector('.project-switcher-header');
+
+  // Seed MRUs from current state.
+  var seedSlug = store.get('currentSlug');
+  if (seedSlug) _projectMru = [seedSlug];
+  var seedTarget = store.get('dmTargetUser');
+  if (seedTarget && seedTarget.isMate && seedTarget.id) _mateMru = [seedTarget.id];
+
+  // Track MRUs by watching the store for navigation changes.
+  store.subscribe(function (state, prev) {
+    if (state.currentSlug && state.currentSlug !== prev.currentSlug) {
+      bumpMru(_projectMru, state.currentSlug);
+      _projectMru = _projectMru; // (keep reference; bumpMru mutates via reassignment)
+    }
+    var curMate = mateIdFrom(state.dmTargetUser);
+    var prevMate = mateIdFrom(prev.dmTargetUser);
+    if (curMate && curMate !== prevMate) bumpMru(_mateMru, curMate);
+  });
+
+  var backdrop = _overlay.querySelector('.cmd-palette-backdrop');
+  if (backdrop) backdrop.addEventListener('click', function () { closeSwitcher(false); });
+
+  document.addEventListener('keydown', handleKeyDown, true);
+  document.addEventListener('keyup', handleKeyUp, true);
+  window.addEventListener('blur', function () { if (_open) closeSwitcher(false); });
+
+  // Wire hotkey hint pills next to the icon strip so the keybinding is
+  // discoverable in the same surface users use for clicking. Clicking
+  // the pill is equivalent to pressing the shortcut itself.
+  var isMac = /Mac|iPhone|iPod|iPad/i.test(navigator.platform);
+  var projectHintLabel = isMac ? '\u2318E' : 'Ctrl+E';
+  var mateHintLabel    = isMac ? '\u2318M' : 'Ctrl+M';
+  var projectHint = document.getElementById('icon-strip-hint-project');
+  var mateHint    = document.getElementById('icon-strip-hint-mate');
+  if (projectHint) {
+    projectHint.textContent = projectHintLabel;
+    projectHint.title = 'Switch project (' + projectHintLabel + ')';
+    projectHint.addEventListener('click', function () { openSwitcherForMode('project'); });
+  }
+  if (mateHint) {
+    mateHint.textContent = mateHintLabel;
+    mateHint.title = 'Switch mate (' + mateHintLabel + ')';
+    mateHint.addEventListener('click', function () { openSwitcherForMode('mate'); });
+  }
+
+  // Mate hint piggybacks on the users-strip visibility: show when the
+  // mate list has any entries, hide otherwise. cachedMatesList is the
+  // source of truth; we also listen for changes to keep the hint in
+  // sync without touching sidebar-mates.js.
+  function refreshMateHintVisibility() {
+    if (!mateHint) return;
+    var mates = store.get('cachedMatesList') || [];
+    mateHint.classList.toggle('hidden', mates.length === 0);
+  }
+  refreshMateHintVisibility();
+  store.subscribe(function (state, prev) {
+    if (state.cachedMatesList !== prev.cachedMatesList) refreshMateHintVisibility();
+  });
+}
+
+function buildOverlayIfMissing() {
+  _overlay = document.getElementById('project-switcher');
+  if (_overlay) return;
+  var isMac = /Mac|iPhone|iPod|iPad/i.test(navigator.platform);
+  var modKbd = isMac ? '<kbd>\u2318</kbd>' : '<kbd>Ctrl</kbd>';
+  _overlay = document.createElement('div');
+  _overlay.id = 'project-switcher';
+  _overlay.className = 'cmd-palette hidden project-switcher';
+  _overlay.innerHTML =
+    '<div class="cmd-palette-backdrop"></div>' +
+    '<div class="cmd-palette-dialog project-switcher-dialog">' +
+      '<div class="project-switcher-header">Switch project</div>' +
+      '<div class="cmd-palette-results"></div>' +
+      '<div class="cmd-palette-footer project-switcher-footer">' +
+        '<span class="project-switcher-shortcuts">' + modKbd + '<kbd class="proj-next-key">E</kbd> next \u00b7 <kbd>\u21E7</kbd>' + modKbd + '<kbd class="proj-prev-key">E</kbd> prev \u00b7 <kbd>\u23CE</kbd> select \u00b7 <kbd>Esc</kbd> cancel</span>' +
+      '</div>' +
+    '</div>';
+  document.body.appendChild(_overlay);
+}
+
+function mateIdFrom(target) {
+  return target && target.isMate && target.id ? target.id : null;
+}
+
+function bumpMru(list, key) {
+  // Mutate the original array to preserve the module-level reference
+  // so subscribers / future reads see the update without a reassign.
+  var idx = list.indexOf(key);
+  if (idx !== -1) list.splice(idx, 1);
+  list.unshift(key);
+}
+
+function handleKeyDown(e) {
+  if (!e.key) return;
+  var isMod = (e.metaKey || e.ctrlKey) && !e.altKey;
+  var k = e.key.toLowerCase();
+
+  // Mode shortcuts: Cmd/Ctrl+E (projects) and Cmd/Ctrl+M (mates).
+  // Pressing the other shortcut while open switches mode; pressing the
+  // same shortcut cycles.
+  if (isMod && (k === 'e' || k === 'm')) {
+    var requestedMode = k === 'e' ? 'project' : 'mate';
+    e.preventDefault();
+    e.stopPropagation();
+    if (!_open) {
+      openSwitcher(requestedMode);
+    } else if (_mode !== requestedMode) {
+      // Switched modes mid-flight. Rebuild the list for the new mode.
+      openSwitcher(requestedMode);
+    } else if (e.shiftKey) {
+      cycle(-1);
+    } else {
+      cycle(1);
+    }
+    return;
+  }
+
+  if (!_open) return;
+
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    e.stopPropagation();
+    closeSwitcher(false);
+    return;
+  }
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    e.stopPropagation();
+    closeSwitcher(true);
+    return;
+  }
+  if (e.key === 'ArrowRight' || e.key === 'ArrowDown') { e.preventDefault(); cycle(1); return; }
+  if (e.key === 'ArrowLeft'  || e.key === 'ArrowUp')   { e.preventDefault(); cycle(-1); return; }
+}
+
+function handleKeyUp(e) {
+  if (!_open) return;
+  if (e.key === 'Meta' || e.key === 'Control') {
+    closeSwitcher(true);
+  }
+}
+
+function openSwitcher(mode) {
+  _mode = mode;
+  _entries = buildEntries(mode);
+  if (_entries.length === 0) {
+    // Nothing to switch to; don't show an empty modal.
+    if (_open) closeSwitcher(false);
+    return;
+  }
+  if (_headerEl) {
+    _headerEl.textContent = mode === 'mate' ? 'Switch mate' : 'Switch project';
+  }
+  updateFooterShortcut(mode);
+  renderEntries();
+  _highlightedIndex = pickInitialIndex();
+  paintHighlight();
+  _overlay.classList.remove('hidden');
+  _open = true;
+  refreshIcons();
+  // UI chrome matches the rest of Clay by swapping native emoji into
+  // Twemoji <img>s (same pattern as title bar, icon strip, project
+  // settings). The global COLR font fallback alone isn't reliable for
+  // UI surfaces because OS emoji fonts tend to match first.
+  parseEmojis(_list);
+}
+
+function updateFooterShortcut(mode) {
+  var nextKey = _overlay.querySelector('.proj-next-key');
+  var prevKey = _overlay.querySelector('.proj-prev-key');
+  var letter = mode === 'mate' ? 'M' : 'E';
+  if (nextKey) nextKey.textContent = letter;
+  if (prevKey) prevKey.textContent = letter;
+}
+
+function pickInitialIndex() {
+  // Highlight the "previous" selectable entry (Cmd+Tab semantics),
+  // while keeping the list in a stable natural order. Uses MRU to
+  // find which project/mate was visited before the current one, then
+  // locates its position in _entries.
+  if (_entries.length === 0) return 0;
+  var mru = _mode === 'mate' ? _mateMru : _projectMru;
+  var currentKey = currentActiveKey();
+  for (var m = 0; m < mru.length; m++) {
+    var key = mru[m];
+    if (key === currentKey) continue;
+    for (var i = 0; i < _entries.length; i++) {
+      if (_entries[i].key === key && !_entries[i].disabled) return i;
+    }
+  }
+  // Fallback: first non-current, non-disabled entry.
+  for (var j = 0; j < _entries.length; j++) {
+    if (!_entries[j].disabled && _entries[j].key !== currentKey) return j;
+  }
+  for (var d = 0; d < _entries.length; d++) {
+    if (!_entries[d].disabled) return d;
+  }
+  return 0;
+}
+
+function currentActiveKey() {
+  if (_mode === 'mate') {
+    return mateIdFrom(store.get('dmTargetUser'));
+  }
+  return store.get('currentSlug');
+}
+
+function buildEntries(mode) {
+  if (mode === 'mate') return buildMateEntries();
+  return buildProjectEntries();
+}
+
+function buildProjectEntries() {
+  var projects = (getCachedProjects() || []).filter(function (p) { return !p.isMate; });
+  // Keep natural (server-provided) order so the list looks the same
+  // every time the switcher opens. MRU only drives initial highlight.
+  return projects.map(function (p) {
+    // Worktrees can end up "outside project path" (parent workspace
+    // unmounted or moved); those are effectively unreachable from
+    // this session and shouldn't be switchable.
+    var unreachable = p.isWorktree && p.worktreeAccessible === false;
+    return {
+      key: p.slug,
+      title: p.title || p.project || p.slug,
+      icon: p.icon || null,
+      fallbackIcon: 'folder',
+      isCurrent: p.slug === store.get('currentSlug'),
+      disabled: unreachable,
+      disabledReason: unreachable ? 'Outside project path' : null,
+    };
+  });
+}
+
+function buildMateEntries() {
+  var mates = store.get('cachedMatesList') || [];
+  var currentMateId = mateIdFrom(store.get('dmTargetUser'));
+  // Natural list order; MRU is only for choosing the initial highlight.
+  return mates.map(function (m) {
+    return {
+      key: m.id,
+      title: m.displayName || m.name || m.id,
+      icon: null,
+      avatarUrl: mateAvatarUrl(m, 88),
+      fallbackIcon: 'user',
+      isCurrent: m.id === currentMateId,
+      disabled: false,
+      disabledReason: null,
+    };
+  });
+}
+
+function closeSwitcher(commit) {
+  if (!_open) return;
+  _open = false;
+  _overlay.classList.add('hidden');
+  if (!commit) return;
+  var entry = _entries[_highlightedIndex];
+  if (!entry || entry.disabled) return;
+  if (_mode === 'mate') {
+    if (entry.key !== currentActiveKey()) openDm(entry.key);
+  } else {
+    if (entry.key !== store.get('currentSlug')) switchProject(entry.key);
+  }
+}
+
+function cycle(delta) {
+  if (_entries.length === 0) return;
+  // Skip over disabled entries so unreachable worktrees aren't part
+  // of the cycle. If every entry is disabled (shouldn't happen, since
+  // openSwitcher bails on empty lists), fall back to plain stepping.
+  var step = delta > 0 ? 1 : -1;
+  var idx = _highlightedIndex;
+  for (var i = 0; i < _entries.length; i++) {
+    idx = (idx + step + _entries.length) % _entries.length;
+    if (!_entries[idx].disabled) {
+      _highlightedIndex = idx;
+      paintHighlight();
+      return;
+    }
+  }
+}
+
+function renderEntries() {
+  if (!_list) return;
+  _list.innerHTML = '';
+  for (var i = 0; i < _entries.length; i++) {
+    _list.appendChild(buildEntryNode(_entries[i], i));
+  }
+}
+
+function buildEntryNode(entry, index) {
+  var item = document.createElement('button');
+  item.type = 'button';
+  item.className = 'cmd-palette-item project-switcher-item';
+  if (entry.disabled) item.classList.add('disabled');
+  if (entry.disabled && entry.disabledReason) item.title = entry.disabledReason;
+  item.dataset.index = String(index);
+
+  var iconWrap = document.createElement('div');
+  iconWrap.className = 'cmd-palette-item-icon';
+  if (entry.icon) {
+    iconWrap.textContent = entry.icon;
+  } else if (entry.avatarUrl) {
+    var img = document.createElement('img');
+    img.src = entry.avatarUrl;
+    img.alt = '';
+    img.className = 'project-switcher-avatar';
+    iconWrap.appendChild(img);
+  } else {
+    var fallback = document.createElement('i');
+    fallback.setAttribute('data-lucide', entry.fallbackIcon || 'folder');
+    iconWrap.appendChild(fallback);
+  }
+  item.appendChild(iconWrap);
+
+  var body = document.createElement('div');
+  body.className = 'cmd-palette-item-body';
+  var titleRow = document.createElement('div');
+  titleRow.className = 'cmd-palette-item-title-row';
+  var title = document.createElement('span');
+  title.className = 'cmd-palette-item-title';
+  title.textContent = entry.title;
+  titleRow.appendChild(title);
+  if (entry.isCurrent) {
+    var badge = document.createElement('span');
+    badge.className = 'project-switcher-current';
+    badge.textContent = 'current';
+    titleRow.appendChild(badge);
+  }
+  if (entry.disabled && entry.disabledReason) {
+    var reason = document.createElement('span');
+    reason.className = 'project-switcher-disabled-reason';
+    reason.textContent = entry.disabledReason;
+    titleRow.appendChild(reason);
+  }
+  body.appendChild(titleRow);
+  item.appendChild(body);
+
+  item.addEventListener('mouseenter', function () {
+    if (entry.disabled) return;
+    _highlightedIndex = index;
+    paintHighlight();
+  });
+  item.addEventListener('click', function () {
+    if (entry.disabled) return;
+    _highlightedIndex = index;
+    closeSwitcher(true);
+  });
+  return item;
+}
+
+function paintHighlight() {
+  if (!_list) return;
+  var items = _list.querySelectorAll('.cmd-palette-item');
+  for (var i = 0; i < items.length; i++) {
+    items[i].classList.toggle('active', i === _highlightedIndex);
+  }
+  var active = items[_highlightedIndex];
+  if (active && active.scrollIntoView) {
+    active.scrollIntoView({ block: 'nearest' });
+  }
+}

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -1,6 +1,7 @@
 import { closeArchive } from './sticky-notes.js';
 import { closeScheduler } from './scheduler.js';
 import { initSidebarSessions } from './sidebar-sessions.js';
+import { focusFileTree } from './filebrowser.js';
 import { initSidebarProjects, closeProjectCtxMenu } from './sidebar-projects.js';
 import {
   initSidebarMates,
@@ -142,6 +143,9 @@ export function initSidebar(_ctx) {
       filesPanel.classList.add("fb-enter");
     }
     if (ctx.onFilesTabOpen) ctx.onFilesTabOpen();
+    // Hand focus to the file tree so arrow keys work immediately
+    // after the panel opens (no click-to-focus extra step).
+    requestAnimationFrame(function () { focusFileTree(); });
   }
 
   function hideFilesPanel(cb) {

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -158,7 +158,16 @@ export function initSidebar(_ctx) {
   }
 
   if (fileBrowserBtn) {
-    fileBrowserBtn.addEventListener("click", showFilesPanel);
+    // Clicking the tile toggles: open if closed, close (back to sessions)
+    // if it's already the visible panel. Same behavior via the Cmd+O
+    // hotkey since that calls .click().
+    fileBrowserBtn.addEventListener("click", function () {
+      if (filesPanel && !filesPanel.classList.contains("hidden")) {
+        hideFilesPanel(function () { showSessionsPanel(); });
+      } else {
+        showFilesPanel();
+      }
+    });
   }
   if (filePanelClose) {
     filePanelClose.addEventListener("click", function() {

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -108,15 +108,6 @@ export function initSidebar(_ctx) {
     });
   }
 
-  // --- Tools section collapse/expand ---
-  var toolsToggle = ctx.$("sidebar-tools-toggle");
-  var toolsSection = ctx.$("sidebar-tools");
-  if (toolsToggle && toolsSection) {
-    toolsToggle.addEventListener("click", function () {
-      toolsSection.classList.toggle("collapsed");
-    });
-  }
-
   // --- Panel switch (sessions / files / projects) ---
   var fileBrowserBtn = ctx.$("file-browser-btn");
   var projectsPanel = ctx.$("sidebar-panel-projects");

--- a/lib/public/modules/terminal.js
+++ b/lib/public/modules/terminal.js
@@ -164,12 +164,17 @@ export function initTerminal(_ctx) {
     });
   }
 
-  // Sidebar terminal button
+  // Sidebar terminal button — toggles open/close. Second click (or the
+  // Cmd+O hotkey on the same tile) dismisses the terminal panel.
   var sidebarTermBtn = document.getElementById("terminal-sidebar-btn");
   if (sidebarTermBtn) {
     sidebarTermBtn.addEventListener("click", function () {
-      closeSidebar();
-      openTerminal();
+      if (isOpen && !ctx.terminalContainerEl.classList.contains("hidden")) {
+        closeTerminal();
+      } else {
+        closeSidebar();
+        openTerminal();
+      }
     });
   }
 

--- a/lib/public/modules/tool-palette.js
+++ b/lib/public/modules/tool-palette.js
@@ -1,0 +1,436 @@
+// tool-palette.js — Customizable sidebar tool palette
+//
+// Renders the per-session and per-mate tool grids from a data registry,
+// so users can reorder tools and hide ones they don't use. Preserves the
+// original button IDs so existing click handlers (attached by sidebar.js,
+// terminal.js, mcp-ui.js, etc.) keep working on the rendered nodes.
+//
+// Design notes (see issue #325 for the broader context):
+// - Buttons are created once on init and never destroyed; hide/reorder
+//   moves existing DOM nodes, so event listeners bound elsewhere survive.
+// - Edit mode is a state on the palette container (class="edit-mode").
+//   CSS shows the × remove affordance and enables drag reordering.
+// - Preferences persist per-user via the /api/user/tool-palettes endpoint.
+//   An in-flight save is debounced so rapid drag reorders don't spam.
+
+import { refreshIcons } from './icons.js';
+
+var SESSION_TOOLS = [
+  { id: "file-browser-btn",        icon: "folder-tree",    label: "File browser" },
+  { id: "terminal-sidebar-btn",    icon: "square-terminal", label: "Terminal",        countId: "terminal-sidebar-count" },
+  { id: "sticky-notes-sidebar-btn", icon: "sticky-note",   label: "Sticky Notes",    countId: "sticky-notes-sidebar-count" },
+  { id: "email-sidebar-btn",       icon: "mail",           label: "Email" },
+  { id: "mcp-btn",                 icon: "cable",          label: "MCP Servers",     countId: "mcp-sidebar-count" },
+  { id: "skills-btn",              icon: "puzzle",         label: "Skills" },
+  { id: "scheduler-btn",           icon: "calendar-clock", label: "Scheduled Tasks" },
+];
+
+var MATE_TOOLS = [
+  { id: "mate-memory-btn",       icon: "brain",          label: "Memory",          countId: "mate-memory-count" },
+  { id: "mate-knowledge-btn",    icon: "book-open",      label: "Knowledge",       countId: "mate-knowledge-count" },
+  { id: "mate-sticky-notes-btn", icon: "sticky-note",    label: "Sticky Notes" },
+  { id: "mate-email-btn",        icon: "mail",           label: "Email" },
+  { id: "mate-mcp-btn",          icon: "cable",          label: "MCP Servers",     countId: "mate-mcp-sidebar-count" },
+  { id: "mate-skills-btn",       icon: "puzzle",         label: "Skills" },
+  { id: "mate-scheduler-btn",    icon: "calendar-clock", label: "Scheduled Tasks" },
+];
+
+var PALETTES = {
+  session: {
+    tools: SESSION_TOOLS,
+    activeContainerId: "session-actions",
+    hiddenSectionId: "session-actions-hidden",
+  },
+  mate: {
+    tools: MATE_TOOLS,
+    activeContainerId: "mate-sidebar-tools",
+    hiddenSectionId: "mate-sidebar-tools-hidden",
+  },
+};
+
+var _saveTimers = {};
+var _draggingEl = null;
+var _draggingPaletteName = null;
+
+export function initToolPalettes() {
+  for (var name in PALETTES) {
+    buildPalette(name);
+  }
+
+  // Edit pills toggle edit mode on their associated palette.
+  var editBtns = document.querySelectorAll('.tool-palette-edit-btn');
+  for (var i = 0; i < editBtns.length; i++) {
+    (function (btn) {
+      btn.addEventListener('click', function () {
+        toggleEditMode(btn.dataset.palette);
+      });
+    })(editBtns[i]);
+  }
+
+  // Load saved preferences and apply to both palettes once buttons exist.
+  loadPreferences();
+
+  refreshIcons();
+}
+
+function buildPalette(name) {
+  var palette = PALETTES[name];
+  var active = document.getElementById(palette.activeContainerId);
+  if (!active) return;
+
+  // Create buttons with stable IDs and append in registry order (default).
+  for (var i = 0; i < palette.tools.length; i++) {
+    active.appendChild(buildToolButton(palette.tools[i], name));
+  }
+
+  // Scaffold the hidden section (its grid fills in when items are hidden).
+  var hiddenSection = document.getElementById(palette.hiddenSectionId);
+  if (hiddenSection) {
+    hiddenSection.innerHTML = '';
+    var labelEl = document.createElement('div');
+    labelEl.className = 'tool-palette-hidden-label';
+    labelEl.textContent = 'Add back';
+    var gridEl = document.createElement('div');
+    gridEl.className = 'tool-palette-hidden-grid';
+    hiddenSection.appendChild(labelEl);
+    hiddenSection.appendChild(gridEl);
+  }
+
+  // Drag-reorder within the active container. Works in both normal and
+  // edit mode so users can rearrange without entering a separate mode
+  // (matches the macOS dock pattern). HTML5 drag has a small movement
+  // threshold, so quick clicks still activate the tool normally.
+  active.addEventListener('dragover', function (e) {
+    if (_draggingPaletteName !== name || !_draggingEl) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    var after = getDragAfterElement(active, e.clientX, e.clientY);
+    if (after == null) {
+      if (_draggingEl.parentNode !== active || _draggingEl.nextSibling) {
+        active.appendChild(_draggingEl);
+      }
+    } else if (after !== _draggingEl) {
+      active.insertBefore(_draggingEl, after);
+    }
+  });
+  active.addEventListener('drop', function (e) {
+    if (_draggingPaletteName !== name) return;
+    e.preventDefault();
+  });
+}
+
+function buildToolButton(tool, paletteName) {
+  var btn = document.createElement('button');
+  btn.id = tool.id;
+  btn.type = 'button';
+  btn.className = 'palette-tile';
+  btn.title = tool.label;
+  btn.setAttribute('aria-label', tool.label);
+  btn.dataset.toolId = tool.id;
+  btn.dataset.palette = paletteName;
+  // Draggable at all times so users can reorder without entering edit
+  // mode. Drag is gated to the active grid in the handlers below; tiles
+  // in the hidden grid get draggable=false set on move.
+  btn.draggable = true;
+
+  var icon = document.createElement('i');
+  icon.setAttribute('data-lucide', tool.icon);
+  btn.appendChild(icon);
+
+  var labelEl = document.createElement('span');
+  labelEl.className = 'tool-btn-label';
+  labelEl.textContent = tool.label;
+  btn.appendChild(labelEl);
+
+  if (tool.countId) {
+    var count = document.createElement('span');
+    count.id = tool.countId;
+    count.className = 'sidebar-badge hidden';
+    btn.appendChild(count);
+  }
+
+  // × affordance — shown only in edit mode via CSS.
+  var remove = document.createElement('span');
+  remove.className = 'tool-palette-remove';
+  remove.setAttribute('role', 'button');
+  remove.setAttribute('aria-label', 'Remove ' + tool.label + ' from palette');
+  remove.textContent = '\u00D7';
+  btn.appendChild(remove);
+
+  // Click interceptor, registered before any other module attaches to
+  // the button by ID. stopImmediatePropagation prevents the tool's own
+  // handler from running in three cases: clicking the × in edit mode,
+  // clicking a tile in the hidden-grid (which should restore it), and
+  // clicking any tile while edit mode is active (tiles are inert then).
+  btn.addEventListener('click', function (e) {
+    if (e.target.closest('.tool-palette-remove')) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      moveToHidden(paletteName, tool.id);
+      return;
+    }
+    var container = btn.parentNode;
+    if (!container) return;
+    if (container.classList.contains('tool-palette-hidden-grid')) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      moveToActive(paletteName, tool.id);
+      return;
+    }
+    if (container.classList.contains('edit-mode')) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }
+  });
+
+  btn.addEventListener('contextmenu', function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    var container = btn.parentNode;
+    var inHidden = container && container.classList.contains('tool-palette-hidden-grid');
+    openPaletteContextMenu(e.clientX, e.clientY, inHidden ? [
+      { label: 'Add back to palette', action: function () { moveToActive(paletteName, tool.id); } },
+    ] : [
+      { label: 'Remove from palette', action: function () { moveToHidden(paletteName, tool.id); } },
+      { label: 'Edit palette\u2026', action: function () {
+          if (!document.getElementById(PALETTES[paletteName].activeContainerId).classList.contains('edit-mode')) {
+            toggleEditMode(paletteName);
+          }
+        } },
+    ]);
+  });
+
+  btn.addEventListener('dragstart', function (e) {
+    var container = btn.parentNode;
+    // Only allow drag from the active grid; hidden tiles are added back
+    // via click, not drag.
+    if (!container || container.id !== PALETTES[paletteName].activeContainerId) {
+      e.preventDefault();
+      return;
+    }
+    _draggingEl = btn;
+    _draggingPaletteName = paletteName;
+    e.dataTransfer.effectAllowed = 'move';
+    // Firefox requires data to be set for drag to start.
+    try { e.dataTransfer.setData('text/plain', tool.id); } catch (err) { /* ignore */ }
+    btn.classList.add('dragging');
+  });
+  btn.addEventListener('dragend', function () {
+    btn.classList.remove('dragging');
+    if (_draggingPaletteName) queueSave(_draggingPaletteName);
+    _draggingEl = null;
+    _draggingPaletteName = null;
+  });
+
+  return btn;
+}
+
+function toggleEditMode(name) {
+  var palette = PALETTES[name];
+  if (!palette) return;
+  var active = document.getElementById(palette.activeContainerId);
+  var hidden = document.getElementById(palette.hiddenSectionId);
+  var editBtn = document.querySelector('.tool-palette-edit-btn[data-palette="' + name + '"]');
+  if (!active || !editBtn) return;
+
+  var entering = !active.classList.contains('edit-mode');
+  active.classList.toggle('edit-mode', entering);
+  if (hidden) {
+    // Show hidden-section in edit mode if any items exist there (or to
+    // allow adding back even when empty, keep visible so the state is
+    // legible). We show whenever edit mode is on.
+    hidden.classList.toggle('hidden', !entering);
+  }
+  editBtn.classList.toggle('active', entering);
+  editBtn.textContent = entering ? 'Done' : 'Edit';
+
+  if (!entering) queueSave(name);
+}
+
+function moveToHidden(name, toolId) {
+  var palette = PALETTES[name];
+  if (!palette) return;
+  var btn = document.getElementById(toolId);
+  var hiddenSection = document.getElementById(palette.hiddenSectionId);
+  if (!btn || !hiddenSection) return;
+  var grid = hiddenSection.querySelector('.tool-palette-hidden-grid');
+  if (!grid) return;
+  // Hidden tiles stay draggable=false so users don't drag them around
+  // before adding them back. The active-grid dragstart gate also
+  // enforces this.
+  btn.draggable = false;
+  grid.appendChild(btn);
+  queueSave(name);
+}
+
+function moveToActive(name, toolId) {
+  var palette = PALETTES[name];
+  if (!palette) return;
+  var btn = document.getElementById(toolId);
+  var active = document.getElementById(palette.activeContainerId);
+  if (!btn || !active) return;
+  active.appendChild(btn);
+  btn.draggable = true;
+  queueSave(name);
+}
+
+// (Hidden-tile clicks are handled in each button's own click listener,
+// attached in buildToolButton before any external module attaches
+// handlers by ID. See the stopImmediatePropagation logic there.)
+
+// --- Right-click context menu ---
+
+var _openMenu = null;
+
+function openPaletteContextMenu(x, y, items) {
+  closePaletteContextMenu();
+  var menu = document.createElement('div');
+  menu.className = 'tool-palette-ctx-menu';
+  for (var i = 0; i < items.length; i++) {
+    (function (item) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'tool-palette-ctx-item';
+      btn.textContent = item.label;
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        closePaletteContextMenu();
+        item.action();
+      });
+      menu.appendChild(btn);
+    })(items[i]);
+  }
+  document.body.appendChild(menu);
+  // Clamp to viewport.
+  var rect = menu.getBoundingClientRect();
+  var px = x, py = y;
+  if (px + rect.width > window.innerWidth - 4) px = window.innerWidth - rect.width - 4;
+  if (py + rect.height > window.innerHeight - 4) py = window.innerHeight - rect.height - 4;
+  menu.style.left = px + 'px';
+  menu.style.top = py + 'px';
+  _openMenu = menu;
+}
+
+function closePaletteContextMenu() {
+  if (_openMenu && _openMenu.parentNode) _openMenu.parentNode.removeChild(_openMenu);
+  _openMenu = null;
+}
+
+document.addEventListener('click', function () { closePaletteContextMenu(); });
+document.addEventListener('keydown', function (e) {
+  if (e.key === 'Escape') closePaletteContextMenu();
+});
+window.addEventListener('blur', function () { closePaletteContextMenu(); });
+window.addEventListener('resize', function () { closePaletteContextMenu(); });
+
+function getDragAfterElement(container, x, y) {
+  var tiles = Array.prototype.slice.call(
+    container.querySelectorAll('[data-tool-id]:not(.dragging)')
+  );
+  var closest = null;
+  var closestDist = Number.POSITIVE_INFINITY;
+  for (var i = 0; i < tiles.length; i++) {
+    var rect = tiles[i].getBoundingClientRect();
+    // Pointer is "before" the tile if it's left of the tile's horizontal
+    // midpoint on the same row (or on a higher row).
+    var rowDelta = y - (rect.top + rect.height / 2);
+    var colDelta = x - (rect.left + rect.width / 2);
+    // Weight row heavier than column so flowing between rows works.
+    var dist = Math.abs(rowDelta) * 2 + Math.abs(colDelta);
+    var before = rowDelta < -rect.height / 2
+      || (Math.abs(rowDelta) <= rect.height / 2 && colDelta < 0);
+    if (before && dist < closestDist) {
+      closestDist = dist;
+      closest = tiles[i];
+    }
+  }
+  return closest;
+}
+
+// --- Persistence ---
+
+function loadPreferences() {
+  fetch('/api/user/tool-palettes', { credentials: 'same-origin' })
+    .then(function (res) { return res.ok ? res.json() : null; })
+    .then(function (data) {
+      if (!data) return;
+      applyPreferences('session', data.session || null);
+      applyPreferences('mate', data.mate || null);
+    })
+    .catch(function () { /* first-time users have no saved prefs; ignore */ });
+}
+
+function applyPreferences(name, prefs) {
+  if (!prefs) return;
+  var palette = PALETTES[name];
+  if (!palette) return;
+  var active = document.getElementById(palette.activeContainerId);
+  var hiddenSection = document.getElementById(palette.hiddenSectionId);
+  var hiddenGrid = hiddenSection ? hiddenSection.querySelector('.tool-palette-hidden-grid') : null;
+  if (!active || !hiddenGrid) return;
+
+  var hiddenSet = {};
+  var hiddenList = prefs.hidden || [];
+  for (var i = 0; i < hiddenList.length; i++) hiddenSet[hiddenList[i]] = true;
+
+  var orderList = prefs.order || [];
+  // Any tools not in the stored order are appended in registry order so
+  // newly-added tools surface automatically for existing users.
+  var placed = {};
+  for (var j = 0; j < orderList.length; j++) {
+    var id = orderList[j];
+    if (hiddenSet[id]) continue;
+    var btn = document.getElementById(id);
+    if (btn) {
+      active.appendChild(btn);
+      placed[id] = true;
+    }
+  }
+  for (var k = 0; k < palette.tools.length; k++) {
+    var tid = palette.tools[k].id;
+    if (placed[tid] || hiddenSet[tid]) continue;
+    var tbtn = document.getElementById(tid);
+    if (tbtn) active.appendChild(tbtn);
+  }
+  for (var h = 0; h < hiddenList.length; h++) {
+    var hbtn = document.getElementById(hiddenList[h]);
+    if (hbtn) {
+      hbtn.draggable = false;
+      hiddenGrid.appendChild(hbtn);
+    }
+  }
+}
+
+function queueSave(name) {
+  if (_saveTimers[name]) clearTimeout(_saveTimers[name]);
+  _saveTimers[name] = setTimeout(function () {
+    _saveTimers[name] = null;
+    savePreferences(name);
+  }, 250);
+}
+
+function savePreferences(name) {
+  var palette = PALETTES[name];
+  if (!palette) return;
+  var active = document.getElementById(palette.activeContainerId);
+  var hiddenSection = document.getElementById(palette.hiddenSectionId);
+  var hiddenGrid = hiddenSection ? hiddenSection.querySelector('.tool-palette-hidden-grid') : null;
+  if (!active) return;
+
+  var order = [];
+  var activeTiles = active.querySelectorAll('[data-tool-id]');
+  for (var i = 0; i < activeTiles.length; i++) order.push(activeTiles[i].dataset.toolId);
+
+  var hidden = [];
+  if (hiddenGrid) {
+    var hiddenTiles = hiddenGrid.querySelectorAll('[data-tool-id]');
+    for (var j = 0; j < hiddenTiles.length; j++) hidden.push(hiddenTiles[j].dataset.toolId);
+  }
+
+  fetch('/api/user/tool-palettes', {
+    method: 'PUT',
+    credentials: 'same-origin',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ palette: name, order: order, hidden: hidden }),
+  }).catch(function () { /* save best-effort */ });
+}

--- a/lib/public/modules/tool-palette.js
+++ b/lib/public/modules/tool-palette.js
@@ -323,6 +323,107 @@ document.addEventListener('keydown', function (e) {
 window.addEventListener('blur', function () { closePaletteContextMenu(); });
 window.addEventListener('resize', function () { closePaletteContextMenu(); });
 
+// --- Hotkey overlay (Cmd/Ctrl + O) ---
+//
+// Press Cmd/Ctrl + O to reveal a hotkey badge on each visible palette
+// tile. Then press the shown digit (1..9, 0) or letter (a..z) to
+// activate that tool. Escape or clicking away dismisses. Inspired by
+// Vimium / Superhuman-style "pick a tile with one keystroke" flows.
+
+var _pickActive = false;
+var HOTKEYS = (function () {
+  var k = [];
+  for (var i = 1; i <= 9; i++) k.push(String(i));
+  k.push('0');
+  for (var c = 97; c <= 122; c++) k.push(String.fromCharCode(c));
+  return k;
+})();
+
+function getVisiblePaletteName() {
+  // offsetParent is null when the element (or an ancestor) is hidden.
+  var mateActive = document.getElementById('mate-sidebar-tools');
+  if (mateActive && mateActive.offsetParent !== null) return 'mate';
+  var sessionActive = document.getElementById('session-actions');
+  if (sessionActive && sessionActive.offsetParent !== null) return 'session';
+  return null;
+}
+
+function enterToolPickMode() {
+  if (_pickActive) return;
+  var name = getVisiblePaletteName();
+  if (!name) return;
+  var active = document.getElementById(PALETTES[name].activeContainerId);
+  if (!active) return;
+  var tiles = active.querySelectorAll('[data-tool-id]');
+  if (tiles.length === 0) return;
+  for (var i = 0; i < tiles.length && i < HOTKEYS.length; i++) {
+    var key = HOTKEYS[i];
+    tiles[i].dataset.hotkey = key;
+    var badge = document.createElement('span');
+    badge.className = 'tool-palette-hotkey-badge';
+    badge.textContent = key.toUpperCase();
+    tiles[i].appendChild(badge);
+  }
+  _pickActive = true;
+}
+
+function exitToolPickMode() {
+  if (!_pickActive) return;
+  _pickActive = false;
+  var badges = document.querySelectorAll('.tool-palette-hotkey-badge');
+  for (var i = 0; i < badges.length; i++) {
+    if (badges[i].parentNode) badges[i].parentNode.removeChild(badges[i]);
+  }
+  var marked = document.querySelectorAll('[data-hotkey]');
+  for (var j = 0; j < marked.length; j++) {
+    delete marked[j].dataset.hotkey;
+  }
+}
+
+// Capture phase so we reliably preempt typing and browser shortcuts
+// when focus is in an input.
+document.addEventListener('keydown', function (e) {
+  // Pick mode: consume the next printable key.
+  if (_pickActive) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      exitToolPickMode();
+      return;
+    }
+    // Ignore modifier-only keys; react to single-character keys.
+    if (e.key.length !== 1) return;
+    if (e.ctrlKey || e.metaKey || e.altKey) return;
+    var key = e.key.toLowerCase();
+    var tile = document.querySelector('[data-hotkey="' + key + '"]');
+    if (tile) {
+      e.preventDefault();
+      exitToolPickMode();
+      tile.click();
+    } else {
+      // Unknown key exits pick mode without triggering a tile.
+      exitToolPickMode();
+    }
+    return;
+  }
+
+  // Enter pick mode on Cmd/Ctrl + O (letter O). Intercepted globally
+  // including inside text inputs — the browser's native Cmd+O is a
+  // file-picker dialog Clay never wants, so taking it over costs the
+  // user nothing and is especially useful when jumping to a tool from
+  // the session search box.
+  if ((e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey && e.key && e.key.toLowerCase() === 'o') {
+    if (!getVisiblePaletteName()) return;
+    e.preventDefault();
+    enterToolPickMode();
+  }
+}, true);
+
+// Dismiss the overlay on click-away, blur, or viewport changes so it
+// never lingers invisibly.
+document.addEventListener('click', function () { if (_pickActive) exitToolPickMode(); });
+window.addEventListener('blur', function () { if (_pickActive) exitToolPickMode(); });
+window.addEventListener('resize', function () { if (_pickActive) exitToolPickMode(); });
+
 function getDragAfterElement(container, x, y) {
   var tiles = Array.prototype.slice.call(
     container.querySelectorAll('[data-tool-id]:not(.dragging)')

--- a/lib/public/modules/tool-palette.js
+++ b/lib/public/modules/tool-palette.js
@@ -15,14 +15,18 @@
 
 import { refreshIcons } from './icons.js';
 
+// Registry order = default order for users who haven't customized. Users
+// with saved preferences keep their own order (applyPreferences uses
+// saved order first, then appends any registry entries the user's saved
+// list doesn't mention). So changes here only affect fresh palettes.
 var SESSION_TOOLS = [
   { id: "file-browser-btn",        icon: "folder-tree",    label: "File browser" },
   { id: "terminal-sidebar-btn",    icon: "square-terminal", label: "Terminal",        countId: "terminal-sidebar-count" },
   { id: "sticky-notes-sidebar-btn", icon: "sticky-note",   label: "Sticky Notes",    countId: "sticky-notes-sidebar-count" },
+  { id: "scheduler-btn",           icon: "calendar-clock", label: "Scheduled Tasks" },
   { id: "email-sidebar-btn",       icon: "mail",           label: "Email" },
   { id: "mcp-btn",                 icon: "cable",          label: "MCP Servers",     countId: "mcp-sidebar-count" },
   { id: "skills-btn",              icon: "puzzle",         label: "Skills" },
-  { id: "scheduler-btn",           icon: "calendar-clock", label: "Scheduled Tasks" },
 ];
 
 var MATE_TOOLS = [
@@ -65,6 +69,19 @@ export function initToolPalettes() {
         toggleEditMode(btn.dataset.palette);
       });
     })(editBtns[i]);
+  }
+
+  // Keyboard-hotkey hint text. Clickable so users who read it can also
+  // trigger pick mode without reaching for the keyboard the first time.
+  var isMac = /Mac|iPhone|iPod|iPad/i.test(navigator.platform);
+  var hintText = (isMac ? '\u2318O' : 'Ctrl+O') + ' for hotkeys';
+  var hints = document.querySelectorAll('.sidebar-tools-hint');
+  for (var h = 0; h < hints.length; h++) {
+    hints[h].textContent = hintText;
+    hints[h].addEventListener('click', function () {
+      if (_pickActive) exitToolPickMode();
+      else enterToolPickMode();
+    });
   }
 
   // Load saved preferences and apply to both palettes once buttons exist.
@@ -241,8 +258,9 @@ function toggleEditMode(name) {
     // legible). We show whenever edit mode is on.
     hidden.classList.toggle('hidden', !entering);
   }
+  // Pencil icon stays; the .active class provides visual feedback by
+  // swapping to the accent background. No label text swap needed now.
   editBtn.classList.toggle('active', entering);
-  editBtn.textContent = entering ? 'Done' : 'Edit';
 
   if (!entering) queueSave(name);
 }

--- a/lib/public/modules/tool-palette.js
+++ b/lib/public/modules/tool-palette.js
@@ -71,14 +71,20 @@ export function initToolPalettes() {
     })(editBtns[i]);
   }
 
-  // Keyboard-hotkey hint text. Clickable so users who read it can also
-  // trigger pick mode without reaching for the keyboard the first time.
+  // Keyboard-hotkey hint pill. Matches the icon-strip shortcut pills
+  // in shape — just the chord, no prose. Clicking the pill opens the
+  // hotkey overlay, same as pressing the shortcut.
   var isMac = /Mac|iPhone|iPod|iPad/i.test(navigator.platform);
-  var hintText = (isMac ? '\u2318O' : 'Ctrl+O') + ' for hotkeys';
+  var hintLabel = isMac ? '\u2318O' : 'Ctrl+O';
   var hints = document.querySelectorAll('.sidebar-tools-hint');
   for (var h = 0; h < hints.length; h++) {
-    hints[h].textContent = hintText;
-    hints[h].addEventListener('click', function () {
+    hints[h].textContent = hintLabel;
+    hints[h].title = 'Show keyboard hotkeys (' + hintLabel + ')';
+    hints[h].addEventListener('click', function (e) {
+      // Stop the click from bubbling to the document-level dismiss
+      // handler below, which would immediately tear down the pick-mode
+      // we just entered.
+      e.stopPropagation();
       if (_pickActive) exitToolPickMode();
       else enterToolPickMode();
     });

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1208,8 +1208,11 @@ function createSDKBridge(opts) {
     if (tryExec("which claude")) result.push("claude");
 
     // Codex: check bundled binary or PATH
-    var codexBin = path.join(__dirname, "../node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex");
-    if (fs.existsSync(codexBin) || tryExec("which codex")) result.push("codex");
+    var codexBin = null;
+    try {
+      codexBin = require("./yoke/codex-app-server").findCodexPath();
+    } catch (e) {}
+    if ((codexBin && fs.existsSync(codexBin)) || tryExec("which codex")) result.push("codex");
 
     return result;
   }

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -107,7 +107,14 @@ function createSDKBridge(opts) {
   var mateDisplayName = opts.mateDisplayName || "";
   var isMate = opts.isMate || (slug.indexOf("mate-") === 0);
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
-  var mcpServers = opts.mcpServers || null;
+  // mcpServers may be either a static object or a getter function. The
+  // getter form lets callers gate individual servers at call time (e.g.
+  // clay-browser is only exposed while the Chrome extension is connected).
+  var _mcpServersSrc = opts.mcpServers || null;
+  function getMcpServers() {
+    if (typeof _mcpServersSrc === "function") return _mcpServersSrc() || null;
+    return _mcpServersSrc;
+  }
   var getRemoteMcpServers = opts.getRemoteMcpServers || null;
   var clayPort = opts.clayPort || 2633;
   var clayTls = opts.clayTls || false;
@@ -1043,7 +1050,7 @@ function createSDKBridge(opts) {
       cwd: cwd,
       model: queryModel,
       effort: ls.effort || sm.currentEffort || undefined,
-      toolServers: mergeMcpServers(mcpServers, getRemoteMcpServers) || undefined,
+      toolServers: mergeMcpServers(getMcpServers(), getRemoteMcpServers) || undefined,
       resumeSessionId: session.cliSessionId || undefined,
       abortController: linuxUser ? undefined : session.abortController,
       canUseTool: function(toolName, input, toolOpts) {
@@ -1386,7 +1393,7 @@ function createSDKBridge(opts) {
         cwd: cwd,
         systemPrompt: opts.claudeMd,
         model: opts.model || undefined,
-        toolServers: opts.includeMcpServers ? (mergeMcpServers(mcpServers, getRemoteMcpServers) || undefined) : undefined,
+        toolServers: opts.includeMcpServers ? (mergeMcpServers(getMcpServers(), getRemoteMcpServers) || undefined) : undefined,
         abortController: abortController,
         canUseTool: opts.canUseTool || function (toolName, input) {
           var whitelisted = checkToolWhitelist(toolName, input);

--- a/lib/server-settings.js
+++ b/lib/server-settings.js
@@ -450,6 +450,59 @@ function attachSettings(ctx) {
       return true;
     }
 
+    // GET /api/user/tool-palettes
+    if (req.method === "GET" && fullUrl === "/api/user/tool-palettes") {
+      var muGet = getMultiUserFromReq(req);
+      var palettes = {};
+      if (!muGet) {
+        if (typeof opts.onGetToolPalettes === "function") {
+          palettes = opts.onGetToolPalettes() || {};
+        }
+      } else {
+        palettes = users.getToolPalettes(muGet.id) || {};
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(palettes));
+      return true;
+    }
+
+    // PUT /api/user/tool-palettes
+    if (req.method === "PUT" && fullUrl === "/api/user/tool-palettes") {
+      var muPut = getMultiUserFromReq(req);
+      var bodyTp = "";
+      req.on("data", function (chunk) { bodyTp += chunk; });
+      req.on("end", function () {
+        try {
+          var dataTp = JSON.parse(bodyTp);
+          var paletteName = dataTp.palette;
+          var order = dataTp.order;
+          var hidden = dataTp.hidden;
+          var result;
+          if (!muPut) {
+            if (typeof opts.onSetToolPalette !== "function") {
+              res.writeHead(500, { "Content-Type": "application/json" });
+              res.end('{"error":"Not supported"}');
+              return;
+            }
+            result = opts.onSetToolPalette(paletteName, order, hidden);
+          } else {
+            result = users.setToolPalette(muPut.id, paletteName, order, hidden);
+          }
+          if (result && result.error) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: result.error }));
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(result));
+        } catch (e) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end('{"error":"Invalid request"}');
+        }
+      });
+      return true;
+    }
+
     // GET /api/user/auto-continue
     if (req.method === "GET" && fullUrl === "/api/user/auto-continue") {
       var mu = getMultiUserFromReq(req);

--- a/lib/users-preferences.js
+++ b/lib/users-preferences.js
@@ -175,6 +175,52 @@ function attachPreferences(deps) {
     return { error: "User not found" };
   }
 
+  // --- Per-user tool palette preferences ---
+  //
+  // Each user can customize the sidebar tool grid by reordering or
+  // hiding individual tools. Stored as an object keyed by palette name
+  // ("session" or "mate"), each holding { order: [...ids], hidden: [...ids] }.
+  // Missing ids are treated as "use registry default at the end", so new
+  // tools added in future releases show up for existing users without a
+  // migration.
+
+  var VALID_PALETTES = { session: true, mate: true };
+
+  function getToolPalettes(userId) {
+    var data = loadUsers();
+    for (var i = 0; i < data.users.length; i++) {
+      if (data.users[i].id === userId) {
+        return data.users[i].toolPalettes || {};
+      }
+    }
+    return {};
+  }
+
+  function setToolPalette(userId, paletteName, order, hidden) {
+    if (!VALID_PALETTES[paletteName]) {
+      return { error: "Unknown palette" };
+    }
+    var safeOrder = Array.isArray(order)
+      ? order.filter(function (s) { return typeof s === "string"; })
+      : [];
+    var safeHidden = Array.isArray(hidden)
+      ? hidden.filter(function (s) { return typeof s === "string"; })
+      : [];
+    var data = loadUsers();
+    for (var i = 0; i < data.users.length; i++) {
+      if (data.users[i].id === userId) {
+        if (!data.users[i].toolPalettes) data.users[i].toolPalettes = {};
+        data.users[i].toolPalettes[paletteName] = {
+          order: safeOrder,
+          hidden: safeHidden,
+        };
+        saveUsers(data);
+        return { ok: true, palette: paletteName, order: safeOrder, hidden: safeHidden };
+      }
+    }
+    return { error: "User not found" };
+  }
+
   // --- Mate onboarding ---
 
   function setMateOnboarded(userId) {
@@ -203,6 +249,8 @@ function attachPreferences(deps) {
     setChatLayout: setChatLayout,
     getAutoContinue: getAutoContinue,
     setAutoContinue: setAutoContinue,
+    getToolPalettes: getToolPalettes,
+    setToolPalette: setToolPalette,
     setMateOnboarded: setMateOnboarded,
   };
 }

--- a/lib/users.js
+++ b/lib/users.js
@@ -416,6 +416,8 @@ var getChatLayout = preferences.getChatLayout;
 var setChatLayout = preferences.setChatLayout;
 var getAutoContinue = preferences.getAutoContinue;
 var setAutoContinue = preferences.setAutoContinue;
+var getToolPalettes = preferences.getToolPalettes;
+var setToolPalette = preferences.setToolPalette;
 var setMateOnboarded = preferences.setMateOnboarded;
 
 module.exports = {
@@ -473,6 +475,8 @@ module.exports = {
   setMateOnboarded: setMateOnboarded,
   getAutoContinue: getAutoContinue,
   setAutoContinue: setAutoContinue,
+  getToolPalettes: getToolPalettes,
+  setToolPalette: setToolPalette,
   getDeletedBuiltinKeys: getDeletedBuiltinKeys,
   addDeletedBuiltinKey: addDeletedBuiltinKey,
   removeDeletedBuiltinKey: removeDeletedBuiltinKey,

--- a/lib/yoke/index.js
+++ b/lib/yoke/index.js
@@ -84,8 +84,8 @@ function checkAuth() {
 
   function checkCodex() {
     try {
-      var path = require("path");
-      var codexBin = path.join(__dirname, "../../node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex");
+      var findCodexPath = require("./codex-app-server").findCodexPath;
+      var codexBin = findCodexPath();
       execSync(codexBin + " login status", { timeout: 5000, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
       return true;
     } catch (e) {
@@ -111,7 +111,8 @@ function checkInstalled() {
     result.claude = true;
   } catch (e) {}
   try {
-    var codexBin = path.join(__dirname, "../../node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex");
+    var findCodexPath = require("./codex-app-server").findCodexPath;
+    var codexBin = findCodexPath();
     if (fs.existsSync(codexBin)) result.codex = true;
   } catch (e) {}
   return result;


### PR DESCRIPTION
## Summary

Three call sites hardcoded `@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/codex/codex`, so codex auth and install checks always failed on Linux, Windows, and Intel Mac. Reuse the existing `findCodexPath()` helper in `lib/yoke/codex-app-server.js` which already resolves the correct platform package (darwin arm64/x64, linux arm64/x64, win32 x64).

Sites fixed:
- `lib/yoke/index.js` — `checkCodex()` (auth check)
- `lib/yoke/index.js` — `checkInstalled()` (install check)
- `lib/sdk-bridge.js` — warmup vendor detection

All three call sites already wrap the lookup in try/catch, so the fact that `findCodexPath()` can throw is safe.

Refs #327 (the login-command typo half was already fixed in #329).

## Test plan

- [x] Darwin ARM64: `checkAuth`/`checkInstalled` still report `codex=true`
- [ ] Linux x64: codex auth check now succeeds when `codex login` has been run
- [ ] Intel Mac: codex binary resolves correctly