### PR TITLE
fix(os-users): inherit supplementary groups in spawned sessions

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -28,7 +28,8 @@ var path = require("path");
 var { loadConfig, saveConfig, socketPath, generateSlug, syncClayrc, removeFromClayrc, writeCrashInfo, readCrashInfo, clearCrashInfo, isPidAlive, clearStaleConfig, REAL_HOME } = require("./config");
 var { createIPCServer } = require("./ipc");
 var { createServer, generateAuthToken } = require("./server");
-var { checkAclSupport, grantProjectAccess, revokeProjectAccess, provisionAllUsers, provisionLinuxUser, grantAllUsersAccess, deactivateLinuxUser, ensureProjectsDir } = require("./os-users");
+var osUsersMod = require("./os-users");
+var { checkAclSupport, grantProjectAccess, revokeProjectAccess, provisionAllUsers, provisionLinuxUser, grantAllUsersAccess, deactivateLinuxUser, ensureProjectsDir } = osUsersMod;
 var usersModule = require("./users");
 var { createWorktree, removeWorktree, isWorktree } = require("./worktree");
 var mates = require("./mates");
@@ -52,6 +53,9 @@ if (process.env.SUDO_USER) console.log("[daemon] SUDO_USER: " + process.env.SUDO
 console.log("[daemon] UID: " + (typeof process.getuid === "function" ? process.getuid() : "N/A"));
 
 // --- OS users mode: check required system dependencies ---
+// Supplementary-group inheritance (issue #367): default on so sessions behave
+// like a normal login; operators can disable via config / the settings toggle.
+osUsersMod.setInheritGroups(config.inheritGroups !== false);
 if (config.osUsers) {
   var checkExec = require("child_process").execFileSync;
   var missing = [];
@@ -62,6 +66,11 @@ if (config.osUsers) {
     console.error("[daemon] OS users mode requires missing system packages: " + missing.join(", "));
     console.error("[daemon] Install with:  sudo apt install " + missing.map(function (m) { return m.split(" ")[0]; }).join(" "));
     process.exit(78); // EX_CONFIG
+  }
+  if (config.inheritGroups !== false) {
+    console.log("[daemon] Sessions inherit each user's supplementary groups (docker, etc.); disable in Settings > User Groups.");
+  } else {
+    console.log("[daemon] Sessions run with primary group only (supplementary groups dropped); enable in Settings > User Groups.");
   }
 }
 
@@ -216,7 +225,8 @@ var relay = createServer({
           if (uidGid) {
             fs.chmodSync(targetDir, 0o700);
             execFileSync("chown", ["-R", linuxUser + ":" + linuxUser, targetDir]);
-            execFileSync("git", ["init"], { cwd: targetDir, uid: uidGid.uid, gid: uidGid.gid, env: { PATH: "/usr/local/bin:/usr/bin:/bin" } });
+            var gitInit = osUsersMod.wrapSpawnAsUser("git", ["init"], { cwd: targetDir, uid: uidGid.uid, gid: uidGid.gid, env: { PATH: "/usr/local/bin:/usr/bin:/bin" } });
+            execFileSync(gitInit.command, gitInit.args, gitInit.options);
           } else {
             execFileSync("git", ["init"], { cwd: targetDir });
           }
@@ -296,7 +306,8 @@ var relay = createServer({
         return;
       }
     }
-    var proc = spawn("git", ["clone", cloneUrl, targetDir], spawnOpts);
+    var cloneSpawn = osUsersMod.wrapSpawnAsUser("git", ["clone", cloneUrl, targetDir], spawnOpts);
+    var proc = spawn(cloneSpawn.command, cloneSpawn.args, cloneSpawn.options);
     var stderrBuf = "";
     proc.stderr.on("data", function (chunk) { stderrBuf += chunk.toString(); });
     // 5 minute timeout
@@ -689,6 +700,8 @@ var relay = createServer({
       headless: !!config.headless,
       keepAwake: !!config.keepAwake,
       autoContinueOnRateLimit: !!config.autoContinueOnRateLimit,
+      osUsers: !!config.osUsers,
+      inheritGroups: config.inheritGroups !== false,
       chatLayout: config.chatLayout || "channel",
       matesEnabled: config.matesEnabled !== false,
       pinEnabled: !!config.pinHash,
@@ -803,6 +816,16 @@ var relay = createServer({
     }
     console.log("[daemon] Keep awake:", want, "(web)");
     return { ok: true, keepAwake: want };
+  },
+  onSetInheritGroups: function (value) {
+    var want = !!value;
+    config.inheritGroups = want;
+    saveConfig(config);
+    // Apply live so subsequent session/terminal spawns pick it up without a
+    // daemon restart; already-running sessions keep their current groups.
+    osUsersMod.setInheritGroups(want);
+    console.log("[daemon] Inherit supplementary groups:", want, "(web)");
+    return { ok: true, inheritGroups: want };
   },
   onShutdown: function () {
     console.log("[daemon] Shutdown requested via web UI");

--- a/lib/os-users.js
+++ b/lib/os-users.js
@@ -14,6 +14,68 @@ function isSafeLinuxUsername(username) {
   return typeof username === "string" && /^[a-z_][a-z0-9_-]*[$]?$/.test(username);
 }
 
+// --- Supplementary group inheritance (issue #367) ---
+// Node's child_process { uid, gid } options call setuid/setgid but never
+// initgroups(), so spawned sessions drop all supplementary groups (docker,
+// video, wheel, ...). When inheritGroups is enabled we route the spawn through
+// `setpriv --init-groups` so the child gets the same groups as a normal login.
+var _inheritGroups = true; // default: behave like a normal login shell
+var _setprivAvail = null;
+var _warnedNoSetpriv = false;
+
+function setInheritGroups(value) {
+  _inheritGroups = !!value;
+}
+
+function getInheritGroups() {
+  return _inheritGroups;
+}
+
+function setprivAvailable() {
+  if (_setprivAvail !== null) return _setprivAvail;
+  try {
+    execFileSync("setpriv", ["--help"], { stdio: "ignore", timeout: 5000 });
+    _setprivAvail = true;
+  } catch (e) {
+    _setprivAvail = false;
+  }
+  return _setprivAvail;
+}
+
+/**
+ * Wrap a spawn/exec invocation so the child runs as the target user WITH its
+ * supplementary groups initialized (initgroups), which Node's uid/gid options
+ * do not do. Accepts (command, args, options) where options may carry
+ * uid/gid, and returns a normalized { command, args, options } to pass to
+ * spawn()/execFileSync()/pty.spawn().
+ *
+ * - Same-user spawns (no uid/gid in options) are returned unchanged.
+ * - When inheritGroups is disabled, or setpriv is unavailable, falls back to
+ *   Node's uid/gid options (primary group only) so behavior degrades safely.
+ * Requires the parent process to be root, which is the case in os-users mode.
+ */
+function wrapSpawnAsUser(command, args, options) {
+  args = args || [];
+  options = options || {};
+  var uid = options.uid;
+  var gid = options.gid;
+  if (uid == null || gid == null) return { command: command, args: args, options: options };
+
+  if (_inheritGroups && setprivAvailable()) {
+    var wrappedArgs = ["--reuid", String(uid), "--regid", String(gid), "--init-groups", "--", command].concat(args);
+    var newOpts = Object.assign({}, options);
+    delete newOpts.uid;
+    delete newOpts.gid;
+    return { command: "setpriv", args: wrappedArgs, options: newOpts };
+  }
+
+  if (_inheritGroups && !_warnedNoSetpriv) {
+    _warnedNoSetpriv = true;
+    console.warn("[os-users] inheritGroups enabled but `setpriv` not found; supplementary groups will be dropped. Install util-linux to restore them.");
+  }
+  return { command: command, args: args, options: options };
+}
+
 /**
  * Resolve Linux user info from username via getent passwd.
  * Returns { uid, gid, home, user, shell } or throws on failure.
@@ -84,13 +146,14 @@ function fsAsUser(op, args, osUserInfo) {
       "var buf = fs.readFileSync(f);",
       "process.stdout.write(buf.toString('base64'));",
     ].join(" ");
-    var binOutput = execFileSync(process.execPath, ["-e", script], {
+    var binSpawn = wrapSpawnAsUser(process.execPath, ["-e", script], {
       encoding: "utf8",
       timeout: 10000,
       uid: osUserInfo.uid,
       gid: osUserInfo.gid,
       maxBuffer: 50 * 1024 * 1024,
     });
+    var binOutput = execFileSync(binSpawn.command, binSpawn.args, binSpawn.options);
     return { buffer: Buffer.from(binOutput.trim(), "base64") };
   } else if (op === "write") {
     script = [
@@ -104,12 +167,13 @@ function fsAsUser(op, args, osUserInfo) {
     throw new Error("Unknown fsAsUser operation: " + op);
   }
 
-  var output = execFileSync(process.execPath, ["-e", script], {
+  var fsSpawn = wrapSpawnAsUser(process.execPath, ["-e", script], {
     encoding: "utf8",
     timeout: 10000,
     uid: osUserInfo.uid,
     gid: osUserInfo.gid,
   });
+  var output = execFileSync(fsSpawn.command, fsSpawn.args, fsSpawn.options);
 
   return JSON.parse(output.trim());
 }
@@ -554,6 +618,9 @@ module.exports = {
   grantAllUsersAccess: grantAllUsersAccess,
   installClaudeCli: installClaudeCli,
   claudeAvailableForUser: claudeAvailableForUser,
+  setInheritGroups: setInheritGroups,
+  getInheritGroups: getInheritGroups,
+  wrapSpawnAsUser: wrapSpawnAsUser,
   deactivateLinuxUser: deactivateLinuxUser,
   ensureProjectsDir: ensureProjectsDir,
   isHomeDirectory: isHomeDirectory,

--- a/lib/project-http.js
+++ b/lib/project-http.js
@@ -335,7 +335,8 @@ function attachHTTP(ctx) {
           });
         }
         console.log("[skill-install] spawning: npx skills add " + url + " --skill " + skill + " --yes " + scopeFlag + " (cwd: " + spawnCwd + ")");
-        var child = spawn("npx", ["skills", "add", url, "--skill", skill, "--yes", scopeFlag], skillSpawnOpts);
+        var skillAddSpawn = require("./os-users").wrapSpawnAsUser("npx", ["skills", "add", url, "--skill", skill, "--yes", scopeFlag], skillSpawnOpts);
+        var child = spawn(skillAddSpawn.command, skillAddSpawn.args, skillAddSpawn.options);
         var stdoutBuf = "";
         var stderrBuf = "";
         child.stdout.on("data", function (chunk) {
@@ -427,11 +428,12 @@ function attachHTTP(ctx) {
           if (uninstallUserInfo) {
             // Run rm as target user to respect permissions
             var rmScript = "var fs = require('fs'); fs.rmSync(" + JSON.stringify(resolved) + ", { recursive: true, force: true });";
-            execFileSync(process.execPath, ["-e", rmScript], {
+            var rmSpawn = require("./os-users").wrapSpawnAsUser(process.execPath, ["-e", rmScript], {
               uid: uninstallUserInfo.uid,
               gid: uninstallUserInfo.gid,
               timeout: 10000,
             });
+            execFileSync(rmSpawn.command, rmSpawn.args, rmSpawn.options);
           } else {
             fs.rmSync(resolved, { recursive: true, force: true });
           }

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -1700,7 +1700,7 @@ function attachSessions(ctx) {
 
     // --- Daemon config / server management (admin-only in multi-user mode) ---
     if (msg.type === "get_daemon_config" || msg.type === "set_pin" || msg.type === "set_keep_awake" ||
-        msg.type === "set_auto_continue" || msg.type === "set_image_retention" || msg.type === "shutdown_server" || msg.type === "restart_server") {
+        msg.type === "set_auto_continue" || msg.type === "set_inherit_groups" || msg.type === "set_image_retention" || msg.type === "shutdown_server" || msg.type === "restart_server") {
       if (usersModule.isMultiUser()) {
         var _wsUser = ws._clayUser;
         if (!_wsUser || _wsUser.role !== "admin") {
@@ -1740,6 +1740,15 @@ function attachSessions(ctx) {
         var acResult = opts.onSetAutoContinue(msg.value);
         sendTo(ws, { type: "set_auto_continue_result", ok: acResult.ok, autoContinueOnRateLimit: acResult.autoContinueOnRateLimit });
         send({ type: "auto_continue_changed", autoContinueOnRateLimit: acResult.autoContinueOnRateLimit });
+      }
+      return true;
+    }
+
+    if (msg.type === "set_inherit_groups") {
+      if (typeof opts.onSetInheritGroups === "function") {
+        var igResult = opts.onSetInheritGroups(msg.value);
+        sendTo(ws, { type: "set_inherit_groups_result", ok: igResult.ok, inheritGroups: igResult.inheritGroups });
+        send({ type: "inherit_groups_changed", inheritGroups: igResult.inheritGroups });
       }
       return true;
     }

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -1151,6 +1151,7 @@
           </optgroup>
           <optgroup label="Server">
             <option value="keep-awake" class="hidden" id="settings-keep-awake-opt">Keep Awake</option>
+            <option value="inherit-groups" class="hidden" id="settings-inherit-groups-opt">User Groups</option>
             <option value="restart">Restart</option>
             <option value="shutdown">Shutdown</option>
           </optgroup>
@@ -1177,6 +1178,7 @@
           <div class="settings-nav-separator"></div>
           <div class="settings-nav-category">Server</div>
           <button class="settings-nav-item hidden" data-section="keep-awake" id="settings-keep-awake-nav"><span>Keep Awake</span></button>
+          <button class="settings-nav-item hidden settings-admin-only" data-section="inherit-groups" id="settings-inherit-groups-nav"><span>User Groups</span></button>
           <button class="settings-nav-item" data-section="restart"><span>Restart</span></button>
           <button class="settings-nav-item settings-nav-danger" data-section="shutdown"><span>Shutdown</span></button>
         </div>
@@ -1426,6 +1428,19 @@
                 <div class="settings-hint">Prevent the system from sleeping while the server is running (macOS only).</div>
               </div>
               <input type="checkbox" id="settings-keep-awake">
+              <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </label>
+          </div>
+        </div>
+        <div class="server-settings-section hidden settings-admin-only" data-section="inherit-groups" id="settings-inherit-groups-section">
+          <h2>User Groups</h2>
+          <div class="settings-card">
+            <label class="settings-toggle-row">
+              <div>
+                <span class="settings-label">Inherit supplementary groups</span>
+                <div class="settings-hint">Give each session the user's full group membership (docker, video, etc.), matching a normal login. Disable to run sessions with only the primary group. Requires <code>setpriv</code> (util-linux). Applies to new sessions.</div>
+              </div>
+              <input type="checkbox" id="settings-inherit-groups">
               <span class="toggle-track"><span class="toggle-thumb"></span></span>
             </label>
           </div>

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -25,7 +25,7 @@ import { startThinking, appendThinking, stopThinking, resetThinkingGroup, create
 import { showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './notifications.js';
 import { handleFsList, handleFsRead, handleFileChanged, handleDirChanged, handleFileHistory, handleGitDiff, handleFileAt, refreshIfOpen, getPendingNavigate, handleFsSearch } from './filebrowser.js';
 import { isProjectSettingsOpen, handleInstructionsRead, handleInstructionsWrite, handleProjectEnv, handleProjectEnvSaved, handleProjectSharedEnv, handleProjectSharedEnvSaved, handleProjectOwnerChanged } from './project-settings.js';
-import { updateSettingsModels, updateSettingsStats, updateDaemonConfig, handleSetPinResult, handleKeepAwakeChanged, handleAutoContinueChanged, handleRestartResult, handleShutdownResult, handleSharedEnv, handleSharedEnvSaved, handleGlobalClaudeMdRead, handleGlobalClaudeMdWrite } from './server-settings.js';
+import { updateSettingsModels, updateSettingsStats, updateDaemonConfig, handleSetPinResult, handleKeepAwakeChanged, handleInheritGroupsChanged, handleAutoContinueChanged, handleRestartResult, handleShutdownResult, handleSharedEnv, handleSharedEnvSaved, handleGlobalClaudeMdRead, handleGlobalClaudeMdWrite } from './server-settings.js';
 import { handleTermList, handleTermCreated, sendTerminalCommand, handleTermOutput, handleTermResized, handleTermExited, handleTermClosed } from './terminal.js';
 import { attachTuiView, detachTuiView, setTuiSuspendedView, tuiHandleTermOutput, tuiHandleTermResized, tuiHandleTermExited, tuiHandleTermClosed } from './session-tui-view.js';
 import { handleTuiTranscriptState } from './tui-grab.js';
@@ -1703,6 +1703,11 @@ export function processMessage(msg) {
 
       case "keep_awake_changed":
         handleKeepAwakeChanged(msg);
+        break;
+
+      case "set_inherit_groups_result":
+      case "inherit_groups_changed":
+        handleInheritGroupsChanged(msg);
         break;
 
       case "set_auto_continue_result":

--- a/lib/public/modules/server-settings.js
+++ b/lib/public/modules/server-settings.js
@@ -157,6 +157,17 @@ export function initServerSettings(appCtx) {
     });
   }
 
+  // Inherit supplementary groups toggle (OS-users mode)
+  var inheritGroupsToggle = document.getElementById("settings-inherit-groups");
+  if (inheritGroupsToggle) {
+    inheritGroupsToggle.addEventListener("change", function () {
+      var ws = ctx.ws;
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: "set_inherit_groups", value: this.checked }));
+      }
+    });
+  }
+
   // Image retention select
   var imageRetentionSelect = document.getElementById("settings-image-retention");
   if (imageRetentionSelect) {
@@ -482,6 +493,10 @@ export function updateDaemonConfig(config) {
   var keepAwakeToggle = document.getElementById("settings-keep-awake");
   if (keepAwakeToggle) keepAwakeToggle.checked = !!config.keepAwake;
 
+  // Inherit supplementary groups (only relevant in OS-users mode)
+  var inheritGroupsToggle = document.getElementById("settings-inherit-groups");
+  if (inheritGroupsToggle) inheritGroupsToggle.checked = config.inheritGroups !== false;
+
   // Image retention
   var imageRetentionSelect = document.getElementById("settings-image-retention");
   if (imageRetentionSelect && config.imageRetentionDays !== undefined) {
@@ -517,6 +532,20 @@ export function updateDaemonConfig(config) {
     if (keepAwakeNav) keepAwakeNav.classList.add("hidden");
     if (keepAwakeOpt) keepAwakeOpt.classList.add("hidden");
   }
+
+  // Show inherit-groups section/nav only in OS-users mode
+  var inheritGroupsSection = document.getElementById("settings-inherit-groups-section");
+  var inheritGroupsNav = document.getElementById("settings-inherit-groups-nav");
+  var inheritGroupsOpt = document.getElementById("settings-inherit-groups-opt");
+  if (config.osUsers) {
+    if (inheritGroupsSection) inheritGroupsSection.classList.remove("hidden");
+    if (inheritGroupsNav) inheritGroupsNav.classList.remove("hidden");
+    if (inheritGroupsOpt) inheritGroupsOpt.classList.remove("hidden");
+  } else {
+    if (inheritGroupsSection) inheritGroupsSection.classList.add("hidden");
+    if (inheritGroupsNav) inheritGroupsNav.classList.add("hidden");
+    if (inheritGroupsOpt) inheritGroupsOpt.classList.add("hidden");
+  }
 }
 
 export function handleSetPinResult(msg) {
@@ -530,6 +559,11 @@ export function handleSetPinResult(msg) {
 export function handleKeepAwakeChanged(msg) {
   var keepAwakeToggle = document.getElementById("settings-keep-awake");
   if (keepAwakeToggle) keepAwakeToggle.checked = !!msg.keepAwake;
+}
+
+export function handleInheritGroupsChanged(msg) {
+  var inheritGroupsToggle = document.getElementById("settings-inherit-groups");
+  if (inheritGroupsToggle) inheritGroupsToggle.checked = msg.inheritGroups !== false;
 }
 
 export function handleAutoContinueChanged(msg) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -153,6 +153,7 @@ function createServer(opts) {
   var onGetDaemonConfig = opts.onGetDaemonConfig || null;
   var onSetPin = opts.onSetPin || null;
   var onSetKeepAwake = opts.onSetKeepAwake || null;
+  var onSetInheritGroups = opts.onSetInheritGroups || null;
   var onSetImageRetention = opts.onSetImageRetention || null;
   var onShutdown = opts.onShutdown || null;
   var onRestart = opts.onRestart || null;
@@ -1257,6 +1258,7 @@ function createServer(opts) {
       onGetDaemonConfig: onGetDaemonConfig,
       onSetPin: onSetPin,
       onSetKeepAwake: onSetKeepAwake,
+      onSetInheritGroups: onSetInheritGroups,
       onSetImageRetention: onSetImageRetention,
       onSetUpdateChannel: onSetUpdateChannel,
       updateChannel: onGetDaemonConfig ? (onGetDaemonConfig().updateChannel || "stable") : "stable",

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -39,7 +39,10 @@ function createTerminal(cwd, cols, rows, osUserInfo, opts) {
   }
 
   var args = osUserInfo ? ["-l"] : [];
-  var term = pty.spawn(shell, args, spawnOpts);
+  // Route through setpriv when group inheritance is enabled so the terminal
+  // gets the user's supplementary groups (docker, etc.), not just primary gid.
+  var ptySpawn = require("./os-users").wrapSpawnAsUser(shell, args, spawnOpts);
+  var term = pty.spawn(ptySpawn.command, ptySpawn.args, ptySpawn.options);
 
   if (opts && opts.initialInput) {
     try { term.write(opts.initialInput); } catch (e) {}

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -517,13 +517,16 @@ function spawnWorker(linuxUser, workerScriptPath, cwd) {
     console.log("[yoke/claude] Spawning worker: uid=" + userInfo.uid + " gid=" + userInfo.gid + " cwd=" + cwd + " socket=" + socketPath);
     console.log("[yoke/claude] Worker script: " + workerScriptPath);
     console.log("[yoke/claude] Node: " + process.execPath);
-    worker.process = spawn(process.execPath, [workerScriptPath, socketPath], {
+    // Route through setpriv when group inheritance is enabled so the worker
+    // (and the agent CLI it spawns) inherits the user's supplementary groups.
+    var workerSpawn = require("../../os-users").wrapSpawnAsUser(process.execPath, [workerScriptPath, socketPath], {
       uid: userInfo.uid,
       gid: userInfo.gid,
       env: workerEnv,
       cwd: cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    worker.process = spawn(workerSpawn.command, workerSpawn.args, workerSpawn.options);
 
     worker.process.stdout.on("data", function(data) {
       console.log("[sdk-worker:" + linuxUser + "] " + data.toString().trim());


### PR DESCRIPTION
## Summary

Fixes #367.

In os-users mode, Clay spawns sessions/processes with Node's `child_process` `{ uid, gid }`, which calls setuid/setgid but never `initgroups()`. As a result spawned sessions, terminals and helper processes dropped all supplementary groups (docker, video, wheel, ...), so inside a session `id` showed only the primary group and e.g. `docker` failed with a socket permission error.

## Changes

- Add `wrapSpawnAsUser(command, args, options)` in `lib/os-users.js`. When group inheritance is enabled it routes the spawn through `setpriv --reuid <uid> --regid <gid> --init-groups -- <cmd>` so the child inherits the user's supplementary groups, matching a normal login. Falls back to Node's `uid`/`gid` (primary group only) when disabled or when `setpriv` (util-linux) is unavailable, with a one-time warning.
- Apply it to every user-spawn site: the agent worker (`yoke/adapters/claude.js`), TUI terminals (`terminal.js`), `fsAsUser` file ops (`os-users.js`), git init/clone (`daemon.js`) and skill install/uninstall (`project-http.js`).
- New daemon setting `inheritGroups` (default `true`), wired through `onGetDaemonConfig` / `onSetInheritGroups` and the `set_inherit_groups` WS message. Applied live without a daemon restart.
- Admin-only **Settings > User Groups** toggle, shown only in os-users mode.
- Boot log states whether sessions inherit supplementary groups and where to change it.

## Behavior change

Default is `true`, so on upgrade os-users deployments that mapped Clay accounts to users **with** supplementary groups will see those groups restored in sessions. Freshly provisioned Clay users (`useradd` with no `-G`) have no supplementary groups and are unaffected. Set `inheritGroups: false` (or toggle it off in Settings) to keep the previous primary-group-only behavior.

## Test

- `node --check` passes on all 10 changed files.
- `wrapSpawnAsUser` verified for enabled/disabled/passthrough paths (falls back cleanly where `setpriv` is absent).
- Existing security test suite (`test/security.test.js`) passes (23/23).