### PR TITLE
fix(mobile): add profile entry to mobile settings sheet

### DIFF
--- a/lib/public/css/profile.css
+++ b/lib/public/css/profile.css
@@ -18,6 +18,24 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+.profile-popover.profile-popover-mobile {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  bottom: auto;
+  transform: translate(-50%, -50%);
+  width: calc(100vw - 32px);
+  max-width: 360px;
+  max-height: 80vh;
+  overflow-y: auto;
+  animation: profile-popover-mobile-in 0.15s ease-out;
+}
+
+@keyframes profile-popover-mobile-in {
+  from { opacity: 0; transform: translate(-50%, -45%); }
+  to { opacity: 1; transform: translate(-50%, -50%); }
+}
+
 /* Banner */
 .profile-banner {
   height: 52px;

--- a/lib/public/modules/profile.js
+++ b/lib/public/modules/profile.js
@@ -477,7 +477,12 @@ function showPopover() {
   });
 
   var island = document.getElementById('user-island');
-  island.appendChild(popoverEl);
+  if (island) {
+    island.appendChild(popoverEl);
+  } else {
+    popoverEl.classList.add('profile-popover-mobile');
+    document.body.appendChild(popoverEl);
+  }
   refreshIcons();
 
   if (!profile.name) {
@@ -511,7 +516,7 @@ function refreshAvatarPreviews() {
 
 function closeOnOutside(e) {
   var island = document.getElementById('user-island');
-  if (popoverEl && !popoverEl.contains(e.target) && !island.contains(e.target)) {
+  if (popoverEl && !popoverEl.contains(e.target) && !(island && island.contains(e.target))) {
     hidePopover();
   }
 }
@@ -596,6 +601,10 @@ export function getProfile() {
 
 export function getProfileLang() {
   return profile.lang;
+}
+
+export function openProfilePopover() {
+  showPopover();
 }
 
 // --- Mate profile popover (reuses same UI minus language) ---

--- a/lib/public/modules/sidebar-mobile.js
+++ b/lib/public/modules/sidebar-mobile.js
@@ -9,6 +9,7 @@ import { getCurrentTheme, getChatLayout, setChatLayout } from './theme.js';
 import { openCommandPalette } from './command-palette.js';
 import { getMateSessions } from './mate-sidebar.js';
 import { openProjectSettings } from './project-settings.js';
+import { openProfilePopover } from './profile.js';
 import {
   getCachedSessions,
   getDateGroup,
@@ -1058,6 +1059,7 @@ function renderSheetTools(listEl) {
 
 function renderSheetSettings(listEl) {
   var items = [
+    { icon: "user", label: "Profile", action: "profile" },
     { icon: "folder-cog", label: "Project Settings", action: "project-settings" },
     { icon: "settings", label: "Server Settings", action: "server-settings" }
   ];
@@ -1094,6 +1096,8 @@ function renderSheetSettings(listEl) {
             if (proj && store.get('ownerLocked')) proj = Object.assign({}, proj, { ownerLocked: true });
             openProjectSettings(getCachedCurrentSlug(), proj);
           }, 250);
+        } else if (item.action === "profile") {
+          setTimeout(function () { openProfilePopover(); }, 250);
         } else if (item.action === "server-settings") {
           var settingsBtn = document.getElementById("server-settings-btn");
           if (settingsBtn) setTimeout(function () { settingsBtn.click(); }, 250);


### PR DESCRIPTION
## Summary

Mobile users could not access the profile editor because:
1. The #user-island element is hidden on mobile via CSS
2. The mobile settings sheet only offered Project/Server settings

## Changes

- Export `openProfilePopover()` so it can be triggered outside user-island
- `showPopover()`: append to body with centered styling when user-island is absent (mobile viewport)
- `closeOnOutside()`: guard against null island on mobile
- `sidebar-mobile.js`: add Profile item to settings sheet
- `profile.css`: add `.profile-popover-mobile` with fixed positioning and mobile-specific enter animation

## Test plan

- [ ] Open mobile settings sheet (tap gear icon in bottom nav)
- [ ] Tap Profile — profile popover should open centered on screen
- [ ] Edit display name and avatar, save
- [ ] Close popover, reopen — changes should persist
- [ ] Desktop profile access still works (via user-island click)