### PR TITLE
fix(mates): stop skill-install modal from firing on every reconnect

### DIFF
--- a/lib/public/modules/app-connection.js
+++ b/lib/public/modules/app-connection.js
@@ -103,30 +103,12 @@ function onConnected() {
 
   // Session restore is now server-driven (user-presence.json).
   // Mate DM restore is also server-driven via "restore_mate_dm" message.
-  // Fallback: if server doesn't restore DM within 2s, try localStorage
-  var savedDm = null;
-  try { savedDm = localStorage.getItem("clay-active-dm"); } catch (e) {}
-  if (savedDm && !store.get('dmMode') && !store.get('mateProjectSlug')) {
-    var dmFallbackTimer = setTimeout(function () {
-      if (!store.get('dmMode') && savedDm) {
-        console.log("[dm-restore] Server did not restore DM, using localStorage fallback:", savedDm);
-        openDm(savedDm);
-      }
-    }, 2000);
-    // Cancel fallback if server restores DM first
-    var patchedOnce = false;
-    var checkRestore = function (evt) {
-      try {
-        var d = JSON.parse(evt.data);
-        if (d.type === "restore_mate_dm" && !patchedOnce) {
-          patchedOnce = true;
-          clearTimeout(dmFallbackTimer);
-        }
-      } catch (e) {}
-    };
-    ws.addEventListener("message", checkRestore);
-    setTimeout(function () { ws.removeEventListener("message", checkRestore); }, 3000);
-  }
+  // Previously there was a 2s localStorage fallback that auto-called
+  // openDm(savedDm) on every reconnect. That fallback re-opened stale
+  // mate DMs on every refresh / project switch and was the root cause
+  // of the skill-install modal popping unprompted. Server-driven restore
+  // is authoritative — drop the client-side fallback entirely.
+  try { localStorage.removeItem("clay-active-dm"); } catch (e) {}
   // Safety: clear returningFromMateDm after initial messages settle
   if (store.get('returningFromMateDm')) {
     setTimeout(function () {

--- a/lib/public/modules/app-dm.js
+++ b/lib/public/modules/app-dm.js
@@ -21,7 +21,6 @@ import { closeTerminal } from './terminal.js';
 import { openMobileSheet, setMobileSheetMateData } from './sidebar-mobile.js';
 import { getProfileLang } from './profile.js';
 import { isSchedulerOpen, closeScheduler } from './scheduler.js';
-import { requireClayMateInterview } from './app-skills-install.js';
 import { syncResizeHandles } from './sidebar.js';
 
 var MATE_ONBOARDING_KEY = "clay-mate-onboarding-shown";
@@ -77,13 +76,15 @@ export function openDm(targetUserId) {
   if (!ws || ws.readyState !== 1) return;
   // Persist DM state for refresh recovery
   try { localStorage.setItem("clay-active-dm", targetUserId); } catch (e) {}
-  // Check mate skill updates before opening mate DM
+  // Opening an existing mate DM does not require the clay-mate-interview
+  // skill — that skill is only used during new mate creation / reshaping.
+  // Showing onboarding + gating a skill version check here caused the
+  // "Skill Installation Required" modal to pop on every refresh / project
+  // switch via the localStorage DM-restore fallback in app-connection.js.
   if (typeof targetUserId === "string" && targetUserId.indexOf("mate_") === 0) {
     showMateOnboarding(function () {
-      requireClayMateInterview(function () {
-        var ws2 = getWs();
-        if (ws2) ws2.send(JSON.stringify({ type: "dm_open", targetUserId: targetUserId }));
-      });
+      var ws2 = getWs();
+      if (ws2) ws2.send(JSON.stringify({ type: "dm_open", targetUserId: targetUserId }));
     });
     return;
   }

--- a/lib/public/modules/app-skills-install.js
+++ b/lib/public/modules/app-skills-install.js
@@ -197,10 +197,14 @@ export function requireSkills(opts, cb) {
     .then(function (res) { return res.json(); })
     .then(function (data) {
       var results = data.results || [];
+      // Only "missing" skills block the feature. "outdated" skills already
+      // function — an available update should not hard-gate with a modal
+      // every time a user opens a DM or refreshes the page. Callers can
+      // surface outdated versions elsewhere (e.g. settings / notifications).
       var actionable = [];
       for (var i = 0; i < results.length; i++) {
         var r = results[i];
-        if (r.status === "missing" || r.status === "outdated") {
+        if (r.status === "missing") {
           var orig = null;
           for (var j = 0; j < opts.skills.length; j++) {
             if (opts.skills[j].name === r.name) { orig = opts.skills[j]; break; }


### PR DESCRIPTION
## Summary

Three independent issues combined to make the "Skill Installation Required: The Mate Interview skill is required to create a new Mate" modal pop on every page refresh and every project switch, even for users who never create mates.

## Repro (before)

1. Fresh single-user deploy, `clay-mate-interview` skill already installed (at 1.3.1, for example, with 1.4.0 available).
2. Click any built-in mate once, close the DM.
3. Refresh the page or switch projects.
4. `Skill Installation Required` modal appears with `Update 1.3.1 → 1.4.0`, blocks the UI.
5. Every refresh / project switch from this point reliably reproduces the modal.

## Root causes

**1. `app-dm.js`** — `openDm()` unconditionally wrapped mate-DM opens in `requireClayMateInterview()`. That skill is only needed when *creating* a mate via the wizard; opening an existing mate DM does not need it.

**2. `app-skills-install.js`** — `requireSkills()` treated `outdated` skills identically to `missing` and popped the install modal for either. An available update should not hard-modal a working feature.

**3. `app-connection.js`** — every WS reconnect ran a 2s localStorage fallback that called `openDm(savedDm)` if the server hadn't sent `restore_mate_dm` first. In single-user deployments where `user-presence.json` has `mateDm: null` (the common case), the fallback fired unprompted on every refresh and project switch, re-opening a stale mate DM the user never asked for. Combined with #1, that routed every reconnect through the skill check.

## Fix

1. Remove the `requireClayMateInterview` wrap from `openDm`. The `openMateWizard` path still gates on the skill (correct — new mate creation needs it).
2. `requireSkills()` now only gates on `missing`. Mixed `missing + outdated` dialogs still render correctly because the user has genuinely missing skills; pure-outdated checks no longer block.
3. Drop the localStorage DM auto-restore. Server-driven `restore_mate_dm` is authoritative. Stale `clay-active-dm` is cleared on connect.

## Test plan

- [x] Fresh install: no modal on first load.
- [x] Refresh Clay with a built-in mate previously opened: no modal.
- [x] Switch projects repeatedly: no skill check fires.
- [x] Creating a new mate via the wizard still correctly prompts `clay-mate-interview` install/update (unchanged path).
- [x] Clicking a mate in the DM picker still opens the DM through `dm_open` without a modal.