### PR TITLE
fix: add session delete and loop group delete on mobile

### DIFF
--- a/lib/public/css/mobile-nav.css
+++ b/lib/public/css/mobile-nav.css
@@ -482,6 +482,32 @@
     margin-left: auto;
   }
 
+  /* Close button on session items */
+  .mobile-session-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    color: var(--text-dimmer);
+    cursor: pointer;
+    flex-shrink: 0;
+    margin-left: 2px;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .mobile-session-close svg {
+    width: 14px;
+    height: 14px;
+    display: block;
+  }
+
+  .mobile-session-close:active {
+    background: rgba(var(--overlay-rgb), 0.08);
+    color: var(--text);
+  }
+
   /* --- Session items inside sheet --- */
   .mobile-session-item {
     display: flex;
@@ -649,6 +675,34 @@
     background: rgba(var(--warning-rgb, 234, 179, 8), 0.15);
     color: var(--warning, #eab308);
     flex-shrink: 0;
+  }
+
+  .mobile-loop-more-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-dimmer);
+    cursor: pointer;
+    padding: 0;
+    flex-shrink: 0;
+    margin-left: 2px;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .mobile-loop-more-btn svg {
+    width: 14px;
+    height: 14px;
+    display: block;
+  }
+
+  .mobile-loop-more-btn:active {
+    background: rgba(var(--overlay-rgb), 0.08);
+    color: var(--text);
   }
 
   .mobile-loop-children {

--- a/lib/public/modules/sidebar-mobile.js
+++ b/lib/public/modules/sidebar-mobile.js
@@ -29,7 +29,8 @@ import {
 
 import { store } from './store.js';
 import { getWs } from './ws-ref.js';
-import { dismissOverlayPanels, closeSidebar } from './sidebar.js';
+import { dismissOverlayPanels, closeSidebar, spawnDustParticles } from './sidebar.js';
+import { showConfirm } from './app-misc.js';
 import { switchProject, getCachedProjects } from './app-projects.js';
 import { openDm } from './app-dm.js';
 import { showHomeHub } from './app-home-hub.js';
@@ -376,6 +377,94 @@ function renderSheetSessions(listEl) {
   }
 }
 
+// Helper: append a delete button to a mobile session/loop item
+function appendMobileSessionCloseButton(el, session) {
+  if (store.get('permissions') && store.get('permissions').sessionDelete === false) return;
+
+  var closeBtn = document.createElement("span");
+  closeBtn.className = "mobile-session-close";
+  closeBtn.setAttribute("role", "button");
+  closeBtn.setAttribute("aria-label", "Delete session");
+  closeBtn.title = "Delete session";
+  closeBtn.innerHTML = iconHtml("x");
+
+  closeBtn.addEventListener("click", function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    showConfirm('Delete "' + (session.title || "New Session") + '"? This session and its history will be permanently removed.', function () {
+      if (getWs() && store.get('connected')) {
+        getWs().send(JSON.stringify({ type: "delete_session", id: session.id }));
+      }
+      if (spawnDustParticles) {
+        var rect = el.getBoundingClientRect();
+        spawnDustParticles(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      }
+    });
+  });
+
+  el.appendChild(closeBtn);
+}
+
+// --- Mobile loop context menu ---
+var mobileLoopCtxMenu = null;
+
+function closeMobileLoopCtxMenu() {
+  if (mobileLoopCtxMenu) {
+    mobileLoopCtxMenu.remove();
+    mobileLoopCtxMenu = null;
+  }
+}
+
+function showMobileLoopCtxMenu(anchorBtn, loopId, loopName, childCount) {
+  closeMobileLoopCtxMenu();
+
+  var menu = document.createElement("div");
+  menu.className = "session-ctx-menu";
+
+  if (!store.get('permissions') || store.get('permissions').sessionDelete !== false) {
+    var deleteItem = document.createElement("button");
+    deleteItem.className = "session-ctx-item session-ctx-delete";
+    deleteItem.innerHTML = iconHtml("trash-2") + " <span>Delete</span>";
+    deleteItem.addEventListener("click", function (e) {
+      e.stopPropagation();
+      closeMobileLoopCtxMenu();
+      var msg = 'Delete "' + (loopName || "Loop") + '"';
+      if (childCount > 1) msg += " and its " + childCount + " sessions";
+      msg += "? This cannot be undone.";
+      showConfirm(msg, function () {
+        if (getWs() && store.get('connected')) {
+          getWs().send(JSON.stringify({ type: "delete_loop_group", loopId: loopId }));
+        }
+      });
+    });
+    menu.appendChild(deleteItem);
+  }
+
+  document.body.appendChild(menu);
+  mobileLoopCtxMenu = menu;
+  refreshIcons();
+
+  // Close on outside click
+  setTimeout(function () {
+    document.addEventListener("click", function closeHandler() {
+      closeMobileLoopCtxMenu();
+      document.removeEventListener("click", closeHandler);
+    });
+  }, 0);
+
+  requestAnimationFrame(function () {
+    var btnRect = anchorBtn.getBoundingClientRect();
+    menu.style.position = "fixed";
+    menu.style.top = (btnRect.bottom + 2) + "px";
+    menu.style.right = (window.innerWidth - btnRect.right) + "px";
+    menu.style.left = "auto";
+    var menuRect = menu.getBoundingClientRect();
+    if (menuRect.bottom > window.innerHeight - 8) {
+      menu.style.top = (btnRect.top - menuRect.height - 2) + "px";
+    }
+  });
+}
+
 // Helper: create a mobile session item element
 function createMobileSessionItem(s) {
   var el = document.createElement("button");
@@ -410,6 +499,8 @@ function createMobileSessionItem(s) {
       closeMobileSheet();
     });
   })(s.id);
