### PR TITLE
fix(adapter): forward per-loop settings to SDK query options

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1168,16 +1168,18 @@ function createSDKBridge(opts) {
 
     if (dangerouslySkipPermissions) {
       claudeOpts.allowDangerouslySkipPermissions = true;
-    }
-    var globalMode = sm.currentPermissionMode || "default";
-    var effectiveDefault;
-    if (globalMode === "bypassPermissions") effectiveDefault = "bypassPermissions";
-    else if (session.acceptEditsAfterStart) effectiveDefault = "acceptEdits";
-    else effectiveDefault = globalMode;
-    var modeToApply = session._loopPermissionMode || effectiveDefault;
-    if (session.acceptEditsAfterStart) delete session.acceptEditsAfterStart;
-    if (modeToApply && modeToApply !== "default") {
-      claudeOpts.permissionMode = modeToApply;
+      claudeOpts.permissionMode = "bypassPermissions";
+    } else {
+      var globalMode = sm.currentPermissionMode || "default";
+      var effectiveDefault;
+      if (globalMode === "bypassPermissions") effectiveDefault = "bypassPermissions";
+      else if (session.acceptEditsAfterStart) effectiveDefault = "acceptEdits";
+      else effectiveDefault = globalMode;
+      var modeToApply = session._loopPermissionMode || effectiveDefault;
+      if (session.acceptEditsAfterStart) delete session.acceptEditsAfterStart;
+      if (modeToApply && modeToApply !== "default") {
+        claudeOpts.permissionMode = modeToApply;
+      }
     }
     if (session.cliSessionId && session.lastRewindUuid) {
       claudeOpts.resumeSessionAt = session.lastRewindUuid;

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -943,6 +943,7 @@ function createClaudeAdapter(opts) {
         cwd: (initOpts && initOpts.cwd) || _cwd,
         settingSources: ["user", "project", "local"],
         abortController: ac,
+        settings: { disableAllHooks: true },
       };
       if (_claudeBinaryPath) warmupOptions.pathToClaudeCodeExecutable = _claudeBinaryPath;
 
@@ -1358,6 +1359,7 @@ function createClaudeAdapter(opts) {
         cwd: (initOpts && initOpts.cwd) || _cwd,
         settingSources: ["user", "project", "local"],
         abortController: ac,
+        settings: { disableAllHooks: true },
       };
       if (_claudeBinaryPath) warmupOptions.pathToClaudeCodeExecutable = _claudeBinaryPath;
 
@@ -1432,7 +1434,7 @@ function createClaudeAdapter(opts) {
       throw new Error("Warmup worker failed to connect: " + (e.message || e));
     }
 
-    var warmupOptions = { cwd: workerCwd, settingSources: ["user", "project", "local"] };
+    var warmupOptions = { cwd: workerCwd, settingSources: ["user", "project", "local"], settings: { disableAllHooks: true } };
     if (_claudeBinaryPath) warmupOptions.pathToClaudeCodeExecutable = _claudeBinaryPath;
     if (initOpts && initOpts.dangerouslySkipPermissions) {
       warmupOptions.permissionMode = "bypassPermissions";

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -1102,6 +1102,7 @@ function createClaudeAdapter(opts) {
       if (co.permissionMode) sdkOptions.permissionMode = co.permissionMode;
       if (co.allowDangerouslySkipPermissions) sdkOptions.allowDangerouslySkipPermissions = true;
       if (co.resumeSessionAt) sdkOptions.resumeSessionAt = co.resumeSessionAt;
+      if (co.settings) sdkOptions.settings = co.settings;
 
       var rawQuery = sdk.query({ prompt: mq, options: sdkOptions });
       return createQueryHandle(rawQuery, mq, ac);
@@ -1250,6 +1251,7 @@ function createClaudeAdapter(opts) {
     if (claudeOpts.betas && claudeOpts.betas.length > 0) queryOptions.betas = claudeOpts.betas;
     if (claudeOpts.permissionMode) queryOptions.permissionMode = claudeOpts.permissionMode;
     if (claudeOpts.allowDangerouslySkipPermissions) queryOptions.allowDangerouslySkipPermissions = true;
+    if (claudeOpts.settings) queryOptions.settings = claudeOpts.settings;
 
     if (queryOpts.toolServers) queryOptions.mcpServers = queryOpts.toolServers;
     if (queryOpts.model) queryOptions.model = queryOpts.model;


### PR DESCRIPTION
## Summary

- sdk-bridge.js sets claudeOpts.settings from LOOP.json (e.g. disableAllHooks: true), but the adapter layer never forwarded it to the SDK queryOptions/sdkOptions
- This was supposed to be fixed in v2.28.0-beta.1 (issue #248), but the adapter-side changes were either lost or never landed
- Warmup "hi" queries triggered user hooks on every Clay startup
- dangerouslySkipPermissions was not paired with permissionMode: bypassPermissions, causing scheduled tasks to prompt for permissions

## Changes

1. Forward per-loop settings to SDK query options (both worker and direct paths)
2. Suppress hooks on warmup queries (all three warmup sites)
3. Pair permissionMode with dangerouslySkipPermissions in sdk-bridge.js

## Test plan

- Scheduled task with disableAllHooks in LOOP.json runs without triggering hooks
- Interactive sessions without disableAllHooks still fire hooks normally
- Restart Clay and verify warmup queries do not trigger hooks
- Scheduled tasks run without permission prompts when dangerouslySkipPermissions is true