### PR TITLE
feat(sessions): default Claude sessions to GUI and tidy Chat settings

### DIFF
--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -155,8 +155,8 @@ function attachConnection(ctx) {
     // Initial per-user preference: how to render Claude sessions.
     if (usersModule && typeof usersModule.getClaudeOpenMode === "function") {
       var _comUid = (wsUser && wsUser.id) || null;
-      var _comVal = _comUid ? usersModule.getClaudeOpenMode(_comUid) : "tui";
-      sendTo(ws, { type: "claude_open_mode_changed", claudeOpenMode: _comVal || "tui" });
+      var _comVal = _comUid ? usersModule.getClaudeOpenMode(_comUid) : "gui";
+      sendTo(ws, { type: "claude_open_mode_changed", claudeOpenMode: _comVal || "gui" });
     }
 
     // What's New: push the full entries list (for the home-page feed)

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -104,10 +104,10 @@ function attachSessions(ctx) {
   // Multi-user mode reads per-user storage; single-user mode falls back to
   // the daemon-level default ('gui').
   function getClaudeOpenModeForWs(ws) {
-    if (!usersModule || typeof usersModule.getClaudeOpenMode !== "function") return "tui";
+    if (!usersModule || typeof usersModule.getClaudeOpenMode !== "function") return "gui";
     var uid = ws && ws._clayUser ? ws._clayUser.id : null;
-    if (!uid) return "tui";
-    try { return usersModule.getClaudeOpenMode(uid) || "tui"; } catch (e) { return "tui"; }
+    if (!uid) return "gui";
+    try { return usersModule.getClaudeOpenMode(uid) || "gui"; } catch (e) { return "gui"; }
   }
 
   // Resolve the home directory where Claude Code writes JSONL for a

--- a/lib/public/css/user-settings.css
+++ b/lib/public/css/user-settings.css
@@ -360,6 +360,15 @@
   color: var(--text-muted);
 }
 
+/* Padded body for cards that hold free content (not a toggle/field row),
+   so their inset matches the 16px used by toggle rows above/below. */
+#user-settings .settings-card-body {
+  padding: 14px 16px;
+}
+#user-settings .settings-card-body > .settings-label:first-child {
+  margin-bottom: 2px;
+}
+
 /* Auto-approve allow-list editor */
 #us-claude-allow-list {
   width: 100%;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -1061,24 +1061,26 @@
             <label class="settings-toggle-row">
               <div>
                 <span class="settings-label">Open Claude as terminal (TUI)</span>
-                <div class="settings-hint">Render Claude sessions in an embedded `claude` terminal instead of Clay's chat UI. Keeps usage in the Interactive billing bucket (post 2026-06-15 Agent SDK split). Applies on the next session open.</div>
+                <div class="settings-hint">Render Claude sessions in an embedded <code>claude</code> terminal instead of Clay's chat UI. Applies on the next session open.</div>
               </div>
               <input type="checkbox" id="us-claude-open-mode">
               <span class="toggle-track"><span class="toggle-thumb"></span></span>
             </label>
           </div>
           <div class="settings-card">
-            <div class="settings-label">Auto-approved commands</div>
-            <div class="settings-hint">Extra patterns Clay should pre-approve in your <code>~/.claude/settings.json</code> so TUI sessions don't prompt for them. One per line. Examples: <code>Bash(npm test:*)</code>, <code>Read</code>, <code>mcp__myserver__*</code>. Clay's safe defaults (read-only tools, common git/ls/grep) are always applied on top and shown below for reference.</div>
-            <textarea id="us-claude-allow-list" rows="6" spellcheck="false" placeholder="Bash(npm test:*)&#10;Bash(make:*)"></textarea>
-            <div class="settings-allow-actions">
-              <button type="button" id="us-claude-allow-save" class="settings-action">Save</button>
-              <span id="us-claude-allow-status" class="settings-allow-status"></span>
+            <div class="settings-card-body">
+              <div class="settings-label">Auto-approved commands</div>
+              <div class="settings-hint">Extra patterns Clay should pre-approve in your <code>~/.claude/settings.json</code> so TUI sessions don't prompt for them. One per line. Examples: <code>Bash(npm test:*)</code>, <code>Read</code>, <code>mcp__myserver__*</code>. Clay's safe defaults (read-only tools, common git/ls/grep) are always applied on top and shown below for reference.</div>
+              <textarea id="us-claude-allow-list" rows="6" spellcheck="false" placeholder="Bash(npm test:*)&#10;Bash(make:*)"></textarea>
+              <div class="settings-allow-actions">
+                <button type="button" id="us-claude-allow-save" class="settings-action">Save</button>
+                <span id="us-claude-allow-status" class="settings-allow-status"></span>
+              </div>
+              <details class="settings-allow-defaults">
+                <summary>Show Clay's managed defaults</summary>
+                <div id="us-claude-allow-managed" class="settings-allow-managed"></div>
+              </details>
             </div>
-            <details class="settings-allow-defaults">
-              <summary>Show Clay's managed defaults</summary>
-              <div id="us-claude-allow-managed" class="settings-allow-managed"></div>
-            </details>
           </div>
         </div>
 

--- a/lib/users-preferences.js
+++ b/lib/users-preferences.js
@@ -245,7 +245,10 @@ function attachPreferences(deps) {
   var CLAUDE_OPEN_MODE_RESET_MS = CLAUDE_OPEN_MODE_CUTOVER_MS;
 
   function defaultClaudeOpenMode() {
-    return (Date.now() >= CLAUDE_OPEN_MODE_CUTOVER_MS) ? "tui" : "gui";
+    // Reverted to GUI: the TUI default was a hedge against the (since-cancelled)
+    // Agent SDK separate-credit billing. Users who explicitly picked TUI after
+    // the cutover keep it (isStoredPreferenceLive); everyone else gets GUI.
+    return "gui";
   }
 
   // A stored preference counts only if it was set on or after the reset


### PR DESCRIPTION
## Why

The default Claude open mode was switched to **TUI** as a hedge against the Agent SDK separate-credit billing announced for 2026-06-15. Anthropic [cancelled that change](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) (SDK / `claude -p` / third-party usage still draws from the subscription), so the hedge is no longer needed.

## Changes

**Default back to GUI**
- `defaultClaudeOpenMode()` returns `"gui"`.
- `getClaudeOpenModeForWs` and the connection-time fallback default to `"gui"`.
- Users who **explicitly** picked TUI after the cutover keep it (`isStoredPreferenceLive` still respects stored choices). Existing live TUI sessions are unaffected.

**Chat settings UI tidy**
- Wrap the "Auto-approved commands" card content in a padded `.settings-card-body` so its inset matches the toggle cards above — it was flush against the card border (the "급조" look).
- Remove the stale billing copy from the TUI toggle hint (referenced the cancelled 2026-06-15 Agent SDK split).

## Notes
- The auto-approved managed list shown in settings is unchanged and still sourced from `safe-bash-commands.js` (single source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)