### PR TITLE
fix(models): normalize vendorModels to strings when comparing and falling back

### DIFF
--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -311,7 +311,8 @@ function attachSessions(ctx) {
         if (switchTargetSess && sm.currentModel) {
           var targetVendor = switchTargetSess.vendor || sm.defaultVendor || null;
           var tvModels = (targetVendor && sm.modelsByVendor && sm.modelsByVendor[targetVendor]) || [];
-          if (tvModels.length > 0 && tvModels.indexOf(sm.currentModel) === -1) {
+          var tvModelIds = tvModels.map(function(m) { return typeof m === "string" ? m : (m.value || ""); }).filter(Boolean);
+          if (tvModelIds.length > 0 && tvModelIds.indexOf(sm.currentModel) === -1) {
             sm.currentModel = "";
           }
         }

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1221,8 +1221,14 @@ function createSDKBridge(opts) {
     var sessionVendor = session.vendor || (adapter && adapter.vendor) || null;
     if (sessionVendor) {
       var vendorModels = (sm.modelsByVendor && sm.modelsByVendor[sessionVendor]) || [];
-      if (vendorModels.length > 0 && queryModel && vendorModels.indexOf(queryModel) === -1) {
-        queryModel = vendorModels[0];
+      // Normalize vendorModels to strings — supportedModels() may return objects
+      // with { value, displayName } shape (as of SDK 2.x). Always extract .value
+      // so comparisons and fallbacks work correctly.
+      var vendorModelIds = vendorModels.map(function(m) {
+        return typeof m === "string" ? m : (m.value || "");
+      }).filter(Boolean);
+      if (vendorModelIds.length > 0 && queryModel && vendorModelIds.indexOf(queryModel) === -1) {
+        queryModel = vendorModelIds[0];
       }
     }
 


### PR DESCRIPTION
## Summary

\`supportedModels()\` can return entries as objects (\`{ value, displayName }\`) rather than plain strings. \`rebuildModelList()\` in \`app-panels.js\` already handles both shapes, but \`startQuery()\` treats the list as strings.

On a fresh session where the persisted \`queryModel\` isn't in the vendor list, \`vendorModels.indexOf(queryModel)\` returns \`-1\` (a string never equals an object), so the fallback \`queryModel = vendorModels[0]\` ends up storing an **object**. That object flows into \`queryOpts.model\` → \`sdkOptions.model\` → CLI \`--model [object Object]\`, producing:

> There's an issue with the selected model ([object Object]). It may not exist or you may not have access to it. Run --model to pick a different model.

## Repro

1. On 2.34.0, start any fresh session where the saved default model differs from the vendor's supported list order (e.g. when persisted \`currentModel\` is \`"default"\` or a model string that happens to be represented as an object in the list).
2. Send any message.
3. Observe: **There's an issue with the selected model ([object Object])...**

Happens on the very first message of a brand-new session — not just on stale sessions. Workaround: re-select \"default\" from the model picker (overwrites the bad object with a clean string).

## Fix

Normalize the vendor model list to strings before \`.indexOf()\` comparison and fallback:

\`\`\`js
var vendorModelIds = vendorModels.map(function(m) {
  return typeof m === \"string\" ? m : (m.value || \"\");
}).filter(Boolean);
\`\`\`

Applied in two places:
- \`sdk-bridge.js\` \`startQuery()\` — the main query path, source of the user-visible error
- \`project-sessions.js\` vendor-switch — same \`indexOf\` pattern, would clear \`sm.currentModel\` at the wrong time if models are objects

## Test plan
- [x] Verified locally on 2.34.0 — fresh sessions send valid model strings, no \`[object Object]\` error
- [ ] Regression check: vendor switching between claude/codex still clears stale model correctly
- [ ] Regression check: when the persisted model IS present in the list (as object with matching \`.value\`), no unnecessary fallback to \`[0]\`