### PR TITLE
ci: run existing tests in CI pipeline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,12 +1,17 @@
 ## Code Review Guidelines
 
+### Coding Style
+- Use `var` instead of `const`/`let`. No arrow functions.
+- Server-side: CommonJS (`require`). Client-side: ES modules (`import`).
+- Commit messages follow Angular Commit Convention (`feat:`, `fix:`, `docs:`, etc.)
+
 ### Security
 - Check for SQL injection, XSS, path traversal
 - No hardcoded secrets or credentials
 - Input validation on user-facing inputs
 
 ### Testing
-- New code paths must have tests
+- New code paths should have tests
 - Happy path and error cases covered
 - Tests should be readable and maintainable
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,15 @@
+## Code Review Guidelines
+
+### Security
+- Check for SQL injection, XSS, path traversal
+- No hardcoded secrets or credentials
+- Input validation on user-facing inputs
+
+### Testing
+- New code paths must have tests
+- Happy path and error cases covered
+- Tests should be readable and maintainable
+
+### Documentation
+- Public APIs must have doc comments
+- Non-obvious logic needs "why" comments

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Summary
-<!-- 一句话描述这个 PR 做了什么 -->
+<!-- Describe what this PR does in one sentence -->
 
 ## Changes
 - 
@@ -10,7 +10,7 @@
 - [ ] Documentation updated
 
 ## Screenshots (if applicable)
-<!-- 截图或 GIF -->
+<!-- Screenshots or GIFs -->
 
 ## Related Issues
 Closes #

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+<!-- 一句话描述这个 PR 做了什么 -->
+
+## Changes
+- 
+
+## Test Plan
+- [ ] CI passes
+- [ ] Manual testing done
+- [ ] Documentation updated
+
+## Screenshots (if applicable)
+<!-- 截图或 GIF -->
+
+## Related Issues
+Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Syntax check
+        run: |
+          set -e
+          fail=0
+          while IFS= read -r f; do
+            if ! node --check "$f"; then
+              echo "Syntax error in: $f" >&2
+              fail=1
+            fi
+          done < <(find bin lib -name '*.js' -not -path 'lib/public/*')
+          exit $fail
+      
+      - name: Test
+        run: node --test test/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
-      - name: Syntax check
+      - name: Syntax check (server-side, CommonJS)
         run: |
           set -e
           fail=0
@@ -32,5 +32,15 @@ jobs:
           done < <(find bin lib -name '*.js' -not -path 'lib/public/*')
           exit $fail
       
-      - name: Test
-        run: node --test test/*.test.js
+      - name: Syntax check (client-side, ES modules)
+        run: |
+          set -e
+          fail=0
+          while IFS= read -r f; do
+            if ! node --check --input-type=module < "$f" >/dev/null 2>&1; then
+              echo "Syntax error in: $f" >&2
+              node --check --input-type=module < "$f" || true
+              fail=1
+            fi
+          done < <(find lib/public -name '*.js')
+          exit $fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
           exit $fail
       
       - name: Test
-        run: node --test test/
+        run: node --test test/*.test.js

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -84,3 +84,6 @@ jobs:
             fi
           done < <(find lib/public -name '*.js')
           exit $fail
+
+      - name: Run tests
+        run: node --test --test-force-exit test/*.test.js


### PR DESCRIPTION
## Problem

The project has a test file (`test/security.test.js`) with 23 tests covering PIN hashing, path traversal prevention, rate limiting, input validation, and file permissions. However, `pr-checks.yml` only runs syntax checks — tests are never executed in CI.

## Fix

Added a "Run tests" step to `pr-checks.yml` that executes all existing tests via Node.js built-in test runner.

### Key details

- **No new dependencies** — tests use only Node.js built-in modules (`node:test`, `node:assert`, `crypto`, `fs`, `path`, `os`) plus project code
- **`--test-force-exit`** is needed because `require("../lib/server")` loads SQLite, which keeps an open handle that prevents clean exit. This flag (available since Node 21) forces exit after tests complete
- **All 23 tests pass** on Node 22 (the version configured in the workflow)
- Same security model as existing steps: no `npm install`, no secret access, pure stdlib + project code

### What the tests cover

| Area | Tests |
|------|-------|
| PIN scrypt hashing/verification | 5 tests |
| Path traversal prevention (`safePath`) | 5 tests |
| WebSocket rate limiting logic | 1 test |
| Skill name/URL validation | 3 tests |
| Environment variable validation | 4 tests |
| File permissions (`chmodSafe`) | 3 tests |
| Hash migration detection | 2 tests |