### PR TITLE
feat(tui): add bypass-permissions launch option to Claude session button

### DIFF
--- a/lib/cli-sessions.js
+++ b/lib/cli-sessions.js
@@ -222,9 +222,9 @@ function appendCliRecord(obj, state, history) {
   }
 }
 
-function readCliSessionHistory(cwd, sessionId) {
+function readCliSessionHistory(home, cwd, sessionId) {
   var encoded = encodeCwd(cwd);
-  var filePath = path.join(REAL_HOME, ".claude", "projects", encoded, sessionId + ".jsonl");
+  var filePath = path.join(home || REAL_HOME, ".claude", "projects", encoded, sessionId + ".jsonl");
 
   return new Promise(function (resolve) {
     var history = [];
@@ -265,15 +265,15 @@ function readCliSessionHistory(cwd, sessionId) {
 // are small enough that blocking on a local read is fine.
 // Modified-time (ms) of a CLI session's jsonl, or 0 if missing. Lets callers
 // cheaply detect that the transcript grew (e.g. after a TUI turn) and re-read.
-function cliSessionFileMtime(cwd, sessionId) {
+function cliSessionFileMtime(home, cwd, sessionId) {
   var encoded = encodeCwd(cwd);
-  var filePath = path.join(REAL_HOME, ".claude", "projects", encoded, sessionId + ".jsonl");
+  var filePath = path.join(home || REAL_HOME, ".claude", "projects", encoded, sessionId + ".jsonl");
   try { return fs.statSync(filePath).mtimeMs; } catch (e) { return 0; }
 }
 
-function readCliSessionHistorySync(cwd, sessionId) {
+function readCliSessionHistorySync(home, cwd, sessionId) {
   var encoded = encodeCwd(cwd);
-  var filePath = path.join(REAL_HOME, ".claude", "projects", encoded, sessionId + ".jsonl");
+  var filePath = path.join(home || REAL_HOME, ".claude", "projects", encoded, sessionId + ".jsonl");
   var raw;
   try { raw = fs.readFileSync(filePath, "utf8"); } catch (e) { return []; }
   var history = [];

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -302,7 +302,8 @@ function attachSessions(ctx) {
     // turn appended messages), not just when history is empty. The earlier
     // "already hydrated" short-circuit kept stale history after a
     // Resume -> chat -> Close cycle (showed A instead of A').
-    var mtime = cliSess.cliSessionFileMtime(cwd, session.cliSessionId);
+    var home = resolveSessionHome(session);
+    var mtime = cliSess.cliSessionFileMtime(home, cwd, session.cliSessionId);
     var fresh = (typeof session.terminalId !== "number") &&
                 Array.isArray(session.history) && session.history.length > 0 &&
                 session._historyMtime === mtime;
@@ -311,7 +312,7 @@ function attachSessions(ctx) {
     // Synchronous read: switch_session must populate session.history before
     // the session_switched broadcast replays it. readCliSessionHistory is
     // Promise-based and would resolve too late (the transcript came up empty).
-    try { history = cliSess.readCliSessionHistorySync(cwd, session.cliSessionId); } catch (e) { history = null; }
+    try { history = cliSess.readCliSessionHistorySync(home, cwd, session.cliSessionId); } catch (e) { history = null; }
     if (Array.isArray(history)) {
       session.history = history;
       session._historyMtime = mtime;
@@ -1200,7 +1201,7 @@ function attachSessions(ctx) {
         } else {
           // Read history from CLI session files
           var cliSess = require("./cli-sessions");
-          return cliSess.readCliSessionHistory(cwd, result.sessionId).then(function(history) {
+          return cliSess.readCliSessionHistory(resolveSessionHome(session), cwd, result.sessionId).then(function(history) {
             var forked = sm.resumeSession(result.sessionId, { history: history, title: forkTitle }, ws);
             if (forked) {
               ws._clayActiveSession = forked.localId;

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -260,7 +260,8 @@ function attachSessions(ctx) {
     }
     var sid = session.cliSessionId;
     var localId = session.localId;
-    var cmd = "claude --resume " + sid + "; exit\n";
+    var resumeSkip = session.dangerouslySkipPermissions ? " --dangerously-skip-permissions" : "";
+    var cmd = "claude --resume " + sid + resumeSkip + "; exit\n";
     var term = tm.create(80, 24, getOsUserInfoForWs(ws), ws, {
       initialInput: cmd,
       kind: "tui-session",
@@ -437,11 +438,15 @@ function attachSessions(ctx) {
         sessionOpts.mode = "tui";
         sessionOpts.cliSessionId = crypto.randomUUID();
         sessionOpts.vendor = sessionOpts.vendor || "claude";
+        // Per-session bypass-permissions: TUI shell command only. The flag is
+        // persisted on the session so lazy-resume re-spawns the same way.
+        if (msg.dangerouslySkipPermissions) sessionOpts.dangerouslySkipPermissions = true;
         newSess = sm.createSessionRaw(sessionOpts);
         if (tm) {
           var tuiSid = newSess.cliSessionId;
           var tuiLocalId = newSess.localId;
-          var tuiCmd = "claude --session-id " + tuiSid + "; exit\n";
+          var tuiSkip = newSess.dangerouslySkipPermissions ? " --dangerously-skip-permissions" : "";
+          var tuiCmd = "claude --session-id " + tuiSid + tuiSkip + "; exit\n";
           var tuiTerm = tm.create(80, 24, getOsUserInfoForWs(ws), ws, {
             initialInput: tuiCmd,
             kind: "tui-session",

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -1040,6 +1040,28 @@
   opacity: 1;
 }
 
+/* Split button: main action + chevron sharing one grid cell. */
+.session-top-action-split {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  min-width: 0;
+}
+
+.session-top-action-split .split-main {
+  flex: 1 1 auto;
+  width: auto;
+}
+
+.session-top-action-split .split-chevron {
+  flex: 0 0 auto;
+  width: 28px;
+  min-width: 28px;
+  padding: 0;
+  justify-content: center;
+  gap: 0;
+}
+
 .session-favorites-section {
   min-height: 6px;
   margin: 0 8px;

--- a/lib/public/modules/sidebar-sessions.js
+++ b/lib/public/modules/sidebar-sessions.js
@@ -296,11 +296,14 @@ function renderSessionTopActions() {
   var wrap = document.createElement("div");
   wrap.className = "session-top-actions";
 
-  // Claude: single button. TUI vs GUI is the user's claudeOpenMode pref
-  // (set in user settings), so we send no explicit mode and let the server
-  // apply it - no per-click chevron/menu needed.
+  // Claude: split button. The main button creates a session using the user's
+  // claudeOpenMode pref (server applies it). The chevron opens a menu with
+  // alternate launch modes (e.g. bypass-permissions, TUI shell only).
+  var claudeCell = document.createElement("div");
+  claudeCell.className = "session-top-action-split";
+
   var claudeBtn = document.createElement("button");
-  claudeBtn.className = "session-top-action";
+  claudeBtn.className = "session-top-action split-main";
   claudeBtn.type = "button";
   claudeBtn.title = "New Claude session";
   claudeBtn.innerHTML = '<img src="/claude-code-avatar.png" class="session-top-action-icon" alt=""><span>Claude</span>';
@@ -309,7 +312,23 @@ function renderSessionTopActions() {
       getWs().send(JSON.stringify({ type: "new_session", vendor: "claude" }));
     }
   });
-  wrap.appendChild(claudeBtn);
+  claudeCell.appendChild(claudeBtn);
+
+  var claudeChevron = document.createElement("button");
+  claudeChevron.className = "session-top-action split-chevron";
+  claudeChevron.type = "button";
+  claudeChevron.title = "More Claude launch options";
+  claudeChevron.setAttribute("aria-label", "More Claude launch options");
+  claudeChevron.innerHTML = iconHtml("chevron-down");
+  claudeChevron.addEventListener("click", function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (sessionCtxMenu) { closeSessionCtxMenu(); return; }
+    showClaudeStartMenu(claudeChevron);
+  });
+  claudeCell.appendChild(claudeChevron);
+
+  wrap.appendChild(claudeCell);
 
   // Codex: always GUI (no TUI adapter for Codex).
   var codexBtn = document.createElement("button");
@@ -325,6 +344,53 @@ function renderSessionTopActions() {
   wrap.appendChild(codexBtn);
 
   return wrap;
+}
+
+// Dropdown anchored to the Claude split-button chevron. Reuses the
+// session-ctx-menu element/var so the global document click handler closes it.
+function showClaudeStartMenu(anchorBtn) {
+  closeSessionCtxMenu();
+
+  var menu = document.createElement("div");
+  menu.className = "session-ctx-menu";
+
+  var skipItem = document.createElement("button");
+  skipItem.className = "session-ctx-item";
+  skipItem.innerHTML = iconHtml("shield-off") + " <span>Skip permissions (TUI)</span>";
+  skipItem.title = "Start a terminal session with --dangerously-skip-permissions";
+  skipItem.addEventListener("click", function (e) {
+    e.stopPropagation();
+    closeSessionCtxMenu();
+    if (getWs() && store.get('connected')) {
+      getWs().send(JSON.stringify({
+        type: "new_session",
+        vendor: "claude",
+        mode: "tui",
+        dangerouslySkipPermissions: true,
+      }));
+    }
+  });
+  menu.appendChild(skipItem);
+
+  document.body.appendChild(menu);
+  sessionCtxMenu = menu;
+  refreshIcons();
+
+  requestAnimationFrame(function () {
+    var btnRect = anchorBtn.getBoundingClientRect();
+    menu.style.position = "fixed";
+    menu.style.top = (btnRect.bottom + 2) + "px";
+    menu.style.left = btnRect.left + "px";
+    menu.style.right = "auto";
+    var menuRect = menu.getBoundingClientRect();
+    if (menuRect.right > window.innerWidth - 8) {
+      menu.style.left = "auto";
+      menu.style.right = (window.innerWidth - btnRect.right) + "px";
+    }
+    if (menuRect.bottom > window.innerHeight - 8) {
+      menu.style.top = (btnRect.top - menuRect.height - 2) + "px";
+    }
+  });
 }
 
 function runSessionSearch(query) {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -100,6 +100,9 @@ function createSessionManager(opts) {
       // the click handler will respawn the PTY via `claude --resume` when
       // the user reopens the session.
       if (session.mode === "tui") metaObj.mode = "tui";
+      // Born-TUI sessions launched in bypass-permissions mode persist the flag
+      // so lazy-resume (`claude --resume`) re-spawns with the same flag.
+      if (session.dangerouslySkipPermissions) metaObj.dangerouslySkipPermissions = true;
       if (session.sessionVisibility) metaObj.sessionVisibility = session.sessionVisibility;
       if (session.bookmarked) metaObj.bookmarked = true;
       if (typeof session.favoriteOrder === "number") metaObj.favoriteOrder = session.favoriteOrder;
@@ -212,6 +215,7 @@ function createSessionManager(opts) {
       // here so it shows up in the sidebar with the right icon; the
       // switch_session handler respawns the PTY on click.
       session.mode = (m.mode === "tui") ? "tui" : "gui";
+      session.dangerouslySkipPermissions = !!m.dangerouslySkipPermissions;
       session.terminalId = null;
       session.runtimeMode = null;
       session.runtimeTerminalId = null;
@@ -497,6 +501,7 @@ function createSessionManager(opts) {
       favoriteOrder: null,
       vendor: (sessionOpts && sessionOpts.vendor) || null,
       mode: (sessionOpts && sessionOpts.mode === "tui") ? "tui" : "gui",
+      dangerouslySkipPermissions: !!(sessionOpts && sessionOpts.dangerouslySkipPermissions),
       terminalId: null,
     };
     sessions.set(localId, session);

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -19,7 +19,7 @@ var schema = {
   "switch_session":           { direction: "c2s", handler: "lib/project-sessions.js", description: "Switch the active session by local ID" },
   "resume_tui_session":       { direction: "c2s", handler: "lib/project-sessions.js", description: "Spawn the claude --resume PTY for a TUI session shown read-only (lazy resume)" },
   "suspend_tui_session":      { direction: "c2s", handler: "lib/project-sessions.js", description: "Close a live TUI session's PTY now but keep it resumable (explicit Close)" },
-  "new_session":              { direction: "c2s", handler: "lib/project-sessions.js", description: "Create a new blank session" },
+  "new_session":              { direction: "c2s", handler: "lib/project-sessions.js", description: "Create a new blank session (opts: vendor, mode, sessionVisibility, dangerouslySkipPermissions)" },
   "delete_session":           { direction: "c2s", handler: "lib/project-sessions.js", description: "Delete a session by ID" },
   "rename_session":           { direction: "c2s", handler: "lib/project-sessions.js", description: "Rename a session" },
   "set_session_bookmark":     { direction: "c2s", handler: "lib/project-sessions.js", description: "Bookmark or unbookmark a session in the sidebar" },


### PR DESCRIPTION
## Summary

Adds a chevron split button next to the sidebar **Claude** button. The chevron opens a menu with **Skip permissions (TUI)**, which starts a terminal session running `claude --dangerously-skip-permissions`.

TUI shell command only — GUI/SDK sessions are untouched.

## Changes

**Server**
- `lib/sessions.js`: new `dangerouslySkipPermissions` field on the session record (`createSessionRaw`), persisted in the session file meta (`saveSessionFile`) and restored on load (`loadSessions`).
- `lib/project-sessions.js`: `new_session` TUI path honors `msg.dangerouslySkipPermissions`, appending the flag to `claude --session-id <id>`. `spawnRuntimeTuiPty` (lazy-resume) reuses the persisted flag so `claude --resume` re-spawns in the same mode.
- `lib/ws-schema.js`: documented the `new_session` options.

**Client**
- `lib/public/modules/sidebar-sessions.js`: Claude button is now a split button (main + chevron). The chevron menu sends `{ type: "new_session", vendor: "claude", mode: "tui", dangerouslySkipPermissions: true }`. Reuses the existing `sessionCtxMenu` so the global click handler closes it.
- `lib/public/css/sidebar.css`: split-button layout.

## Notes

- Independent of the global daemon-level `--dangerously-skip-permissions` flag, since for TUI it is just a CLI argument on the spawned shell.
- Mobile sidebar Claude button is unchanged (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)