### PR TITLE
fix(input): prevent ghost-text suggestion from swallowing pasted content on Enter

### DIFF
--- a/lib/public/modules/app-rendering.js
+++ b/lib/public/modules/app-rendering.js
@@ -10,7 +10,7 @@ import { iconHtml, refreshIcons } from './icons.js';
 import { userAvatarUrl } from './avatar.js';
 import { closeToolGroup } from './tools.js';
 import { showImageModal, showPasteModal } from './app-misc.js';
-import { sendMessage } from './input.js';
+import { sendMessage, hasSendableContent } from './input.js';
 import { getChatLayout } from './theme.js';
 import { getScheduledMsgEl } from './app-rate-limit.js';
 
@@ -547,9 +547,11 @@ export function getGhostSuggestion() {
 
 export function showSuggestionChips(suggestion) {
   if (!suggestion || store.get('processing')) return;
-  var inputEl = getInputEl();
-  // Only show ghost text if input is empty
-  if (inputEl && inputEl.value.trim()) return;
+  // Only show ghost text when there is no sendable content — typed text,
+  // pending pastes, pending images, or pending files all suppress the
+  // suggestion so Enter can't accidentally send it instead of the user's
+  // actual attached content.
+  if (hasSendableContent()) return;
   _ghostSuggestionText = suggestion;
   var ghostEl = document.getElementById("ghost-suggestion");
   if (!ghostEl) return;

--- a/lib/public/modules/input.js
+++ b/lib/public/modules/input.js
@@ -360,6 +360,9 @@ function renderInputPreviews() {
     return;
   }
   bar.classList.add("visible");
+  // Hide any ghost suggestion as soon as attached content appears — Enter
+  // must not silently swallow the user's paste/image/file.
+  if (ctx && ctx.hideSuggestionChips) ctx.hideSuggestionChips();
 
   // Image thumbnails
   for (var i = 0; i < pendingImages.length; i++) {
@@ -1040,9 +1043,13 @@ export function initInput(_ctx) {
         return;
       }
       e.preventDefault();
-      // If input is empty but ghost suggestion is showing, adopt it
+      // If input has no sendable content but ghost suggestion is showing, adopt it.
+      // Use hasSendableContent() instead of checking inputEl.value alone so that
+      // pending images, pastes, or files block the ghost-text adoption — otherwise
+      // pressing Enter with only a pasted image/block queued would send the
+      // suggestion instead of the user's actual content.
       var ghost = ctx.getGhostSuggestion ? ctx.getGhostSuggestion() : "";
-      if (!ctx.inputEl.value.trim() && ghost) {
+      if (!hasSendableContent() && ghost) {
         ctx.inputEl.value = ghost;
         if (ctx.hideSuggestionChips) ctx.hideSuggestionChips();
       }


### PR DESCRIPTION
## Summary

After 0753833 (ghost-text suggestion pattern), pressing Enter with only a pasted image, paste block, or file attached (textarea empty) sends the ghost-text suggestion instead of the user's actual attached content.

The Enter handler checked `!ctx.inputEl.value.trim()` alone, which ignores `pendingImages` / `pendingPastes` / `pendingFiles`. The click handler was already correct (used `hasSendableContent()`). This PR aligns Enter with click and also suppresses ghost display entirely when attachments are present.

## Changes

- `input.js` Enter handler: use `hasSendableContent()` instead of raw textarea value check
- `app-rendering.js` `showSuggestionChips`: use `hasSendableContent()` guard (so suggestion doesn't appear when attachments are already queued)
- `input.js` `renderInputPreviews`: hide any active ghost as soon as attachments appear (defensive — in case a suggestion arrives via WS after an attachment was added)

## Repro

1. Wait for a ghost suggestion to appear with an empty textarea
2. Paste an image or a long text block (goes into pending pastes/images)
3. Press Enter

**Before:** suggestion is sent, paste/image is retained in the input bar.
**After:** paste/image is sent, suggestion is dismissed.

## Test plan
- [x] Verified fix locally on 2.34.0
- [ ] Regression check: ghost-text adoption still works when textarea is fully empty (no attachments)
- [ ] Regression check: typing into textarea still clears ghost (unchanged input-event path)