### PR TITLE
fix(os-users): skip per-user Claude CLI install when already available

### DIFF
--- a/lib/os-users.js
+++ b/lib/os-users.js
@@ -340,11 +340,43 @@ function getLinuxUserUid(username) {
 }
 
 /**
+ * Check whether the Claude CLI is already resolvable for a Linux user,
+ * using the same login PATH the session will actually run with.
+ * Runs `command -v claude` inside a login shell (`su - <user>`) so a
+ * system-wide install (e.g. /usr/bin/claude) is detected, not just the
+ * hardcoded ~/.local/bin/claude path.
+ * Returns true if claude resolves, false otherwise.
+ */
+function claudeAvailableForUser(linuxName) {
+  if (!isSafeLinuxUsername(linuxName)) return false;
+  try {
+    var out = execFileSync("su", ["-", linuxName, "-c", "command -v claude"], {
+      encoding: "utf8",
+      timeout: 10000,
+      stdio: "pipe",
+    }).trim();
+    return out.length > 0;
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
  * Install Claude CLI for a Linux user account.
  * Downloads and runs the install script, then ensures PATH is configured.
  * Non-fatal: logs errors but does not throw.
+ * Skips entirely when claude is already resolvable for the user, or when
+ * CLAY_SKIP_CLAUDE_INSTALL is set (bring-your-own-claude).
  */
 function installClaudeCli(linuxName) {
+  if (process.env.CLAY_SKIP_CLAUDE_INSTALL) {
+    console.log("[os-users] CLAY_SKIP_CLAUDE_INSTALL set, skipping Claude CLI install for " + linuxName);
+    return;
+  }
+  if (claudeAvailableForUser(linuxName)) {
+    console.log("[os-users] Claude CLI already available for " + linuxName + ", skipping install");
+    return;
+  }
   try {
     if (!isSafeLinuxUsername(linuxName)) throw new Error("Invalid Linux username");
     // Download and run the Claude CLI install script as the target user
@@ -429,10 +461,11 @@ function provisionAllUsers(usersModule) {
     if (user.linuxUser) {
       // Already mapped, verify the Linux user still exists
       if (linuxUserExists(user.linuxUser)) {
-        // Ensure Claude CLI is installed for existing users
-        var cliPath = "/home/" + user.linuxUser + "/.local/bin/claude";
-        if (!fs.existsSync(cliPath)) {
-          console.log("[os-users] Claude CLI missing for " + user.linuxUser + ", installing...");
+        // Ensure Claude CLI is available for existing users. Resolve against
+        // the user's actual login PATH so a system-wide install counts, rather
+        // than checking a single hardcoded ~/.local/bin/claude path.
+        if (!claudeAvailableForUser(user.linuxUser)) {
+          console.log("[os-users] Claude CLI not resolvable for " + user.linuxUser + ", installing...");
           installClaudeCli(user.linuxUser);
         }
         // Ensure linger is enabled for existing users
@@ -520,6 +553,7 @@ module.exports = {
   provisionAllUsers: provisionAllUsers,
   grantAllUsersAccess: grantAllUsersAccess,
   installClaudeCli: installClaudeCli,
+  claudeAvailableForUser: claudeAvailableForUser,
   deactivateLinuxUser: deactivateLinuxUser,
   ensureProjectsDir: ensureProjectsDir,
   isHomeDirectory: isHomeDirectory,


### PR DESCRIPTION
## Summary

Fixes #368.

In `--os-users` mode, Clay provisioned a per-user copy of the Claude CLI even on hosts where `claude` is already installed system-wide. The install was gated on a single hardcoded path (`/home/<user>/.local/bin/claude`), so a system-wide binary (e.g. `/usr/bin/claude`) was invisible to the check, triggering a redundant `curl | bash` download per user, an extra PATH export in each user's shell rc, and version drift between the system binary and N per-user copies.

## Changes

- Add `claudeAvailableForUser(linuxName)` which resolves `claude` via `su - <user> -c 'command -v claude'`, i.e. against the same login PATH the session actually runs with, so a system-wide install is detected.
- Gate `installClaudeCli()` on that check and skip the install when `claude` is already resolvable.
- Honor `CLAY_SKIP_CLAUDE_INSTALL` to disable auto-install entirely (bring-your-own-claude).
- `provisionAllUsers()` now uses the PATH-aware check instead of the hardcoded path for existing users.

## Test

- `node -e "require('./lib/os-users.js')"` loads cleanly and exports `claudeAvailableForUser`.