### PR TITLE
fix: preserve model selection on browser refresh

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1503,11 +1503,9 @@ async function forkDaemon(mode, keepAwake, extraProjects, addCwd, wantOsUsers) {
         break;
       }
     }
-    // Restore access settings from previous config
+    // Restore project-level settings from previous config
     if (prevProjectMap[cwd]) {
-      if (prevProjectMap[cwd].visibility) cwdEntry.visibility = prevProjectMap[cwd].visibility;
-      if (prevProjectMap[cwd].allowedUsers) cwdEntry.allowedUsers = prevProjectMap[cwd].allowedUsers;
-      if (prevProjectMap[cwd].ownerId) cwdEntry.ownerId = prevProjectMap[cwd].ownerId;
+      cwdEntry = Object.assign({}, prevProjectMap[cwd], cwdEntry);
     }
     allProjects.push(cwdEntry);
     usedSlugs.push(slug);
@@ -1522,21 +1520,19 @@ async function forkDaemon(mode, keepAwake, extraProjects, addCwd, wantOsUsers) {
       var rpSlug = generateSlug(rp.path, usedSlugs);
       usedSlugs.push(rpSlug);
       var rpEntry = { path: rp.path, slug: rpSlug, title: rp.title || undefined, icon: rp.icon || undefined, addedAt: rp.addedAt || Date.now() };
-      // Restore access settings from previous config
+      // Restore project-level settings from previous config
       if (prevProjectMap[rp.path]) {
-        if (prevProjectMap[rp.path].visibility) rpEntry.visibility = prevProjectMap[rp.path].visibility;
-        if (prevProjectMap[rp.path].allowedUsers) rpEntry.allowedUsers = prevProjectMap[rp.path].allowedUsers;
-        if (prevProjectMap[rp.path].ownerId) rpEntry.ownerId = prevProjectMap[rp.path].ownerId;
+        rpEntry = Object.assign({}, prevProjectMap[rp.path], rpEntry);
       }
       allProjects.push(rpEntry);
     }
   }
 
-  var config = {
+  var config = Object.assign({}, prevConfig || {}, {
     pid: null,
     port: port,
     host: host,
-    pinHash: mode === "multi" && cliPin ? generateAuthToken(cliPin) : null,
+    pinHash: mode === "multi" && cliPin ? generateAuthToken(cliPin) : (prevConfig && prevConfig.pinHash) || null,
     tls: hasTls,
     builtinCert: hasBuiltinCert,
     mkcertDetected: mkcertDetected,
@@ -1548,7 +1544,7 @@ async function forkDaemon(mode, keepAwake, extraProjects, addCwd, wantOsUsers) {
     mode: mode || "single",
     setupCompleted: true,
     projects: allProjects,
-  };
+  });
 
   ensureConfigDir();
   saveConfig(config);
@@ -1687,8 +1683,7 @@ async function devMode(mode, keepAwake, existingPinHash, wantOsUsers) {
   }
   // Restore access settings for cwd from previous config
   if (prevDevProjectMap[cwd]) {
-    if (prevDevProjectMap[cwd].visibility) cwdDevEntry.visibility = prevDevProjectMap[cwd].visibility;
-    if (prevDevProjectMap[cwd].allowedUsers) cwdDevEntry.allowedUsers = prevDevProjectMap[cwd].allowedUsers;
+    cwdDevEntry = Object.assign({}, prevDevProjectMap[cwd], cwdDevEntry);
   }
   var allProjects = [cwdDevEntry];
   var usedSlugs = [slug];
@@ -1697,15 +1692,14 @@ async function devMode(mode, keepAwake, existingPinHash, wantOsUsers) {
     var rpSlug = generateSlug(rp.path, usedSlugs);
     usedSlugs.push(rpSlug);
     var rpDevEntry = { path: rp.path, slug: rpSlug, title: rp.title || undefined, icon: rp.icon || undefined, addedAt: rp.addedAt || Date.now() };
-    // Restore access settings from previous config
+    // Restore project-level settings from previous config
     if (prevDevProjectMap[rp.path]) {
-      if (prevDevProjectMap[rp.path].visibility) rpDevEntry.visibility = prevDevProjectMap[rp.path].visibility;
-      if (prevDevProjectMap[rp.path].allowedUsers) rpDevEntry.allowedUsers = prevDevProjectMap[rp.path].allowedUsers;
+      rpDevEntry = Object.assign({}, prevDevProjectMap[rp.path], rpDevEntry);
     }
     allProjects.push(rpDevEntry);
   }
 
-  var config = {
+  var config = Object.assign({}, prevDevConfig || {}, {
     pid: null,
     port: port,
     host: host,
@@ -1720,7 +1714,7 @@ async function devMode(mode, keepAwake, existingPinHash, wantOsUsers) {
     setupCompleted: true,
     projects: allProjects,
     osUsers: wantOsUsers || (prevDevConfig ? (prevDevConfig.osUsers || false) : false),
-  };
+  });
 
   ensureConfigDir();
   saveConfig(config);

--- a/lib/project.js
+++ b/lib/project.js
@@ -911,7 +911,19 @@ function createProjectContext(opts) {
         var firstModel = vendorModels[0] || "";
         // model value can be string or {value, displayName} object
         var defaultModel = typeof firstModel === "string" ? firstModel : (firstModel.value || "");
-        sendTo(ws, { type: "model_info", model: defaultModel, models: vendorModels, vendor: msg.vendor, availableVendors: sm.availableVendors || [], installedVendors: sm.installedVendors || [] });
+        // Preserve the user's current model selection if it belongs to this
+        // vendor, rather than always snapping back to the vendor's default.
+        var modelToSend = defaultModel;
+        if (sm.currentModel) {
+          for (var mi = 0; mi < vendorModels.length; mi++) {
+            var mv = typeof vendorModels[mi] === "string" ? vendorModels[mi] : (vendorModels[mi].value || "");
+            if (mv === sm.currentModel) {
+              modelToSend = sm.currentModel;
+              break;
+            }
+          }
+        }
+        sendTo(ws, { type: "model_info", model: modelToSend, models: vendorModels, vendor: msg.vendor, availableVendors: sm.availableVendors || [], installedVendors: sm.installedVendors || [] });
       })();
       return;
     }

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -370,7 +370,11 @@ export function processMessage(msg) {
         if (_modelVal && typeof _modelVal === "object") _modelVal = _modelVal.value || _modelVal.displayName || "";
         var _miUpdate = { currentModels: msg.models || [] };
         if (Object.prototype.hasOwnProperty.call(msg, "model")) {
-          _miUpdate.currentModel = _modelVal || "";
+          if (store.get('vendorSelectionLocked') && store.get('currentModel')) {
+            // Keep the user's existing selection; only update models list
+          } else {
+            _miUpdate.currentModel = _modelVal || "";
+          }
         } else {
           _miUpdate.currentModel = store.get('currentModel');
         }


### PR DESCRIPTION
## Summary

- `get_vendor_models`: keep `sm.currentModel` if it exists in the vendor's model list instead of always snapping to the default
- `model_info` handler: respect `vendorSelectionLocked` to prevent late-arriving model_info from overwriting user's current selection after session history is loaded
- `bin/cli.js`: use `Object.assign` when rebuilding daemon config to preserve all existing settings (pinHash, access settings, etc.)

## Test plan

- [ ] Refresh browser with a non-default model selected — model should persist instead of resetting to vendor default
- [ ] Switch vendor after session has history — vendor toggle should lock correctly
- [ ] Restart daemon in dev mode — previous config settings (pinHash, access settings) should be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)