+
+  appendMobileSessionCloseButton(el, s);
 
   return el;
 }
@@ -448,6 +539,8 @@ function createMobileLoopChild(s) {
       closeMobileSheet();
     });
   })(s.id);
+
+  appendMobileSessionCloseButton(el, s);
 
   return el;
 }
@@ -610,6 +703,22 @@ function createMobileLoopGroup(loopId, children, groupKey) {
     var countLabel = runCount === 1 ? String(children.length) : runCount + (runCount === 1 ? " run" : " runs");
     countBadge.textContent = countLabel;
     header.appendChild(countBadge);
+  }
+
+  // More button (loop group actions)
+  if (!store.get('permissions') || store.get('permissions').sessionDelete !== false) {
+    var moreBtn = document.createElement("button");
+    moreBtn.className = "mobile-loop-more-btn";
+    moreBtn.innerHTML = iconHtml("ellipsis");
+    moreBtn.title = "More options";
+    moreBtn.setAttribute("aria-label", "More options");
+    moreBtn.addEventListener("click", (function (lid, lname, lcount, btn) {
+      return function (e) {
+        e.stopPropagation();
+        showMobileLoopCtxMenu(btn, lid, lname, lcount);
+      };
+    })(loopId, loopName, children.length, moreBtn));
+    header.appendChild(moreBtn);
   }
 
   // Chevron toggles expansion
@@ -991,6 +1100,8 @@ function renderSearchResults(container, query) {
         closeMobileSheet();
       });
     })(s.id);
+
+    appendMobileSessionCloseButton(el, s);
 
     container.appendChild(el);
   }


### PR DESCRIPTION
## Summary

Mobile session list items had no delete button, making it impossible to remove sessions on mobile. Loop groups also lacked bulk deletion.

## Changes

- Add X close button to mobile session items, loop children, and search results
- Add confirm dialog before deletion with dust particle effect
- Add loop group context menu (ellipsis button) for bulk loop deletion
- Wire up `delete_session` and `delete_loop_group` WS messages

## Fixes

- Mobile users can now delete individual sessions
- Mobile users can now delete entire loop groups

## Test plan

- [ ] Open mobile session sheet
- [ ] Tap X on a session — confirm dialog appears
- [ ] Confirm — session disappears with dust animation
- [ ] Expand a loop group (Ralph/Scheduled)
- [ ] Tap ellipsis (...) on loop header — context menu opens
- [ ] Tap Delete — confirm dialog shows child session count
- [ ] Confirm — entire loop group is removed
- [ ] Search for a session, tap X in results — deletion works
- [ ] Verify desktop session delete still works