### PR TITLE
fix(daemon): clean up clayrc when removing project via CLI

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -1050,11 +1050,20 @@ var ipc = createIPCServer(socketPath(), function (msg) {
     case "remove_project": {
       if (!msg.path && !msg.slug) return { ok: false, error: "missing path or slug" };
       var target = msg.slug;
+      var removedPath = null;
       if (!target) {
         var abs = path.resolve(msg.path);
         for (var k = 0; k < config.projects.length; k++) {
           if (config.projects[k].path === abs) {
             target = config.projects[k].slug;
+            removedPath = abs;
+            break;
+          }
+        }
+      } else {
+        for (var k = 0; k < config.projects.length; k++) {
+          if (config.projects[k].slug === target) {
+            removedPath = config.projects[k].path;
             break;
           }
         }
@@ -1063,6 +1072,7 @@ var ipc = createIPCServer(socketPath(), function (msg) {
       relay.removeProject(target);
       config.projects = config.projects.filter(function (p) { return p.slug !== target; });
       saveConfig(config);
+      if (removedPath) { try { removeFromClayrc(removedPath); } catch (e) {} }
       try { syncClayrc(config.projects); } catch (e) {}
       console.log("[daemon] Removed project:", target);
       relay.broadcastAll({


### PR DESCRIPTION
## Summary

The IPC `remove_project` handler only called `syncClayrc`, which merges rather than overwrites existing entries. This left removed projects in `~/.clayrc`, causing them to be restored on the next daemon start.

Add `removeFromClayrc` call before `syncClayrc` to match the web UI removal path (`onRemoveProject` already does this correctly).

## Changes

- `lib/daemon.js`: add `removeFromClayrc` before `syncClayrc` in CLI project removal

## Fixes

- Command-line removed projects reappearing after daemon restart

## Test plan

- [ ] CLI remove a project (`clay project remove <name>`)
- [ ] Verify `~/.clayrc` no longer contains the removed project
- [ ] Restart daemon and confirm the project does not reappear in the list
- [ ] Web UI remove a project still works as before