### PR TITLE
fix: make model/mode chip changes per-session instead of project-wide

### DIFF
--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -127,6 +127,10 @@ function attachSessions(ctx) {
       if (msg.sessionVisibility) sessionOpts.sessionVisibility = msg.sessionVisibility;
       if (msg.vendor) sessionOpts.vendor = msg.vendor;
       var newSess = sm.createSession(sessionOpts, ws);
+      // Seed per-session model/mode from project defaults so the first query
+      // uses the right values before the user changes anything via the chip.
+      newSess.model = sm.currentModel || null;
+      newSess.permissionMode = sm.currentPermissionMode || null;
       ws._clayActiveSession = newSess.localId;
       // Apply project-level email defaults to new session
       if (typeof ctx._email === "object" && ctx._email.getEmailDefaults) {
@@ -355,6 +359,12 @@ function attachSessions(ctx) {
           var switchedSources = loadContextSources(slug, msg.id);
           sendTo(ws, { type: "context_sources_state", active: switchedSources });
         }
+        // Re-sync chip to the incoming session's own model/mode so the client
+        // doesn't carry over whatever the previous session had set.
+        var _swSess = sm.sessions.get(msg.id);
+        var _swModel = (_swSess && _swSess.model) || sm.currentModel || "";
+        var _swMode = (_swSess && _swSess.permissionMode) || sm.currentPermissionMode || "default";
+        sendTo(ws, { type: "config_state", model: _swModel, mode: _swMode, effort: sm.currentEffort || "medium", betas: sm.currentBetas || [], thinking: sm.currentThinking || "adaptive", thinkingBudget: sm.currentThinkingBudget || 10000 });
         var swPresKey = ws._clayUser ? ws._clayUser.id : "_default";
         userPresence.setPresence(slug, swPresKey, msg.id, null);
       }
@@ -523,7 +533,9 @@ function attachSessions(ctx) {
     if (msg.type === "set_model" && msg.model) {
       var session = getSessionForWs(ws);
       if (session) {
-        sdk.setModel(session, msg.model);
+        sdk.setModel(session, msg.model).then(function () {
+          sendTo(ws, { type: "config_state", model: session.model || sm.currentModel || "", mode: session.permissionMode || sm.currentPermissionMode || "default", effort: sm.currentEffort || "medium", betas: sm.currentBetas || [], thinking: sm.currentThinking || "adaptive", thinkingBudget: sm.currentThinkingBudget || 10000 });
+        });
       }
       return true;
     }
@@ -588,12 +600,11 @@ function attachSessions(ctx) {
     }
 
     if (msg.type === "set_permission_mode" && msg.mode) {
-      sm.currentPermissionMode = msg.mode;
       var session = getSessionForWs(ws);
       if (session) {
         sdk.setPermissionMode(session, msg.mode);
+        sendTo(ws, { type: "config_state", model: session.model || sm.currentModel || "", mode: session.permissionMode || sm.currentPermissionMode || "default", effort: sm.currentEffort || "medium", betas: sm.currentBetas || [], thinking: sm.currentThinking || "adaptive", thinkingBudget: sm.currentThinkingBudget || 10000 });
       }
-      send({ type: "config_state", model: sm.currentModel || "", mode: sm.currentPermissionMode, effort: sm.currentEffort || "medium", betas: sm.currentBetas || [], thinking: sm.currentThinking || "adaptive", thinkingBudget: sm.currentThinkingBudget || 10000 });
       return true;
     }
 

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1506,19 +1506,17 @@ function createSDKBridge(opts) {
       model = modelEntryValue(model);
     }
     if (!session.queryInstance) {
-      // No active query — store on session and shared state for next startQuery
+      // No active query — store on session only (not sm — that's for project defaults).
+      // config_state sent targeted by caller to avoid broadcasting
+      // this session's model to all other open sessions in the project.
       session.model = model;
-      sm.currentModel = model;
       // Don't send vendor here: session vendor not yet bound, let client keep its selection
       sendModelInfoForVendor(null, model);
-      // config_state is sent targeted by the caller to avoid broadcasting
-      // this session's model to all other open sessions in the project.
       return;
     }
     try {
       await session.queryInstance.setModel(model);
       session.model = model;
-      sm.currentModel = model;
       var sessionVendor = session.vendor || (adapter && adapter.vendor) || "claude";
       sendModelInfoForVendor(sessionVendor, model);
       // config_state sent targeted by caller — no broadcast here.

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1193,7 +1193,7 @@ function createSDKBridge(opts) {
       claudeOpts.allowDangerouslySkipPermissions = true;
       claudeOpts.permissionMode = "bypassPermissions";
     } else {
-      var globalMode = sm.currentPermissionMode || "default";
+      var globalMode = session.permissionMode || sm.currentPermissionMode || "default";
       var effectiveDefault;
       if (globalMode === "bypassPermissions") effectiveDefault = "bypassPermissions";
       else if (session.acceptEditsAfterStart) effectiveDefault = "acceptEdits";
@@ -1233,7 +1233,7 @@ function createSDKBridge(opts) {
     // Claude would reject the unknown model. We validate against the
     // session vendor's model list regardless of which vendor happens to be
     // the project's default adapter.
-    var queryModel = ls.model || sm.currentModel || undefined;
+    var queryModel = ls.model || session.model || sm.currentModel || undefined;
     var sessionVendor = session.vendor || (adapter && adapter.vendor) || null;
     if (sessionVendor) {
       var vendorModels = (sm.modelsByVendor && sm.modelsByVendor[sessionVendor]) || [];
@@ -1506,19 +1506,22 @@ function createSDKBridge(opts) {
       model = modelEntryValue(model);
     }
     if (!session.queryInstance) {
-      // No active query — just store the model for next startQuery
+      // No active query — store on session and shared state for next startQuery
+      session.model = model;
       sm.currentModel = model;
       // Don't send vendor here: session vendor not yet bound, let client keep its selection
       sendModelInfoForVendor(null, model);
-      send({ type: "config_state", model: sm.currentModel, mode: sm.currentPermissionMode || "default", effort: sm.currentEffort || "medium", betas: sm.currentBetas || [] });
+      // config_state is sent targeted by the caller to avoid broadcasting
+      // this session's model to all other open sessions in the project.
       return;
     }
     try {
       await session.queryInstance.setModel(model);
+      session.model = model;
       sm.currentModel = model;
       var sessionVendor = session.vendor || (adapter && adapter.vendor) || "claude";
       sendModelInfoForVendor(sessionVendor, model);
-      send({ type: "config_state", model: sm.currentModel, mode: sm.currentPermissionMode || "default", effort: sm.currentEffort || "medium", betas: sm.currentBetas || [] });
+      // config_state sent targeted by caller — no broadcast here.
     } catch (e) {
       send({ type: "error", text: "Failed to switch model: " + (e.message || e) });
     }
@@ -1540,16 +1543,17 @@ function createSDKBridge(opts) {
 
   async function setPermissionMode(session, mode) {
     if (!session.queryInstance) {
-      // No active query — just store the mode for next startQuery
-      sm.currentPermissionMode = mode;
-      send({ type: "config_state", model: sm.currentModel || "", mode: sm.currentPermissionMode, effort: sm.currentEffort || "medium", betas: sm.currentBetas || [] });
+      // No active query — store on session only (sm.currentPermissionMode is
+      // for project defaults; chip changes are session-scoped).
+      // config_state sent targeted by caller.
+      session.permissionMode = mode;
       return;
     }
     try {
       // Route through QueryHandle (works for both in-process and worker paths)
       await session.queryInstance.setPermissionMode(mode);
-      sm.currentPermissionMode = mode;
-      send({ type: "config_state", model: sm.currentModel || "", mode: sm.currentPermissionMode, effort: sm.currentEffort || "medium", betas: sm.currentBetas || [] });
+      session.permissionMode = mode;
+      // config_state sent targeted by caller — no broadcast here.
     } catch (e) {
       send({ type: "error", text: "Failed to set permission mode: " + (e.message || e) });
     }


### PR DESCRIPTION
When a user changes the model or permission mode via the chip in one session, the current implementation broadcasts `config_state` to all open sessions in the same project and writes through to the shared `sm.currentModel` / `sm.currentPermissionMode`. This means switching to a different model in one tab immediately flips every other tab's chip — there is no way to run two sessions at different settings simultaneously.

This change makes model and permission mode truly per-session:

- **sdk-bridge**: `setModel`/`setPermissionMode` store on `session.model` / `session.permissionMode` and drop the `send()` broadcast. Targeted `config_state` delivery is left to the caller.
- **sdk-bridge**: `startQuery` reads session-level values first, falling back to `sm`-level defaults, so the correct settings reach the Claude CLI invocation for each session independently.
- **project-sessions**: `new_session` seeds per-session fields from project defaults so the first query works without a prior chip interaction.
- **project-sessions**: `switch_session` sends a targeted `config_state` with the incoming session's own model/mode so the client chip updates correctly when switching sessions.
- **project-sessions**: `set_model` / `set_permission_mode` handlers use `sendTo` (targeted) instead of `send` (broadcast) and read session fields for the response payload.

`sm.currentModel` and `sm.currentPermissionMode` are preserved as project-level defaults that seed new sessions. The chip is now session-local.