### PR TITLE
fix(input): gate stop branch on live processing state; never send ghost suggestion on stop click

### DIFF
--- a/lib/public/modules/input.js
+++ b/lib/public/modules/input.js
@@ -1078,6 +1078,13 @@ export function initInput(_ctx) {
         return;
       }
       e.preventDefault();
+      // While Claude is processing and the user has nothing queued, Enter
+      // must not adopt a ghost suggestion — pressing Enter while waiting
+      // should be a no-op, not a send of a stale suggestion the user never
+      // typed.
+      if (ctx.processing && !hasSendableContent()) {
+        return;
+      }
       // If input has no sendable content but ghost suggestion is showing, adopt it.
       // Use hasSendableContent() instead of checking inputEl.value alone so that
       // pending images, pastes, or files block the ghost-text adoption — otherwise
@@ -1097,8 +1104,17 @@ export function initInput(_ctx) {
     ctx.inputEl.setAttribute("enterkeyhint", "enter");
   }
 
-  // Send/Stop button — if sendable content exists, always send; otherwise stop
+  // Send/Stop button — gate stop vs send on live state. If Claude is
+  // processing and the user has nothing queued, the click is a Stop and
+  // must not adopt a ghost suggestion. Otherwise it's a send.
+  // (regression after #337 / 0753833)
   ctx.sendBtn.addEventListener("click", function () {
+    if (ctx.processing && !hasSendableContent()) {
+      if (ctx.connected) {
+        ctx.ws.send(JSON.stringify({ type: "stop" }));
+      }
+      return;
+    }
     // Adopt ghost suggestion if input is empty
     var ghost = ctx.getGhostSuggestion ? ctx.getGhostSuggestion() : "";
     if (!hasSendableContent() && ghost) {
@@ -1110,9 +1126,6 @@ export function initInput(_ctx) {
     if (hasSendableContent()) {
       sendMessage();
       return;
-    }
-    if (ctx.processing && ctx.connected) {
-      ctx.ws.send(JSON.stringify({ type: "stop" }));
     }
   });
   ctx.sendBtn.addEventListener("dblclick", function (e) { e.preventDefault(); });


### PR DESCRIPTION
## Summary

Regression after #337 / 0753833 (ghost-text suggestion pattern). The `sendBtn` click handler in `lib/public/modules/input.js` checks `hasSendableContent()` and the ghost suggestion before the processing-stop branch, so clicking the visible Stop button while a ghost suggestion is queued sends the stale suggestion instead of stopping the SDK loop. Same shape on the Enter handler: pressing Enter while waiting on Claude adopts the ghost.

This PR adds a `(ctx.processing && !hasSendableContent())` guard at the top of both handlers. In that state the click/Enter is a Stop (or no-op for Enter) and never adopts a ghost suggestion. Otherwise the original send paths run unchanged.

The guard predicates on live state rather than the button's `stop` CSS class — that class lives on a state machine that can drift on mobile (backgrounding, ws reconnect) and would wedge the input if its class got stuck.

## Repro

1. Send a message and wait until Claude is processing (button shows the stop square)
2. A ghost suggestion is visible (textarea is empty, server has sent a suggestion)
3. Click Stop

**Before:** the ghost suggestion is sent as a new message; the SDK loop keeps running.
**After:** the SDK loop stops; the ghost is not sent.

## Test plan

- [x] Manual: stop with ghost visible -> SDK stops, suggestion not sent
- [x] Regression: idle + ghost + empty textarea -> click send-up sends ghost (unchanged)
- [x] Regression: typed text + processing -> button shows send -> click sends typed text (unchanged)
- [x] Regression: #337 path — pasted image + Enter sends image, not ghost (unchanged)
- [x] Manual mobile: send works after the SDK has gone processing->idle once