### PR TITLE
fix(mates): persist deletedBuiltinKeys in single-user mode

### DIFF
--- a/lib/users-preferences.js
+++ b/lib/users-preferences.js
@@ -87,6 +87,36 @@ function attachPreferences(deps) {
   }
 
   // --- Deleted built-in mate keys tracking ---
+  //
+  // In single-user mode there is no users.json, so the user row lookup
+  // below returns nothing and the key is silently dropped. That made
+  // "Remove mate" in the sidebar picker a no-op: the key was never
+  // persisted, ensureBuiltinMates re-created the mate on next mate_list,
+  // and the user could not actually get rid of built-in mates.
+  //
+  // Fallback: when the user record isn't found (single-user mode), read
+  // and write deletedBuiltinKeys on daemon.json via lib/config.js. This
+  // preserves multi-user behavior (users.json row still wins) while
+  // giving single-user deploys a place to persist the setting.
+
+  function loadSingleUserDeletedKeys() {
+    try {
+      var config = require("./config");
+      var cfg = config.loadConfig() || {};
+      return Array.isArray(cfg.deletedBuiltinKeys) ? cfg.deletedBuiltinKeys : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveSingleUserDeletedKeys(keys) {
+    try {
+      var config = require("./config");
+      var cfg = config.loadConfig() || {};
+      cfg.deletedBuiltinKeys = keys;
+      config.saveConfig(cfg);
+    } catch (e) {}
+  }
 
   function getDeletedBuiltinKeys(userId) {
     var data = loadUsers();
@@ -95,7 +125,7 @@ function attachPreferences(deps) {
         return data.users[i].deletedBuiltinKeys || [];
       }
     }
-    return [];
+    return loadSingleUserDeletedKeys();
   }
 
   function addDeletedBuiltinKey(userId, key) {
@@ -110,6 +140,12 @@ function attachPreferences(deps) {
         return;
       }
     }
+    // Single-user fallback
+    var keys = loadSingleUserDeletedKeys();
+    if (keys.indexOf(key) === -1) {
+      keys.push(key);
+      saveSingleUserDeletedKeys(keys);
+    }
   }
 
   function removeDeletedBuiltinKey(userId, key) {
@@ -123,6 +159,12 @@ function attachPreferences(deps) {
         saveUsers(data);
         return;
       }
+    }
+    // Single-user fallback
+    var keys = loadSingleUserDeletedKeys();
+    var filtered = keys.filter(function (k) { return k !== key; });
+    if (filtered.length !== keys.length) {
+      saveSingleUserDeletedKeys(filtered);
     }
   }
 


### PR DESCRIPTION
## Summary

"Remove mate" from the DM picker is a silent no-op in single-user mode. The mate appears to go away in the UI but reappears on next connect because the deletion is never persisted.

## Repro (before)

1. Single-user deploy (no `users.json`, `daemon.json.mode: "single"`).
2. Open the `+` / mate picker.
3. Click the `-` button on a built-in mate (e.g. Buzz), confirm "Remove".
4. Mate disappears from the list.
5. Refresh.
6. Mate is back. Deletion never stuck.

## Root cause

`lib/users-preferences.js` persists `deletedBuiltinKeys` on the user row inside `users.json`. In single-user mode `users.json` is not created and `loadUsers()` returns `{ users: [] }`. `addDeletedBuiltinKey` and `removeDeletedBuiltinKey` loop over that empty array, find no matching row, and return without writing anywhere. `getDeletedBuiltinKeys` returns `[]` for the same reason. `ensureBuiltinMates` on the next `mate_list` re-creates every "deleted" built-in because the excluded-keys list it receives is empty.

Same pattern affects `getDmFavorites`, `getDmHidden`, etc., but only `deletedBuiltinKeys` has a user-visible "why didn't that save?" symptom because the re-seed actively reverses the user's action.

## Fix

When the user row is not found (single-user case), fall back to `~/.clay/daemon.json` via `lib/config.js` for persistence. Multi-user behavior is unchanged — a matching `users.json` row still wins. The fallback runs only when there is nowhere else to put the preference.

## Test plan

- [x] Single-user: Remove Buzz → reconnect → Buzz stays gone.
- [x] Single-user: `+ Add Buzz` → reconnect → Buzz is back.
- [x] `daemon.json` gains `deletedBuiltinKeys: ["buzz"]` only when a removal happens in single-user mode.
- [x] Multi-user: behavior unchanged (no fallback path executes when the user row exists).

## Scope

Intentionally narrow. Only `deletedBuiltinKeys` is patched, not the other preference functions that share the same pattern. Those aren't actively broken from a user's perspective right now (favorites and hidden state come from server-side DM payloads, so the preferences silently falling through is recoverable). If you'd prefer a broader sweep of all prefs falling back to `daemon.json`, happy to follow up — wanted to keep this PR tight to the bug actually reported.