### PR TITLE
Upgrade claude-agent-sdk to 0.3.196 and adopt the new message/dialog surface

### DIFF
--- a/docs/ongoing/SDK-UPGRADE.md
+++ b/docs/ongoing/SDK-UPGRADE.md
@@ -26,10 +26,9 @@ Next up, in order (detail under "New in 0.2.133-0.3.196"):
 2. **#73-74** — model-refusal messages (fallback + no-fallback)
 3. **#79 + #75** — `informational` + `permission_denied` system messages
 4. **#76-78** — `reloadSkills` (supersedes #8), `setMcpPermissionModeOverride`, `thinking_tokens`
-5. **#80-81** — `toolAliases`, `backgroundTasks`
-6. **#82-84** — `commands_changed`, `worker_shutting_down`, verify built-in tool surface (#84)
+5. **#82-84** — `commands_changed`, `worker_shutting_down`, verify built-in tool surface (#84)
 
-Done: npm bump + #68-71. Deferred: #85 (experimental usage API).
+Done: npm bump + #68-79 (incl. #76/#77 client UI). Deferred: #80 toolAliases, #81 backgroundTasks (no driver in Clay), #85 (experimental usage API).
 
 
 ---
@@ -210,8 +209,8 @@ Largest delta in the tracker: minor bump 0.2 -> 0.3 plus ~64 patches. Derived by
 | 77 | `setMcpPermissionModeOverride(server, 'default'\|'auto'\|null)` | **Do** | x | Realizes the runtime half of #12 (per-server MCP permission mode). Returns `warning` on fuzzy server-name match | `sdk-bridge.js`, `project-mcp.js` UI |
 | 78 | `SDKThinkingTokensMessage` (`subtype:'thinking_tokens'`) | **Do** | x | Live thinking-token estimate (`estimated_tokens`, `_delta`). Feeds #16/#17 (thinking display, ttft) | `sdk-message-processor.js`, client |
 | 79 | `SDKInformationalMessage` (`subtype:'informational'`) | **Do** | x | Generalizes #4 notification: `level: info\|notice\|suggestion\|warning`, `tool_use_id` dedupe, `prevent_continuation`. Honor the render level and stop-on-`prevent_continuation` | `sdk-message-processor.js`, client |
-| 80 | `Options.toolAliases: Record<string,string>` | **Do** | x | Remap a tool name to another (e.g. `{Bash:'mcp__workspace__bash'}`). Complements `disallowedTools`. Useful for routing built-ins to sandboxed equivalents | `sdk-bridge.js` query options |
-| 81 | `backgroundTasks(toolUseId?)` + `BackgroundTaskSummary` | **Do** | x | Query/poll background task state from the relay. Pairs with the background-agent UX | `sdk-bridge.js`, client task UI |
+| 80 | `Options.toolAliases: Record<string,string>` | Defer | x | No driver in Clay: aliasing exists to route built-ins to sandboxed equivalents, but sandbox is not adopted (#88). Revisit if/when a tool-alias config or sandbox lands | `sdk-bridge.js` query options |
+| 81 | `backgroundTasks(toolUseId?)` + `BackgroundTaskSummary` | Defer | x | Polling API with no trigger/UI in Clay. Background-agent state is already pushed via `task_updated`/`task_notification` (incl. backgrounded). Revisit if an on-demand refresh is needed | `sdk-bridge.js`, client task UI |
 
 #### P3 - Low
 
@@ -237,14 +236,14 @@ Largest delta in the tracker: minor bump 0.2 -> 0.3 plus ~64 patches. Derived by
 
 | | Count | Items |
 |--|-------|-------|
-| **Do** | 12 | #72-83 |
-| of which **Codex-reusable** | 10 | #72, #75-83 |
+| **Do** | 10 | #72-79, #82-83 |
+| of which **Codex-reusable** | 8 | #72, #75-79, #82-83 |
 | **Verify** | 2 | #71, #84 |
-| Defer | 1 | #85 |
+| Defer | 3 | #80, #81, #85 |
 | Skip | 5 | #86-90 |
 | N/A (removed upstream) | 3 | #68-70 (retires #40-42) |
 
-Suggested order once the npm bump lands: #72 (host dialog / #14) -> #73-74 (refusal handling) -> #79 + #75 (informational + permission-denied messages) -> #76-78 -> remainder.
+Done so far: #68-79 (#72 host dialog, #73-74 refusal, #75 permission-denied, #76 reloadSkills, #77 MCP permission override, #78 thinking-tokens, #79 informational) plus #76/#77 client UI. Deferred #80/#81 (no driver in Clay). Remaining: #82-83 (messages) + #84 (verify).
 
 
 ---

--- a/docs/ongoing/SDK-UPGRADE.md
+++ b/docs/ongoing/SDK-UPGRADE.md
@@ -16,6 +16,25 @@ Codex multi-provider expansion planned. Items marked with Codex support are wort
 ---
 
 
+## Current Focus (2026-06-30)
+
+**On 0.3.196.** The npm bump and breaking-change verification are done (see header). Active work is the 0.2.133 -> 0.3.196 feature backlog below. Older 0.2.x items (#6-63) stay open as lower-priority backlog; fully completed history lives in the **Archive** at the bottom of this file.
+
+Next up, in order (detail under "New in 0.2.133-0.3.196"):
+
+1. **#72** — host dialog / `onUserDialog`; lands long-standing **#14** (OAuth / interactive auth)
+2. **#73-74** — model-refusal messages (fallback + no-fallback)
+3. **#79 + #75** — `informational` + `permission_denied` system messages
+4. **#76-78** — `reloadSkills` (supersedes #8), `setMcpPermissionModeOverride`, `thinking_tokens`
+5. **#80-81** — `toolAliases`, `backgroundTasks`
+6. **#82-84** — `commands_changed`, `worker_shutting_down`, verify built-in tool surface (#84)
+
+Done: npm bump + #68-71. Deferred: #85 (experimental usage API).
+
+
+---
+
+
 ## Master Item Table
 
 67 items total. Action: **Do** = implement, **Skip** = not needed. Codex: **x** = reusable for Codex (build as platform-common).
@@ -248,13 +267,7 @@ Suggested order once the npm bump lands: #72 (host dialog / #14) -> #73-74 (refu
 
 ## Upgrade Steps
 
-### 0.2.92 -> 0.2.112 (done)
-1. ~~Verify `SDKSessionInfo.systemPrompt` handling works with `string[]`~~
-2. ~~Verify `EditFileOutput.originalFile` null handling~~
-3. ~~Verify no references to removed `proactive` settings block~~
-4. ~~`npm install @anthropic-ai/claude-agent-sdk@0.2.112`~~
-5. ~~Add `'xhigh'` to effort selector UI~~
-6. ~~Handle new message types: `task_updated`, `notification`, `plugin_install`~~
+> Completed step lists (0.2.38 -> 0.2.112) are in the Archive at the bottom.
 
 ### 0.2.112 -> 0.2.132 (next)
 1. **Verify** `query()` `settingSources` behavior (#44). Pass explicit `settingSources: ["user", "project", "local"]` already (relay does this) — confirm no regression.
@@ -563,9 +576,21 @@ Decisions where Clay deliberately deviates from the Claude Code reference, beyon
 ---
 
 
-# Archive: 0.2.38 -> 0.2.76 (completed 2026-03-17)
+# Archive
 
-## Priority 1 - High (Functional gaps, user-facing impact) -- DONE
+## Upgrade Steps: 0.2.92 -> 0.2.112 (completed)
+
+1. ~~Verify `SDKSessionInfo.systemPrompt` handling works with `string[]`~~
+2. ~~Verify `EditFileOutput.originalFile` null handling~~
+3. ~~Verify no references to removed `proactive` settings block~~
+4. ~~`npm install @anthropic-ai/claude-agent-sdk@0.2.112`~~
+5. ~~Add `'xhigh'` to effort selector UI~~
+6. ~~Handle new message types: `task_updated`, `notification`, `plugin_install`~~
+
+
+## 0.2.38 -> 0.2.76 (completed 2026-03-17)
+
+### Priority 1 - High (Functional gaps, user-facing impact) -- DONE
 
 ### ~~1.1 `onElicitation` callback (since 0.2.39+)~~
 - ~~**Status:** Implemented~~
@@ -580,7 +605,7 @@ Decisions where Clay deliberately deviates from the Claude Code reference, beyon
 - ~~**Status:** Done~~
 
 
-## Priority 2 - Medium -- DONE
+### Priority 2 - Medium -- DONE
 
 ### ~~2.1 `listSessions()` (since 0.2.51+)~~
 - ~~**Status:** Implemented~~
@@ -598,7 +623,7 @@ Decisions where Clay deliberately deviates from the Claude Code reference, beyon
 - ~~**Status:** Implemented~~
 
 
-## Priority 3 - Low -- DONE
+### Priority 3 - Low -- DONE
 
 ### ~~3.1 `renameSession()` (since 0.2.74+)~~
 - ~~**Status:** Implemented~~
@@ -618,7 +643,7 @@ Decisions where Clay deliberately deviates from the Claude Code reference, beyon
 ### ~~3.6-3.8 Hook events, AgentDefinition.model, Settings export -- N/A~~
 
 
-## Already Implemented (0.2.38 -> 0.2.63 range)
+### Already Implemented (0.2.38 -> 0.2.63 range)
 
 - [x] `promptSuggestions` query option + `SDKPromptSuggestionMessage` handling
 - [x] `SDKRateLimitEvent` / `rate_limit_event` with UI display

--- a/docs/ongoing/SDK-UPGRADE.md
+++ b/docs/ongoing/SDK-UPGRADE.md
@@ -1,8 +1,10 @@
 # Claude Agent SDK Upgrade Tracker
 
-Installed: `@anthropic-ai/claude-agent-sdk@0.2.132` (declared `^0.2.132`)
+Installed: `@anthropic-ai/claude-agent-sdk@0.3.196` (declared `^0.3.196`, bumped 2026-06-30)
 Latest: `@anthropic-ai/claude-agent-sdk@0.3.196` (2026-06-30)
 Updated: 2026-06-30
+
+npm bump to 0.3.196 is **done** (clean lockfile reinstall; peers @anthropic-ai/sdk@0.107.0, @modelcontextprotocol/sdk@1.29.0, zod@4.4.3). Static + load verification passed and runtime smoke confirmed. The 0.2.133 -> 0.3.196 feature work (items #68-90) is still **pending implementation** — only the version bump and breaking-change verification landed.
 
 Covers all unapplied changes from 0.2.80 through 0.3.196.
 The 0.2.133 -> 0.3.196 delta (items #68+) was derived by diffing the published `.d.ts` surface (installed 0.2.132 vs npm 0.3.196), not a changelog, so the "since" version tags inside that range are approximate.
@@ -262,6 +264,15 @@ Suggested order once the npm bump lands: #72 (host dialog / #14) -> #73-74 (refu
 5. Implement #6-12, #14-18 backlog as bandwidth allows.
 6. Tool `duration_ms` (#52) feeds #30 toolStats — implement together.
 7. Add `oauth_org_not_allowed` error path (#61) and extend origin propagation to replay messages (#62) when touching #10.
+
+### 0.2.132 -> 0.3.196 (npm bump done 2026-06-30; feature work pending)
+1. ~~Confirm Clay references none of the removed symbols (#68-70) — grep clean, retired #40-42~~
+2. ~~**Verify** `canUseTool` callback still matches current signature (#71) — sdk-bridge loads clean after bump~~
+3. ~~Clean lockfile reinstall to `^0.3.196`; peers resolved (@anthropic-ai/sdk@0.107.0, @modelcontextprotocol/sdk@1.29.0, zod@4.4.3)~~
+4. ~~Verify: SDK loads + `query` export; client-import + server/client `node --check` pass; sdk-bridge/claude adapter/yoke load; all 7 called SDK members present; runtime smoke~~
+5. Implement P1: host dialog / OAuth (#72, lands #14), then model-refusal messages (#73-74).
+6. Implement P2: `informational` + `permission_denied` messages (#79, #75), `reloadSkills` (#76, supersedes #8), `setMcpPermissionModeOverride` (#77), `thinking_tokens` (#78), `toolAliases` (#80), `backgroundTasks` (#81).
+7. Implement P3: `commands_changed` (#82), `worker_shutting_down` (#83). **Verify** built-in tool surface renders unknown tools gracefully (#84).
 
 
 ---

--- a/docs/ongoing/SDK-UPGRADE.md
+++ b/docs/ongoing/SDK-UPGRADE.md
@@ -1,10 +1,11 @@
 # Claude Agent SDK Upgrade Tracker
 
-Installed: `@anthropic-ai/claude-agent-sdk@0.2.112` (Claude Code 2.1.112)
-Latest: `@anthropic-ai/claude-agent-sdk@0.2.132` (Claude Code 2.1.132, 2026-05-07)
-Updated: 2026-05-07
+Installed: `@anthropic-ai/claude-agent-sdk@0.2.132` (declared `^0.2.132`)
+Latest: `@anthropic-ai/claude-agent-sdk@0.3.196` (2026-06-30)
+Updated: 2026-06-30
 
-Covers all unapplied changes from 0.2.80 through 0.2.132.
+Covers all unapplied changes from 0.2.80 through 0.3.196.
+The 0.2.133 -> 0.3.196 delta (items #68+) was derived by diffing the published `.d.ts` surface (installed 0.2.132 vs npm 0.3.196), not a changelog, so the "since" version tags inside that range are approximate.
 Codex multi-provider expansion planned. Items marked with Codex support are worth building as platform-common features.
 
 **Deliberate parity divergences** (decisions that go beyond per-API skip judgments) are tracked at the bottom of this file under "Parity Divergences" so the rationale is preserved alongside the upgrade trail.
@@ -75,9 +76,9 @@ Codex multi-provider expansion planned. Items marked with Codex support are wort
 
 | # | Item | Action | Codex | Current status | Where |
 |---|------|--------|:-----:|----------------|-------|
-| 40 | Assistant Worker module | Defer | | alpha, new module | -- |
-| 41 | `connectRemoteControl*` types | Defer | | alpha | -- |
-| 42 | Bridge enhancements | Defer | | alpha | -- |
+| 40 | ~~Assistant Worker module~~ | ~~Defer~~ | | **Retired** — `runAssistantWorker`/`AssistantWorker*` removed from SDK in 0.3.x (see #69) | -- |
+| 41 | ~~`connectRemoteControl*` types~~ | ~~Defer~~ | | **Retired** — removed from SDK in 0.3.x (see #70) | -- |
+| 42 | ~~Bridge enhancements~~ | ~~Defer~~ | | **Retired** — alpha bridge surface removed/reshaped in 0.3.x (see #70) | -- |
 | 43 | `taskBudget` query option | Defer | | alpha, beta header required | -- |
 
 
@@ -156,6 +157,73 @@ Diff is small — mostly Remote Control toggles and SessionStore alpha extension
 | # | Item | Action | Codex | Current status | Where |
 |---|------|--------|:-----:|----------------|-------|
 | 67 | `Options.sessionStoreFlush: 'batched' \| 'eager'` (0.2.128, alpha) | Defer | | Flush strategy for SessionStore mirroring. Relevant only if #58 lands | -- |
+
+
+### New in 0.2.133-0.3.196 (added 2026-06-30)
+
+Largest delta in the tracker: minor bump 0.2 -> 0.3 plus ~64 patches. Derived by diffing the published type surface, so version tags below are approximate. **Good news for the bump itself:** no `Options` key was removed, and Clay references none of the removed symbols, so installing `0.3.196` does not break existing call sites. The work is additive: new system-message subtypes to handle, the host-dialog (OAuth) callback that finally lands #14, and a few new query-handle methods.
+
+#### Removed upstream (no Clay impact — confirm & retire tracker entries)
+
+| # | Item | Action | Codex | Current status | Where |
+|---|------|--------|:-----:|----------------|-------|
+| 68 | `unstable_v2_*` session API + `SDKSession`/`SDKSessionOptions` removed | N/A | | Clay never adopted the v2 session API (grep clean). No action | -- |
+| 69 | Assistant Worker removed (`runAssistantWorker`, `AssistantWorker*`, `WorkerState*`) | N/A | | Upstream dropped the module. **Retires #40.** Clay never imported it | -- |
+| 70 | `connectRemoteControl*` + alpha bridge types removed | N/A | | Upstream dropped Remote Control client surface. **Retires #41-42.** Clay never used it | -- |
+| 71 | Permission/prompt types reshaped (`CanUseToolContext`, `InboundPrompt`, `PromptRequest`/`PromptResponse` removed) | **Verify** | | Clay references none of these names, but confirm our `canUseTool` callback still matches the current signature after the bump | `sdk-bridge.js` |
+
+#### P1 - High
+
+| # | Item | Action | Codex | Current status | Where |
+|---|------|--------|:-----:|----------------|-------|
+| 72 | `Options.onUserDialog` + `supportedDialogKinds` (`OnUserDialog`/`UserDialogRequest`/`UserDialogResult`) | **Do** | x | **Lands #14.** Host-rendered dialog channel (the OAuth/interactive-auth flow path). Must answer unrecognized `dialogKind` with `{behavior:'cancelled'}`; providing the callback without `supportedDialogKinds` opts in to nothing | `sdk-bridge.js` query options, client dialog |
+| 73 | `SDKModelRefusalFallbackMessage` (`subtype:'model_refusal_fallback'`) | **Do** | | Model refused and CLI fell back to another model (`direction: retry/revert/sticky`, `original_model`->`fallback_model`, `api_refusal_category`). Surface as a distinct notice instead of dropping silently | `sdk-message-processor.js`, client |
+| 74 | `SDKModelRefusalNoFallbackMessage` (`subtype:'model_refusal_no_fallback'`) | **Do** | | Hard refusal, no fallback (`content`, `api_refusal_explanation`, `refused_user_message_uuid`). Pairs with #73; render as a clear error state | `sdk-message-processor.js`, client |
+
+#### P2 - Medium
+
+| # | Item | Action | Codex | Current status | Where |
+|---|------|--------|:-----:|----------------|-------|
+| 75 | `SDKPermissionDeniedMessage` (`subtype:'permission_denied'`) | **Do** | x | Tool call denied: `tool_name`, `tool_use_id`, `decision_reason_type`/`decision_reason`, `agent_id` for subagents. Surface why a tool was blocked (distinct from hook-config #27) | `sdk-message-processor.js`, client |
+| 76 | `reloadSkills()` + `SDKControlReloadSkillsResponse` | **Do** | x | **Supersedes #8** (`reloadPlugins`). Hot-reload skills without a session restart | `sdk-bridge.js`, WS handler |
+| 77 | `setMcpPermissionModeOverride(server, 'default'\|'auto'\|null)` | **Do** | x | Realizes the runtime half of #12 (per-server MCP permission mode). Returns `warning` on fuzzy server-name match | `sdk-bridge.js`, `project-mcp.js` UI |
+| 78 | `SDKThinkingTokensMessage` (`subtype:'thinking_tokens'`) | **Do** | x | Live thinking-token estimate (`estimated_tokens`, `_delta`). Feeds #16/#17 (thinking display, ttft) | `sdk-message-processor.js`, client |
+| 79 | `SDKInformationalMessage` (`subtype:'informational'`) | **Do** | x | Generalizes #4 notification: `level: info\|notice\|suggestion\|warning`, `tool_use_id` dedupe, `prevent_continuation`. Honor the render level and stop-on-`prevent_continuation` | `sdk-message-processor.js`, client |
+| 80 | `Options.toolAliases: Record<string,string>` | **Do** | x | Remap a tool name to another (e.g. `{Bash:'mcp__workspace__bash'}`). Complements `disallowedTools`. Useful for routing built-ins to sandboxed equivalents | `sdk-bridge.js` query options |
+| 81 | `backgroundTasks(toolUseId?)` + `BackgroundTaskSummary` | **Do** | x | Query/poll background task state from the relay. Pairs with the background-agent UX | `sdk-bridge.js`, client task UI |
+
+#### P3 - Low
+
+| # | Item | Action | Codex | Current status | Where |
+|---|------|--------|:-----:|----------------|-------|
+| 82 | `SDKCommandsChangedMessage` (`subtype:'commands_changed'`) | **Do** | x | Slash-command list changed mid-session (`commands: SlashCommand[]`). Refresh the command palette live | `sdk-message-processor.js`, client |
+| 83 | `SDKWorkerShuttingDownMessage` (`subtype:'worker_shutting_down'`) | **Do** | x | Worker shutdown with `reason` (`host_exit`, `remote_control_disabled`, ...). Extends #7 TerminalReason for clean teardown messaging | `sdk-message-processor.js` |
+| 84 | New built-in tool surface (`Cron*`, `Task*`, `Workflow`, `Monitor`, `Artifact`, `Projects`, `PushNotification`, `RemoteTrigger`, `ScheduleWakeup`, `EnterPlanMode`, `ReportFindings`, `ReadMcpResourceDir`) | **Verify** | x | SDK now ships many built-in tool I/O types. Confirm Clay's tool display/permission UI renders unknown tool names with a generic fallback rather than breaking | `tools.js`, client tool display |
+| 85 | `usage_EXPERIMENTAL_MAY_CHANGE...()` + `SDKControlGetUsageResponse` | Defer | x | Richer usage than #51: `subscription_type` (pro/max/team/enterprise/null), per-model usage, rate-limit status. Method name explicitly warns "do not rely yet" — revisit when stabilized | `sdk-bridge.js` |
+
+#### Skip
+
+| # | Item | Action | Codex | Current status | Where |
+|---|------|--------|:-----:|----------------|-------|
+| 86 | `MessageDisplayHook*`, `StopHookSpecificOutput`, `SubagentStopHookSpecificOutput` | Skip | | Hooks not adopted | -- |
+| 87 | Settings resolution API (`resolveSettings`, `ResolvedSettings`, `ResolvedSettingSource`, `PolicySettingsOrigin`) | Skip | | Programmatic/managed-settings resolution. SDK-internal; relay manages its own settings | -- |
+| 88 | `SandboxCredentialsConfig` + sandbox settings | Skip | | Sandbox execution not adopted. Revisit if/when Clay pursues sandboxing | -- |
+| 89 | `reinitialize()` query method | Skip | | Relay restarts/lazy-resumes sessions itself | -- |
+| 90 | CLI/SDK internals (`extractFromBunfs`, `filterEscalatingDefaultMode`, `meta`, `SpawnOptions`, `REPL*`, `ShowOnboardingRolePicker*`, `ProvenanceEntry`, `SSEOptions`) | Skip | | Not part of the consumed query/message surface | -- |
+
+
+### Delta Action Summary (0.2.133-0.3.196)
+
+| | Count | Items |
+|--|-------|-------|
+| **Do** | 12 | #72-83 |
+| of which **Codex-reusable** | 10 | #72, #75-83 |
+| **Verify** | 2 | #71, #84 |
+| Defer | 1 | #85 |
+| Skip | 5 | #86-90 |
+| N/A (removed upstream) | 3 | #68-70 (retires #40-42) |
+
+Suggested order once the npm bump lands: #72 (host dialog / #14) -> #73-74 (refusal handling) -> #79 + #75 (informational + permission-denied messages) -> #76-78 -> remainder.
 
 
 ---

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -28,7 +28,8 @@ var path = require("path");
 var { loadConfig, saveConfig, socketPath, generateSlug, syncClayrc, removeFromClayrc, writeCrashInfo, readCrashInfo, clearCrashInfo, isPidAlive, clearStaleConfig, REAL_HOME } = require("./config");
 var { createIPCServer } = require("./ipc");
 var { createServer, generateAuthToken } = require("./server");
-var { checkAclSupport, grantProjectAccess, revokeProjectAccess, provisionAllUsers, provisionLinuxUser, grantAllUsersAccess, deactivateLinuxUser, ensureProjectsDir } = require("./os-users");
+var osUsersMod = require("./os-users");
+var { checkAclSupport, grantProjectAccess, revokeProjectAccess, provisionAllUsers, provisionLinuxUser, grantAllUsersAccess, deactivateLinuxUser, ensureProjectsDir } = osUsersMod;
 var usersModule = require("./users");
 var { createWorktree, removeWorktree, isWorktree } = require("./worktree");
 var mates = require("./mates");
@@ -52,6 +53,9 @@ if (process.env.SUDO_USER) console.log("[daemon] SUDO_USER: " + process.env.SUDO
 console.log("[daemon] UID: " + (typeof process.getuid === "function" ? process.getuid() : "N/A"));
 
 // --- OS users mode: check required system dependencies ---
+// Supplementary-group inheritance (issue #367): default on so sessions behave
+// like a normal login; operators can disable via config / the settings toggle.
+osUsersMod.setInheritGroups(config.inheritGroups !== false);
 if (config.osUsers) {
   var checkExec = require("child_process").execFileSync;
   var missing = [];
@@ -62,6 +66,11 @@ if (config.osUsers) {
     console.error("[daemon] OS users mode requires missing system packages: " + missing.join(", "));
     console.error("[daemon] Install with:  sudo apt install " + missing.map(function (m) { return m.split(" ")[0]; }).join(" "));
     process.exit(78); // EX_CONFIG
+  }
+  if (config.inheritGroups !== false) {
+    console.log("[daemon] Sessions inherit each user's supplementary groups (docker, etc.); disable in Settings > User Groups.");
+  } else {
+    console.log("[daemon] Sessions run with primary group only (supplementary groups dropped); enable in Settings > User Groups.");
   }
 }
 
@@ -216,7 +225,8 @@ var relay = createServer({
           if (uidGid) {
             fs.chmodSync(targetDir, 0o700);
             execFileSync("chown", ["-R", linuxUser + ":" + linuxUser, targetDir]);
-            execFileSync("git", ["init"], { cwd: targetDir, uid: uidGid.uid, gid: uidGid.gid, env: { PATH: "/usr/local/bin:/usr/bin:/bin" } });
+            var gitInit = osUsersMod.wrapSpawnAsUser("git", ["init"], { cwd: targetDir, uid: uidGid.uid, gid: uidGid.gid, env: { PATH: "/usr/local/bin:/usr/bin:/bin" } });
+            execFileSync(gitInit.command, gitInit.args, gitInit.options);
           } else {
             execFileSync("git", ["init"], { cwd: targetDir });
           }
@@ -296,7 +306,8 @@ var relay = createServer({
         return;
       }
     }
-    var proc = spawn("git", ["clone", cloneUrl, targetDir], spawnOpts);
+    var cloneSpawn = osUsersMod.wrapSpawnAsUser("git", ["clone", cloneUrl, targetDir], spawnOpts);
+    var proc = spawn(cloneSpawn.command, cloneSpawn.args, cloneSpawn.options);
     var stderrBuf = "";
     proc.stderr.on("data", function (chunk) { stderrBuf += chunk.toString(); });
     // 5 minute timeout
@@ -689,6 +700,8 @@ var relay = createServer({
       headless: !!config.headless,
       keepAwake: !!config.keepAwake,
       autoContinueOnRateLimit: !!config.autoContinueOnRateLimit,
+      osUsers: !!config.osUsers,
+      inheritGroups: config.inheritGroups !== false,
       chatLayout: config.chatLayout || "channel",
       matesEnabled: config.matesEnabled !== false,
       pinEnabled: !!config.pinHash,
@@ -803,6 +816,16 @@ var relay = createServer({
     }
     console.log("[daemon] Keep awake:", want, "(web)");
     return { ok: true, keepAwake: want };
+  },
+  onSetInheritGroups: function (value) {
+    var want = !!value;
+    config.inheritGroups = want;
+    saveConfig(config);
+    // Apply live so subsequent session/terminal spawns pick it up without a
+    // daemon restart; already-running sessions keep their current groups.
+    osUsersMod.setInheritGroups(want);
+    console.log("[daemon] Inherit supplementary groups:", want, "(web)");
+    return { ok: true, inheritGroups: want };
   },
   onShutdown: function () {
     console.log("[daemon] Shutdown requested via web UI");

--- a/lib/os-users.js
+++ b/lib/os-users.js
@@ -14,6 +14,68 @@ function isSafeLinuxUsername(username) {
   return typeof username === "string" && /^[a-z_][a-z0-9_-]*[$]?$/.test(username);
 }
 
+// --- Supplementary group inheritance (issue #367) ---
+// Node's child_process { uid, gid } options call setuid/setgid but never
+// initgroups(), so spawned sessions drop all supplementary groups (docker,
+// video, wheel, ...). When inheritGroups is enabled we route the spawn through
+// `setpriv --init-groups` so the child gets the same groups as a normal login.
+var _inheritGroups = true; // default: behave like a normal login shell
+var _setprivAvail = null;
+var _warnedNoSetpriv = false;
+
+function setInheritGroups(value) {
+  _inheritGroups = !!value;
+}
+
+function getInheritGroups() {
+  return _inheritGroups;
+}
+
+function setprivAvailable() {
+  if (_setprivAvail !== null) return _setprivAvail;
+  try {
+    execFileSync("setpriv", ["--help"], { stdio: "ignore", timeout: 5000 });
+    _setprivAvail = true;
+  } catch (e) {
+    _setprivAvail = false;
+  }
+  return _setprivAvail;
+}
+
+/**
+ * Wrap a spawn/exec invocation so the child runs as the target user WITH its
+ * supplementary groups initialized (initgroups), which Node's uid/gid options
+ * do not do. Accepts (command, args, options) where options may carry
+ * uid/gid, and returns a normalized { command, args, options } to pass to
+ * spawn()/execFileSync()/pty.spawn().
+ *
+ * - Same-user spawns (no uid/gid in options) are returned unchanged.
+ * - When inheritGroups is disabled, or setpriv is unavailable, falls back to
+ *   Node's uid/gid options (primary group only) so behavior degrades safely.
+ * Requires the parent process to be root, which is the case in os-users mode.
+ */
+function wrapSpawnAsUser(command, args, options) {
+  args = args || [];
+  options = options || {};
+  var uid = options.uid;
+  var gid = options.gid;
+  if (uid == null || gid == null) return { command: command, args: args, options: options };
+
+  if (_inheritGroups && setprivAvailable()) {
+    var wrappedArgs = ["--reuid", String(uid), "--regid", String(gid), "--init-groups", "--", command].concat(args);
+    var newOpts = Object.assign({}, options);
+    delete newOpts.uid;
+    delete newOpts.gid;
+    return { command: "setpriv", args: wrappedArgs, options: newOpts };
+  }
+
+  if (_inheritGroups && !_warnedNoSetpriv) {
+    _warnedNoSetpriv = true;
+    console.warn("[os-users] inheritGroups enabled but `setpriv` not found; supplementary groups will be dropped. Install util-linux to restore them.");
+  }
+  return { command: command, args: args, options: options };
+}
+
 /**
  * Resolve Linux user info from username via getent passwd.
  * Returns { uid, gid, home, user, shell } or throws on failure.
@@ -84,13 +146,14 @@ function fsAsUser(op, args, osUserInfo) {
       "var buf = fs.readFileSync(f);",
       "process.stdout.write(buf.toString('base64'));",
     ].join(" ");
-    var binOutput = execFileSync(process.execPath, ["-e", script], {
+    var binSpawn = wrapSpawnAsUser(process.execPath, ["-e", script], {
       encoding: "utf8",
       timeout: 10000,
       uid: osUserInfo.uid,
       gid: osUserInfo.gid,
       maxBuffer: 50 * 1024 * 1024,
     });
+    var binOutput = execFileSync(binSpawn.command, binSpawn.args, binSpawn.options);
     return { buffer: Buffer.from(binOutput.trim(), "base64") };
   } else if (op === "write") {
     script = [
@@ -104,12 +167,13 @@ function fsAsUser(op, args, osUserInfo) {
     throw new Error("Unknown fsAsUser operation: " + op);
   }
 
-  var output = execFileSync(process.execPath, ["-e", script], {
+  var fsSpawn = wrapSpawnAsUser(process.execPath, ["-e", script], {
     encoding: "utf8",
     timeout: 10000,
     uid: osUserInfo.uid,
     gid: osUserInfo.gid,
   });
+  var output = execFileSync(fsSpawn.command, fsSpawn.args, fsSpawn.options);
 
   return JSON.parse(output.trim());
 }
@@ -554,6 +618,9 @@ module.exports = {
   grantAllUsersAccess: grantAllUsersAccess,
   installClaudeCli: installClaudeCli,
   claudeAvailableForUser: claudeAvailableForUser,
+  setInheritGroups: setInheritGroups,
+  getInheritGroups: getInheritGroups,
+  wrapSpawnAsUser: wrapSpawnAsUser,
   deactivateLinuxUser: deactivateLinuxUser,
   ensureProjectsDir: ensureProjectsDir,
   isHomeDirectory: isHomeDirectory,

--- a/lib/project-http.js
+++ b/lib/project-http.js
@@ -335,7 +335,8 @@ function attachHTTP(ctx) {
           });
         }
         console.log("[skill-install] spawning: npx skills add " + url + " --skill " + skill + " --yes " + scopeFlag + " (cwd: " + spawnCwd + ")");
-        var child = spawn("npx", ["skills", "add", url, "--skill", skill, "--yes", scopeFlag], skillSpawnOpts);
+        var skillAddSpawn = require("./os-users").wrapSpawnAsUser("npx", ["skills", "add", url, "--skill", skill, "--yes", scopeFlag], skillSpawnOpts);
+        var child = spawn(skillAddSpawn.command, skillAddSpawn.args, skillAddSpawn.options);
         var stdoutBuf = "";
         var stderrBuf = "";
         child.stdout.on("data", function (chunk) {
@@ -427,11 +428,12 @@ function attachHTTP(ctx) {
           if (uninstallUserInfo) {
             // Run rm as target user to respect permissions
             var rmScript = "var fs = require('fs'); fs.rmSync(" + JSON.stringify(resolved) + ", { recursive: true, force: true });";
-            execFileSync(process.execPath, ["-e", rmScript], {
+            var rmSpawn = require("./os-users").wrapSpawnAsUser(process.execPath, ["-e", rmScript], {
               uid: uninstallUserInfo.uid,
               gid: uninstallUserInfo.gid,
               timeout: 10000,
             });
+            execFileSync(rmSpawn.command, rmSpawn.args, rmSpawn.options);
           } else {
             fs.rmSync(resolved, { recursive: true, force: true });
           }

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -1700,7 +1700,7 @@ function attachSessions(ctx) {
 
     // --- Daemon config / server management (admin-only in multi-user mode) ---
     if (msg.type === "get_daemon_config" || msg.type === "set_pin" || msg.type === "set_keep_awake" ||
-        msg.type === "set_auto_continue" || msg.type === "set_image_retention" || msg.type === "shutdown_server" || msg.type === "restart_server") {
+        msg.type === "set_auto_continue" || msg.type === "set_inherit_groups" || msg.type === "set_image_retention" || msg.type === "shutdown_server" || msg.type === "restart_server") {
       if (usersModule.isMultiUser()) {
         var _wsUser = ws._clayUser;
         if (!_wsUser || _wsUser.role !== "admin") {
@@ -1740,6 +1740,15 @@ function attachSessions(ctx) {
         var acResult = opts.onSetAutoContinue(msg.value);
         sendTo(ws, { type: "set_auto_continue_result", ok: acResult.ok, autoContinueOnRateLimit: acResult.autoContinueOnRateLimit });
         send({ type: "auto_continue_changed", autoContinueOnRateLimit: acResult.autoContinueOnRateLimit });
+      }
+      return true;
+    }
+
+    if (msg.type === "set_inherit_groups") {
+      if (typeof opts.onSetInheritGroups === "function") {
+        var igResult = opts.onSetInheritGroups(msg.value);
+        sendTo(ws, { type: "set_inherit_groups_result", ok: igResult.ok, inheritGroups: igResult.inheritGroups });
+        send({ type: "inherit_groups_changed", inheritGroups: igResult.inheritGroups });
       }
       return true;
     }

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -904,6 +904,24 @@ function attachSessions(ctx) {
       return true;
     }
 
+    if (msg.type === "reload_skills") {
+      var session = getSessionForWs(ws);
+      if (session && sdk.reloadSkills) {
+        sdk.reloadSkills(session);
+      }
+      return true;
+    }
+
+    if (msg.type === "set_mcp_permission_mode_override" && msg.serverName) {
+      var session = getSessionForWs(ws);
+      if (session && sdk.setMcpPermissionModeOverride) {
+        // mode: "default" | "auto" | null (null clears the override)
+        var mcpMode = (msg.mode === "auto" || msg.mode === "default") ? msg.mode : null;
+        sdk.setMcpPermissionModeOverride(session, msg.serverName, mcpMode);
+      }
+      return true;
+    }
+
     if (msg.type === "set_vendor" && msg.vendor) {
       var vendorSession = getSessionForWs(ws);
       if (vendorSession) {

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -1274,13 +1274,18 @@ function attachSessions(ctx) {
           sdk.pushMessage(session, answerText);
         }
       } else {
-        // Claude native AskUserQuestion path (canUseTool). The SDK is
-        // synchronously blocked on the permission callback, so we must
-        // resolve it with the standard permission shape.
-        pending.resolve({
-          behavior: "allow",
-          updatedInput: Object.assign({}, pending.input, { answers: answers }),
-        });
+        // Claude native AskUserQuestion path (built-in tool, intercepted via
+        // canUseTool). In headless SDK mode the built-in can't render its own
+        // answer UI: resolving "allow" lets it return an EMPTY result, so the
+        // model continues the same turn with no answer ("I don't see an
+        // answer"). Injected user messages also lose the race against that
+        // empty result. Instead, deliver the answer as the tool_result by
+        // denying with the formatted answer text — the SDK surfaces a deny
+        // `message` to the model as the tool result, so the model receives the
+        // user's choice in the same turn. (updatedInput.answers is not read by
+        // the 0.3.x built-in, which is what caused answers to be dropped.)
+        var nativeAnswerText = formatAskUserAnswerAsMessage(pending.input, answers);
+        pending.resolve({ behavior: "deny", message: nativeAnswerText });
       }
       return true;
     }

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -1457,6 +1457,26 @@ function attachSessions(ctx) {
       return true;
     }
 
+    // --- Host user dialog response (SDK request_user_dialog) ---
+    if (msg.type === "user_dialog_response") {
+      var session = getSessionForWs(ws);
+      if (!session) return true;
+      var pending = session.pendingUserDialogs && session.pendingUserDialogs[msg.requestId];
+      if (!pending) return true;
+      delete session.pendingUserDialogs[msg.requestId];
+      if (msg.behavior === "completed") {
+        pending.resolve({ behavior: "completed", result: msg.result });
+      } else {
+        pending.resolve({ behavior: "cancelled" });
+      }
+      sm.sendAndRecord(session, {
+        type: "user_dialog_resolved",
+        requestId: msg.requestId,
+        behavior: msg.behavior === "completed" ? "completed" : "cancelled",
+      });
+      return true;
+    }
+
     // --- Browse directories (for add-project autocomplete) ---
     if (msg.type === "browse_dir") {
       var rawPath = (msg.path || "").replace(/^~/, require("./config").REAL_HOME);

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -169,19 +169,32 @@ function attachSessions(ctx) {
         var termId = (typeof s.runtimeTerminalId === "number")
           ? s.runtimeTerminalId
           : (typeof s.terminalId === "number" ? s.terminalId : null);
-        try {
-          ctx._notifications && ctx._notifications.notify("tui_attention", {
-            slug: slug,
-            sessionId: s.localId,
-            ownerId: s.ownerId || null,
-            targetUserId: s.ownerId || null,
-            title: "Claude responded",
-            body: firstLine,
-            terminalId: termId,
-            sessionTitle: s.title || "",
-            cliSessionId: s.cliSessionId || null,
-          });
-        } catch (e) {}
+        // Don't banner a session someone is already watching — they can see
+        // the reply in the TUI. Gate at the source (server) rather than relying
+        // on the client's activeSessionId suppression, which isn't reliable for
+        // TUI sessions and lets banners pile up for the session in view.
+        var beingViewed = false;
+        for (var vws of clients) {
+          if (vws.readyState === 1 && vws._clayActiveSession === s.localId) {
+            beingViewed = true;
+            break;
+          }
+        }
+        if (!beingViewed) {
+          try {
+            ctx._notifications && ctx._notifications.notify("tui_attention", {
+              slug: slug,
+              sessionId: s.localId,
+              ownerId: s.ownerId || null,
+              targetUserId: s.ownerId || null,
+              title: "Claude responded",
+              body: firstLine,
+              terminalId: termId,
+              sessionTitle: s.title || "",
+              cliSessionId: s.cliSessionId || null,
+            });
+          } catch (e) {}
+        }
         // Re-read the assistant text index and broadcast it so any client
         // with this session in view can wire hover-to-grab onto the new
         // message right away. The transcript is small enough that a full

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -1151,6 +1151,7 @@
           </optgroup>
           <optgroup label="Server">
             <option value="keep-awake" class="hidden" id="settings-keep-awake-opt">Keep Awake</option>
+            <option value="inherit-groups" class="hidden" id="settings-inherit-groups-opt">User Groups</option>
             <option value="restart">Restart</option>
             <option value="shutdown">Shutdown</option>
           </optgroup>
@@ -1177,6 +1178,7 @@
           <div class="settings-nav-separator"></div>
           <div class="settings-nav-category">Server</div>
           <button class="settings-nav-item hidden" data-section="keep-awake" id="settings-keep-awake-nav"><span>Keep Awake</span></button>
+          <button class="settings-nav-item hidden settings-admin-only" data-section="inherit-groups" id="settings-inherit-groups-nav"><span>User Groups</span></button>
           <button class="settings-nav-item" data-section="restart"><span>Restart</span></button>
           <button class="settings-nav-item settings-nav-danger" data-section="shutdown"><span>Shutdown</span></button>
         </div>
@@ -1426,6 +1428,19 @@
                 <div class="settings-hint">Prevent the system from sleeping while the server is running (macOS only).</div>
               </div>
               <input type="checkbox" id="settings-keep-awake">
+              <span class="toggle-track"><span class="toggle-thumb"></span></span>
+            </label>
+          </div>
+        </div>
+        <div class="server-settings-section hidden settings-admin-only" data-section="inherit-groups" id="settings-inherit-groups-section">
+          <h2>User Groups</h2>
+          <div class="settings-card">
+            <label class="settings-toggle-row">
+              <div>
+                <span class="settings-label">Inherit supplementary groups</span>
+                <div class="settings-hint">Give each session the user's full group membership (docker, video, etc.), matching a normal login. Disable to run sessions with only the primary group. Requires <code>setpriv</code> (util-linux). Applies to new sessions.</div>
+              </div>
+              <input type="checkbox" id="settings-inherit-groups">
               <span class="toggle-track"><span class="toggle-thumb"></span></span>
             </label>
           </div>

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -25,7 +25,7 @@ import { startThinking, appendThinking, stopThinking, resetThinkingGroup, create
 import { showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './notifications.js';
 import { handleFsList, handleFsRead, handleFileChanged, handleDirChanged, handleFileHistory, handleGitDiff, handleFileAt, refreshIfOpen, getPendingNavigate, handleFsSearch } from './filebrowser.js';
 import { isProjectSettingsOpen, handleInstructionsRead, handleInstructionsWrite, handleProjectEnv, handleProjectEnvSaved, handleProjectSharedEnv, handleProjectSharedEnvSaved, handleProjectOwnerChanged } from './project-settings.js';
-import { updateSettingsModels, updateSettingsStats, updateDaemonConfig, handleSetPinResult, handleKeepAwakeChanged, handleAutoContinueChanged, handleRestartResult, handleShutdownResult, handleSharedEnv, handleSharedEnvSaved, handleGlobalClaudeMdRead, handleGlobalClaudeMdWrite } from './server-settings.js';
+import { updateSettingsModels, updateSettingsStats, updateDaemonConfig, handleSetPinResult, handleKeepAwakeChanged, handleInheritGroupsChanged, handleAutoContinueChanged, handleRestartResult, handleShutdownResult, handleSharedEnv, handleSharedEnvSaved, handleGlobalClaudeMdRead, handleGlobalClaudeMdWrite } from './server-settings.js';
 import { handleTermList, handleTermCreated, sendTerminalCommand, handleTermOutput, handleTermResized, handleTermExited, handleTermClosed } from './terminal.js';
 import { attachTuiView, detachTuiView, setTuiSuspendedView, tuiHandleTermOutput, tuiHandleTermResized, tuiHandleTermExited, tuiHandleTermClosed } from './session-tui-view.js';
 import { handleTuiTranscriptState } from './tui-grab.js';
@@ -1703,6 +1703,11 @@ export function processMessage(msg) {
 
       case "keep_awake_changed":
         handleKeepAwakeChanged(msg);
+        break;
+
+      case "set_inherit_groups_result":
+      case "inherit_groups_changed":
+        handleInheritGroupsChanged(msg);
         break;
 
       case "set_auto_continue_result":

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -1098,6 +1098,20 @@ export function processMessage(msg) {
         addSystemMessage(msg.text, false);
         break;
 
+      case "informational":
+        // level: info | notice | suggestion | warning
+        if (msg.content) addSystemMessage(msg.content, msg.level === "warning");
+        break;
+
+      case "permission_denied": {
+        var deniedText = (msg.toolName ? msg.toolName + ": " : "")
+          + "tool call denied"
+          + (msg.reason ? " — " + msg.reason : (msg.message ? " — " + msg.message : ""))
+          + ".";
+        addSystemMessage(deniedText, false);
+        break;
+      }
+
       case "model_refusal": {
         var refusalText;
         if (msg.refusalKind === "fallback") {

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -21,7 +21,7 @@ import { renderMemoryList } from './mate-memory.js';
 import { handlePaletteSessionSwitch, setPaletteVersion } from './command-palette.js';
 import { handleFindInSessionResults } from './session-search.js';
 import { handleInputSync, autoResize, builtinCommands, setScheduleBtnDisabled } from './input.js';
-import { startThinking, appendThinking, stopThinking, resetThinkingGroup, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, closeToolGroup, removeToolFromGroup, resetToolState, getTools, getPlanContent, setPlanContent, renderPlanBanner, renderPlanCard, getTodoTools, handleTodoWrite, handleTaskCreate, handleTaskUpdate, applyDeadSessionTodoCompaction, isPlanFilePath, enableMainInput, addTurnMeta, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, initSubagentStop, updateSubagentProgress, updateSubagentTaskStatus, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionCancelled, markPermissionResolved, renderElicitationRequest, markElicitationResolved } from './tools.js';
+import { startThinking, appendThinking, stopThinking, resetThinkingGroup, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, closeToolGroup, removeToolFromGroup, resetToolState, getTools, getPlanContent, setPlanContent, renderPlanBanner, renderPlanCard, getTodoTools, handleTodoWrite, handleTaskCreate, handleTaskUpdate, applyDeadSessionTodoCompaction, isPlanFilePath, enableMainInput, addTurnMeta, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, initSubagentStop, updateSubagentProgress, updateSubagentTaskStatus, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionCancelled, markPermissionResolved, renderElicitationRequest, markElicitationResolved, renderUserDialogRequest, markUserDialogResolved } from './tools.js';
 import { showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './notifications.js';
 import { handleFsList, handleFsRead, handleFileChanged, handleDirChanged, handleFileHistory, handleGitDiff, handleFileAt, refreshIfOpen, getPendingNavigate, handleFsSearch } from './filebrowser.js';
 import { isProjectSettingsOpen, handleInstructionsRead, handleInstructionsWrite, handleProjectEnv, handleProjectEnvSaved, handleProjectSharedEnv, handleProjectSharedEnvSaved, handleProjectOwnerChanged } from './project-settings.js';
@@ -989,6 +989,16 @@ export function processMessage(msg) {
 
       case "elicitation_resolved":
         markElicitationResolved(msg.requestId, msg.action);
+        stopUrgentBlink();
+        break;
+
+      case "user_dialog_request":
+        renderUserDialogRequest(msg);
+        startUrgentBlink();
+        break;
+
+      case "user_dialog_resolved":
+        markUserDialogResolved(msg.requestId, msg.behavior);
         stopUrgentBlink();
         break;
 

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -21,7 +21,7 @@ import { renderMemoryList } from './mate-memory.js';
 import { handlePaletteSessionSwitch, setPaletteVersion } from './command-palette.js';
 import { handleFindInSessionResults } from './session-search.js';
 import { handleInputSync, autoResize, builtinCommands, setScheduleBtnDisabled } from './input.js';
-import { startThinking, appendThinking, stopThinking, resetThinkingGroup, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, closeToolGroup, removeToolFromGroup, resetToolState, getTools, getPlanContent, setPlanContent, renderPlanBanner, renderPlanCard, getTodoTools, handleTodoWrite, handleTaskCreate, handleTaskUpdate, applyDeadSessionTodoCompaction, isPlanFilePath, enableMainInput, addTurnMeta, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, initSubagentStop, updateSubagentProgress, updateSubagentTaskStatus, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionCancelled, markPermissionResolved, renderElicitationRequest, markElicitationResolved, renderUserDialogRequest, markUserDialogResolved } from './tools.js';
+import { startThinking, appendThinking, stopThinking, resetThinkingGroup, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, closeToolGroup, removeToolFromGroup, resetToolState, getTools, getPlanContent, setPlanContent, renderPlanBanner, renderPlanCard, getTodoTools, handleTodoWrite, handleTaskCreate, handleTaskUpdate, applyDeadSessionTodoCompaction, isPlanFilePath, enableMainInput, addTurnMeta, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, initSubagentStop, updateSubagentProgress, updateSubagentTaskStatus, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionCancelled, markPermissionResolved, renderElicitationRequest, markElicitationResolved, renderUserDialogRequest, markUserDialogResolved, updateThinkingTokens } from './tools.js';
 import { showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './notifications.js';
 import { handleFsList, handleFsRead, handleFileChanged, handleDirChanged, handleFileHistory, handleGitDiff, handleFileAt, refreshIfOpen, getPendingNavigate, handleFsSearch } from './filebrowser.js';
 import { isProjectSettingsOpen, handleInstructionsRead, handleInstructionsWrite, handleProjectEnv, handleProjectEnvSaved, handleProjectSharedEnv, handleProjectSharedEnvSaved, handleProjectOwnerChanged } from './project-settings.js';
@@ -1096,6 +1096,10 @@ export function processMessage(msg) {
 
       case "sdk_notification":
         addSystemMessage(msg.text, false);
+        break;
+
+      case "thinking_tokens":
+        updateThinkingTokens(msg.estimatedTokens);
         break;
 
       case "informational":

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -1098,6 +1098,25 @@ export function processMessage(msg) {
         addSystemMessage(msg.text, false);
         break;
 
+      case "model_refusal": {
+        var refusalText;
+        if (msg.refusalKind === "fallback") {
+          refusalText = "The model declined this request and automatically retried"
+            + (msg.fallbackModel ? " with " + msg.fallbackModel : " with a fallback model")
+            + (msg.originalModel ? " (originally " + msg.originalModel + ")" : "")
+            + ".";
+          if (msg.category) refusalText += " Category: " + msg.category + ".";
+          addSystemMessage(refusalText, false);
+        } else {
+          refusalText = "The model declined to respond to this request.";
+          if (msg.explanation) refusalText += " " + msg.explanation;
+          else if (msg.content) refusalText += " " + msg.content;
+          if (msg.category) refusalText += " (Category: " + msg.category + ")";
+          addSystemMessage(refusalText, true);
+        }
+        break;
+      }
+
       case "process_conflict":
         removeMatePreThinking();
         setActivity(null);

--- a/lib/public/modules/mcp-ui.js
+++ b/lib/public/modules/mcp-ui.js
@@ -137,6 +137,28 @@ function renderMcpServerList() {
 
       row.appendChild(cb);
       row.appendChild(info);
+
+      // Per-server permission mode override (applies to the active session only).
+      if (server.projectEnabled) {
+        var modeSel = document.createElement("select");
+        modeSel.className = "mcp-server-perm-mode";
+        modeSel.dataset.serverName = server.name;
+        modeSel.title = "Permission mode for this server (this session only)";
+        var optAsk = document.createElement("option");
+        optAsk.value = "default";
+        optAsk.textContent = "Ask";
+        var optAuto = document.createElement("option");
+        optAuto.value = "auto";
+        optAuto.textContent = "Auto-approve";
+        modeSel.appendChild(optAsk);
+        modeSel.appendChild(optAuto);
+        modeSel.value = server.permissionModeOverride === "auto" ? "auto" : "default";
+        // The row is a <label>; keep select interactions from toggling the checkbox.
+        modeSel.addEventListener("click", function (e) { e.stopPropagation(); e.preventDefault(); });
+        modeSel.addEventListener("change", onPermissionModeChange);
+        row.appendChild(modeSel);
+      }
+
       contentEl.appendChild(row);
     }
     refreshIcons(contentEl);
@@ -290,6 +312,28 @@ function onToggle(e) {
       type: "mcp_toggle_server",
       name: name,
       enabled: enabled,
+    }));
+  }
+}
+
+function onPermissionModeChange(e) {
+  var name = e.target.dataset.serverName;
+  var mode = e.target.value; // "default" | "auto"
+
+  // Remember locally so a re-render keeps the selection.
+  for (var i = 0; i < _mcpServers.length; i++) {
+    if (_mcpServers[i].name === name) {
+      _mcpServers[i].permissionModeOverride = mode;
+      break;
+    }
+  }
+
+  var ws = getWs();
+  if (ws && ws.readyState === 1) {
+    ws.send(JSON.stringify({
+      type: "set_mcp_permission_mode_override",
+      serverName: name,
+      mode: mode,
     }));
   }
 }

--- a/lib/public/modules/server-settings.js
+++ b/lib/public/modules/server-settings.js
@@ -157,6 +157,17 @@ export function initServerSettings(appCtx) {
     });
   }
 
+  // Inherit supplementary groups toggle (OS-users mode)
+  var inheritGroupsToggle = document.getElementById("settings-inherit-groups");
+  if (inheritGroupsToggle) {
+    inheritGroupsToggle.addEventListener("change", function () {
+      var ws = ctx.ws;
+      if (ws && ws.readyState === 1) {
+        ws.send(JSON.stringify({ type: "set_inherit_groups", value: this.checked }));
+      }
+    });
+  }
+
   // Image retention select
   var imageRetentionSelect = document.getElementById("settings-image-retention");
   if (imageRetentionSelect) {
@@ -482,6 +493,10 @@ export function updateDaemonConfig(config) {
   var keepAwakeToggle = document.getElementById("settings-keep-awake");
   if (keepAwakeToggle) keepAwakeToggle.checked = !!config.keepAwake;
 
+  // Inherit supplementary groups (only relevant in OS-users mode)
+  var inheritGroupsToggle = document.getElementById("settings-inherit-groups");
+  if (inheritGroupsToggle) inheritGroupsToggle.checked = config.inheritGroups !== false;
+
   // Image retention
   var imageRetentionSelect = document.getElementById("settings-image-retention");
   if (imageRetentionSelect && config.imageRetentionDays !== undefined) {
@@ -517,6 +532,20 @@ export function updateDaemonConfig(config) {
     if (keepAwakeNav) keepAwakeNav.classList.add("hidden");
     if (keepAwakeOpt) keepAwakeOpt.classList.add("hidden");
   }
+
+  // Show inherit-groups section/nav only in OS-users mode
+  var inheritGroupsSection = document.getElementById("settings-inherit-groups-section");
+  var inheritGroupsNav = document.getElementById("settings-inherit-groups-nav");
+  var inheritGroupsOpt = document.getElementById("settings-inherit-groups-opt");
+  if (config.osUsers) {
+    if (inheritGroupsSection) inheritGroupsSection.classList.remove("hidden");
+    if (inheritGroupsNav) inheritGroupsNav.classList.remove("hidden");
+    if (inheritGroupsOpt) inheritGroupsOpt.classList.remove("hidden");
+  } else {
+    if (inheritGroupsSection) inheritGroupsSection.classList.add("hidden");
+    if (inheritGroupsNav) inheritGroupsNav.classList.add("hidden");
+    if (inheritGroupsOpt) inheritGroupsOpt.classList.add("hidden");
+  }
 }
 
 export function handleSetPinResult(msg) {
@@ -530,6 +559,11 @@ export function handleSetPinResult(msg) {
 export function handleKeepAwakeChanged(msg) {
   var keepAwakeToggle = document.getElementById("settings-keep-awake");
   if (keepAwakeToggle) keepAwakeToggle.checked = !!msg.keepAwake;
+}
+
+export function handleInheritGroupsChanged(msg) {
+  var inheritGroupsToggle = document.getElementById("settings-inherit-groups");
+  if (inheritGroupsToggle) inheritGroupsToggle.checked = msg.inheritGroups !== false;
 }
 
 export function handleAutoContinueChanged(msg) {

--- a/lib/public/modules/skills.js
+++ b/lib/public/modules/skills.js
@@ -1,6 +1,16 @@
 import { iconHtml, refreshIcons } from './icons.js';
 import { escapeHtml, copyToClipboard, showToast } from './utils.js';
 import { store } from './store.js';
+import { getWs } from './ws-ref.js';
+
+// Ask the active session to hot-reload skills so a just-installed/uninstalled
+// skill takes effect without restarting the session. No-op if no live session.
+function reloadActiveSessionSkills() {
+  var ws = getWs();
+  if (ws && ws.readyState === 1) {
+    ws.send(JSON.stringify({ type: "reload_skills" }));
+  }
+}
 
 var modal;
 var contentEl;
@@ -607,6 +617,9 @@ export function handleSkillInstalled(msg) {
     if (activeTab === "installed" && currentView === "list") {
       loadInstalledSkills();
     }
+
+    // Hot-reload skills in the active session so it's usable immediately
+    reloadActiveSessionSkills();
   } else {
     // Show error toast
     showToast("Failed to install " + skill + (msg.error ? ": " + msg.error : ""), "error");
@@ -676,6 +689,9 @@ export function handleSkillUninstalled(msg) {
     if (activeTab === "installed" && currentView === "list") {
       loadInstalledSkills();
     }
+
+    // Hot-reload skills in the active session so the change applies immediately
+    reloadActiveSessionSkills();
   } else {
     showToast("Failed to uninstall " + skill + (msg.error ? ": " + msg.error : ""), "error");
     // Re-enable the uninstall button

--- a/lib/public/modules/tools.js
+++ b/lib/public/modules/tools.js
@@ -1181,6 +1181,147 @@ export function markElicitationResolved(requestId, action) {
   delete pendingElicitations[requestId];
 }
 
+// --- Host user dialog (SDK request_user_dialog) ---
+// Generic, defensive renderer. We declare only kinds we handle in
+// supportedDialogKinds (server side), but treat the payload as opaque: render
+// a human message + any provided choices, fall back to Proceed/Cancel, and
+// log the raw payload so unseen shapes can be refined. Cancel is always safe.
+
+var pendingUserDialogs = {};
+
+function sendUserDialogResponse(container, requestId, behavior, result) {
+  if (container.classList.contains("resolved")) return;
+  container.classList.add("resolved");
+  if (ctx.stopUrgentBlink) ctx.stopUrgentBlink();
+
+  var isCancel = behavior !== "completed";
+  container.classList.add(isCancel ? "resolved-denied" : "resolved-allowed");
+
+  var actions = container.querySelector(".permission-actions");
+  if (actions) {
+    actions.innerHTML = '<span class="permission-decision-label">' + (isCancel ? "Cancelled" : "Submitted") + '</span>';
+  }
+
+  if (ctx.ws && ctx.connected) {
+    var msg = {
+      type: "user_dialog_response",
+      requestId: requestId,
+      behavior: isCancel ? "cancelled" : "completed",
+    };
+    if (!isCancel) msg.result = result;
+    ctx.ws.send(JSON.stringify(msg));
+  }
+
+  delete pendingUserDialogs[requestId];
+}
+
+export function renderUserDialogRequest(msg) {
+  if (pendingUserDialogs[msg.requestId]) return;
+  ctx.finalizeAssistantBlock();
+  stopThinking();
+  closeToolGroup();
+
+  var payload = msg.payload || {};
+  try { console.log("[user_dialog] kind=" + msg.dialogKind + " payload=", payload); } catch (e) {}
+
+  var container = document.createElement("div");
+  container.className = "permission-container user-dialog-container";
+  container.dataset.requestId = msg.requestId;
+
+  // Header
+  var titleText = payload.title || "Claude needs a decision";
+  var header = document.createElement("div");
+  header.className = "permission-header";
+  header.innerHTML =
+    '<span class="permission-icon">' + iconHtml("key") + '</span>' +
+    '<span class="permission-title">' + escapeHtml(titleText) + '</span>';
+
+  // Body: best-effort human message from common payload fields
+  var body = document.createElement("div");
+  body.className = "permission-body";
+  var messageText = payload.message || payload.prompt || payload.question || payload.text || "";
+  if (messageText) {
+    var messageEl = document.createElement("div");
+    messageEl.className = "permission-reason";
+    messageEl.textContent = String(messageText);
+    body.appendChild(messageEl);
+  }
+  var kindEl = document.createElement("div");
+  kindEl.className = "user-dialog-kind";
+  kindEl.style.cssText = "margin-top: 6px; font-size: 11px; color: var(--text-muted);";
+  kindEl.textContent = msg.dialogKind || "dialog";
+  body.appendChild(kindEl);
+
+  // Actions
+  var actions = document.createElement("div");
+  actions.className = "permission-actions";
+
+  // If the payload carries explicit choices, render one button per choice.
+  var choices = Array.isArray(payload.options) ? payload.options
+    : Array.isArray(payload.choices) ? payload.choices
+    : null;
+
+  if (choices && choices.length) {
+    for (var i = 0; i < choices.length; i++) {
+      (function (choice) {
+        var label = (choice && (choice.label || choice.title || choice.name)) || String(choice);
+        var value = (choice && ("value" in choice)) ? choice.value : choice;
+        var btn = document.createElement("button");
+        btn.className = "permission-btn permission-allow";
+        btn.textContent = label;
+        btn.addEventListener("click", function () {
+          sendUserDialogResponse(container, msg.requestId, "completed", value);
+        });
+        actions.appendChild(btn);
+      })(choices[i]);
+    }
+  } else {
+    var proceedBtn = document.createElement("button");
+    proceedBtn.className = "permission-btn permission-allow";
+    proceedBtn.textContent = "Proceed";
+    proceedBtn.addEventListener("click", function () {
+      sendUserDialogResponse(container, msg.requestId, "completed", {});
+    });
+    actions.appendChild(proceedBtn);
+  }
+
+  var cancelBtn = document.createElement("button");
+  cancelBtn.className = "permission-btn permission-deny";
+  cancelBtn.textContent = "Cancel";
+  cancelBtn.addEventListener("click", function () {
+    sendUserDialogResponse(container, msg.requestId, "cancelled", null);
+  });
+  actions.appendChild(cancelBtn);
+
+  container.appendChild(header);
+  container.appendChild(body);
+  container.appendChild(actions);
+  ctx.addToMessages(container);
+
+  pendingUserDialogs[msg.requestId] = container;
+  refreshIcons();
+  ctx.setActivity(null);
+  maybeScrollToBottom();
+}
+
+export function markUserDialogResolved(requestId, behavior) {
+  var container = pendingUserDialogs[requestId];
+  if (!container) {
+    container = ctx.messagesEl.querySelector('.user-dialog-container[data-request-id="' + requestId + '"]');
+  }
+  if (!container || container.classList.contains("resolved")) return;
+
+  container.classList.add("resolved");
+  var isCancel = behavior !== "completed";
+  container.classList.add(isCancel ? "resolved-denied" : "resolved-allowed");
+
+  var actionsEl = container.querySelector(".permission-actions");
+  if (actionsEl) {
+    actionsEl.innerHTML = '<span class="permission-decision-label">' + (isCancel ? "Cancelled" : "Submitted") + '</span>';
+  }
+  delete pendingUserDialogs[requestId];
+}
+
 // --- Plan mode rendering ---
 export function renderPlanBanner(type) {
   ctx.finalizeAssistantBlock();
@@ -2379,6 +2520,7 @@ export function resetToolState() {
   if (todoObserver) { todoObserver.disconnect(); todoObserver = null; }
   pendingPermissions = {};
   pendingElicitations = {};
+  pendingUserDialogs = {};
   currentToolGroup = null;
   toolGroupCounter = 0;
   toolGroups = {};

--- a/lib/public/modules/tools.js
+++ b/lib/public/modules/tools.js
@@ -1322,6 +1322,18 @@ export function markUserDialogResolved(requestId, behavior) {
   delete pendingUserDialogs[requestId];
 }
 
+// --- Live thinking-token estimate ---
+// Annotates the active thinking block's label with a running token estimate.
+// No-op when no thinking block is active.
+export function updateThinkingTokens(estimatedTokens) {
+  if (!currentThinking || !currentThinking.el) return;
+  var label = currentThinking.el.querySelector(".thinking-label");
+  if (!label) return;
+  var n = estimatedTokens || 0;
+  var disp = n >= 1000 ? ("~" + (Math.round(n / 100) / 10) + "k") : ("~" + n);
+  label.textContent = "Thinking " + disp + " tokens";
+}
+
 // --- Plan mode rendering ---
 export function renderPlanBanner(type) {
   ctx.finalizeAssistantBlock();
@@ -1695,6 +1707,8 @@ export function startThinking() {
     var el = thinkingGroup.el;
     el.classList.remove("done");
     el.querySelector(".thinking-content").textContent = "";
+    var reuseLabel = el.querySelector(".thinking-label");
+    if (reuseLabel) reuseLabel.textContent = "Thinking";
     // Mate mode: restore dots activity row, hide thinking header
     if (el.classList.contains("mate-thinking")) {
       var actRow = el.querySelector(".mate-thinking-activity");

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -392,11 +392,12 @@ function createSDKBridge(opts) {
     });
   }
 
-  // --- Host user dialog (SDK request_user_dialog, e.g. refusal_fallback_prompt) ---
-  // Mirrors handleElicitation: the SDK invokes onUserDialog, we forward a
-  // user_dialog_request to the client, and resolve once the client answers.
-  // Unknown dialog kinds / autonomous mode resolve to { behavior: "cancelled" },
-  // which the CLI treats as "apply the dialog's default no-dialog behavior".
+  // --- Host user dialog ---
+  // Mirrors handleElicitation: the adapter invokes onUserDialog with an opaque
+  // { dialogKind, payload }, we forward a user_dialog_request to the client, and
+  // resolve once the client answers. Which dialog kinds exist is the adapter's
+  // concern; the relay just transports them. Unknown kinds / autonomous mode
+  // resolve to { behavior: "cancelled" } (the no-dialog default).
 
   function handleUserDialog(session, request, opts) {
     // Ralph Loop: auto-cancel host dialogs in autonomous mode (CLI falls back
@@ -1331,10 +1332,6 @@ function createSDKBridge(opts) {
       onUserDialog: function(dialogRequest, dialogOpts) {
         return handleUserDialog(session, dialogRequest, dialogOpts);
       },
-      // Dialog kinds our client can render. The CLI fails closed: kinds not
-      // listed here are never emitted (the gated flow degrades to its
-      // no-dialog default). Keep in sync with the client renderer.
-      supportedDialogKinds: ["refusal_fallback_prompt"],
       callMcpTool: function(serverName, toolName, args) {
         return callMcpToolHandler(mergedMcpServers, serverName, toolName, args);
       },

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -392,6 +392,53 @@ function createSDKBridge(opts) {
     });
   }
 
+  // --- Host user dialog (SDK request_user_dialog, e.g. refusal_fallback_prompt) ---
+  // Mirrors handleElicitation: the SDK invokes onUserDialog, we forward a
+  // user_dialog_request to the client, and resolve once the client answers.
+  // Unknown dialog kinds / autonomous mode resolve to { behavior: "cancelled" },
+  // which the CLI treats as "apply the dialog's default no-dialog behavior".
+
+  function handleUserDialog(session, request, opts) {
+    // Ralph Loop: auto-cancel host dialogs in autonomous mode (CLI falls back
+    // to the no-dialog default, e.g. the classic refusal error).
+    if (session.loop && session.loop.active && session.loop.role !== "crafting") {
+      return Promise.resolve({ behavior: "cancelled" });
+    }
+
+    return new Promise(function(resolve) {
+      var requestId = crypto.randomUUID();
+      if (!session.pendingUserDialogs) session.pendingUserDialogs = {};
+      session.pendingUserDialogs[requestId] = {
+        resolve: resolve,
+        request: request,
+      };
+      sendAndRecord(session, {
+        type: "user_dialog_request",
+        requestId: requestId,
+        dialogKind: request.dialogKind,
+        payload: request.payload || {},
+        toolUseId: request.toolUseID || null,
+      });
+
+      if (pushModule) {
+        pushModule.sendPush({
+          type: "user_dialog",
+          slug: slug,
+          title: "Claude needs a decision",
+          body: "Waiting for your response",
+          tag: "claude-user-dialog",
+        });
+      }
+
+      if (opts.signal) {
+        opts.signal.addEventListener("abort", function() {
+          delete session.pendingUserDialogs[requestId];
+          resolve({ behavior: "cancelled" });
+        });
+      }
+    });
+  }
+
 
   // --- Linux user project directory setup ---
   // Ensures the linux user's .claude project directory exists and is writable,
@@ -1281,6 +1328,13 @@ function createSDKBridge(opts) {
       onElicitation: function(request, elicitOpts) {
         return handleElicitation(session, request, elicitOpts);
       },
+      onUserDialog: function(dialogRequest, dialogOpts) {
+        return handleUserDialog(session, dialogRequest, dialogOpts);
+      },
+      // Dialog kinds our client can render. The CLI fails closed: kinds not
+      // listed here are never emitted (the gated flow degrades to its
+      // no-dialog default). Keep in sync with the client renderer.
+      supportedDialogKinds: ["refusal_fallback_prompt"],
       callMcpTool: function(serverName, toolName, args) {
         return callMcpToolHandler(mergedMcpServers, serverName, toolName, args);
       },

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1654,6 +1654,29 @@ function createSDKBridge(opts) {
     }
   }
 
+  // Hot-reload skills/MCP/agents on the active query without a restart.
+  async function reloadSkills(session) {
+    if (!session || !session.queryInstance) return;
+    try {
+      // Route through QueryHandle (works for both in-process and worker paths)
+      await session.queryInstance.reloadSkills();
+      send({ type: "system_info", text: "Skills reloaded." });
+    } catch (e) {
+      send({ type: "error", text: "Failed to reload skills: " + (e.message || e) });
+    }
+  }
+
+  // Override the permission mode for one MCP server on the active query.
+  async function setMcpPermissionModeOverride(session, serverName, mode) {
+    if (!session || !session.queryInstance) return;
+    try {
+      // Route through QueryHandle (works for both in-process and worker paths)
+      await session.queryInstance.setMcpPermissionModeOverride(serverName, mode);
+    } catch (e) {
+      send({ type: "error", text: "Failed to set MCP permission mode: " + (e.message || e) });
+    }
+  }
+
   // --- @Mention: persistent read-only session for a mentioned Mate ---
   // Creates a mention session that can be reused across multiple mentions
   // within a conversation flow (session continuity).
@@ -1840,6 +1863,8 @@ function createSDKBridge(opts) {
     permissionPushBody: permissionPushBody,
     warmup: warmup,
     stopTask: stopTask,
+    reloadSkills: reloadSkills,
+    setMcpPermissionModeOverride: setMcpPermissionModeOverride,
     createMentionSession: createMentionSession,
     startIdleReaper: startIdleReaper,
     stopIdleReaper: stopIdleReaper,

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -698,6 +698,20 @@ function attachMessageProcessor(ctx) {
       var retryText = parsed.message || parsed.error || "Retrying API request...";
       sendToSession(session, { type: "system_info", text: retryText });
 
+    } else if (parsed.yokeType === "model_refusal") {
+      // Model declined the request. "fallback" => the CLI retried on another
+      // model; "no_fallback" => the turn ended with a refusal.
+      sendAndRecord(session, {
+        type: "model_refusal",
+        refusalKind: parsed.refusalKind || "no_fallback",
+        originalModel: parsed.originalModel || null,
+        fallbackModel: parsed.fallbackModel || null,
+        direction: parsed.direction || null,
+        category: parsed.category || null,
+        explanation: parsed.explanation || null,
+        content: parsed.content || null,
+      });
+
     } else if (parsed.yokeType === "system") {
       // Catch-all for unhandled system subtypes (e.g. hook-block errors).
       // Extract any error text and surface it in the UI.

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -698,6 +698,30 @@ function attachMessageProcessor(ctx) {
       var retryText = parsed.message || parsed.error || "Retrying API request...";
       sendToSession(session, { type: "system_info", text: retryText });
 
+    } else if (parsed.yokeType === "informational") {
+      // Leveled informational message from the agent (info/notice/suggestion/warning).
+      if (parsed.content) {
+        sendAndRecord(session, {
+          type: "informational",
+          level: parsed.level || "info",
+          content: parsed.content,
+          toolUseId: parsed.toolUseId || null,
+          preventContinuation: !!parsed.preventContinuation,
+        });
+      }
+
+    } else if (parsed.yokeType === "permission_denied") {
+      // A tool call was blocked; surface why.
+      sendAndRecord(session, {
+        type: "permission_denied",
+        toolName: parsed.toolName || "",
+        toolUseId: parsed.toolUseId || null,
+        agentId: parsed.agentId || null,
+        reasonType: parsed.reasonType || null,
+        reason: parsed.reason || null,
+        message: parsed.message || "",
+      });
+
     } else if (parsed.yokeType === "model_refusal") {
       // Model declined the request. "fallback" => the CLI retried on another
       // model; "no_fallback" => the turn ended with a refusal.

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -698,6 +698,27 @@ function attachMessageProcessor(ctx) {
       var retryText = parsed.message || parsed.error || "Retrying API request...";
       sendToSession(session, { type: "system_info", text: retryText });
 
+    } else if (parsed.yokeType === "commands_changed") {
+      // Mid-session command list change: rebuild the union with skills (same as
+      // init) and push a full replacement to the client.
+      var cmdSeen = new Set();
+      var cmdCombined = [];
+      var cmdAll = (parsed.commandNames || []).concat(Array.from(sm.skillNames || []));
+      for (var ci = 0; ci < cmdAll.length; ci++) {
+        if (!cmdSeen.has(cmdAll[ci])) {
+          cmdSeen.add(cmdAll[ci]);
+          cmdCombined.push(cmdAll[ci]);
+        }
+      }
+      sm.slashCommands = cmdCombined;
+      send({ type: "slash_commands", commands: sm.slashCommands });
+
+    } else if (parsed.yokeType === "worker_shutting_down") {
+      // Surface non-routine teardown reasons; "host_exit" is the normal close.
+      if (parsed.reason && parsed.reason !== "host_exit") {
+        sendToSession(session, { type: "system_info", text: "Session worker shutting down: " + parsed.reason });
+      }
+
     } else if (parsed.yokeType === "thinking_tokens") {
       // Live thinking-token estimate; ephemeral, do not persist in history.
       sendToSession(session, {

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -698,6 +698,14 @@ function attachMessageProcessor(ctx) {
       var retryText = parsed.message || parsed.error || "Retrying API request...";
       sendToSession(session, { type: "system_info", text: retryText });
 
+    } else if (parsed.yokeType === "thinking_tokens") {
+      // Live thinking-token estimate; ephemeral, do not persist in history.
+      sendToSession(session, {
+        type: "thinking_tokens",
+        estimatedTokens: parsed.estimatedTokens || 0,
+        estimatedTokensDelta: parsed.estimatedTokensDelta || 0,
+      });
+
     } else if (parsed.yokeType === "informational") {
       // Leveled informational message from the agent (info/notice/suggestion/warning).
       if (parsed.content) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -153,6 +153,7 @@ function createServer(opts) {
   var onGetDaemonConfig = opts.onGetDaemonConfig || null;
   var onSetPin = opts.onSetPin || null;
   var onSetKeepAwake = opts.onSetKeepAwake || null;
+  var onSetInheritGroups = opts.onSetInheritGroups || null;
   var onSetImageRetention = opts.onSetImageRetention || null;
   var onShutdown = opts.onShutdown || null;
   var onRestart = opts.onRestart || null;
@@ -1257,6 +1258,7 @@ function createServer(opts) {
       onGetDaemonConfig: onGetDaemonConfig,
       onSetPin: onSetPin,
       onSetKeepAwake: onSetKeepAwake,
+      onSetInheritGroups: onSetInheritGroups,
       onSetImageRetention: onSetImageRetention,
       onSetUpdateChannel: onSetUpdateChannel,
       updateChannel: onGetDaemonConfig ? (onGetDaemonConfig().updateChannel || "stable") : "stable",

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -39,7 +39,10 @@ function createTerminal(cwd, cols, rows, osUserInfo, opts) {
   }
 
   var args = osUserInfo ? ["-l"] : [];
-  var term = pty.spawn(shell, args, spawnOpts);
+  // Route through setpriv when group inheritance is enabled so the terminal
+  // gets the user's supplementary groups (docker, etc.), not just primary gid.
+  var ptySpawn = require("./os-users").wrapSpawnAsUser(shell, args, spawnOpts);
+  var term = pty.spawn(ptySpawn.command, ptySpawn.args, ptySpawn.options);
 
   if (opts && opts.initialInput) {
     try { term.write(opts.initialInput); } catch (e) {}

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -70,6 +70,7 @@ var schema = {
   "model_refusal":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Model declined the request (fallback to another model, or no fallback)" },
   "informational":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Leveled informational message from the agent (info/notice/suggestion/warning)" },
   "permission_denied":        { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "A tool call was denied; explains why" },
+  "thinking_tokens":          { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Live thinking-token estimate (ephemeral)" },
   "context_preview":          { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Preview of context sources included in a query" },
 
   // -----------------------------------------------------------------------
@@ -163,6 +164,8 @@ var schema = {
   "set_server_default_model": { direction: "c2s", handler: "lib/project-sessions.js", description: "Set the server-wide default model" },
   "set_project_default_model": { direction: "c2s", handler: "lib/project-sessions.js", description: "Set the project default model" },
   "set_permission_mode":      { direction: "c2s", handler: "lib/project-sessions.js", description: "Set permission mode for the current session" },
+  "reload_skills":            { direction: "c2s", handler: "lib/project-sessions.js", description: "Hot-reload skills/MCP/agents on the active query without a restart" },
+  "set_mcp_permission_mode_override": { direction: "c2s", handler: "lib/project-sessions.js", description: "Override permission mode (default/auto/null) for one MCP server" },
   "set_server_default_mode":  { direction: "c2s", handler: "lib/project-sessions.js", description: "Set the server-wide default permission mode" },
   "set_project_default_mode": { direction: "c2s", handler: "lib/project-sessions.js", description: "Set the project default permission mode" },
   "set_effort":               { direction: "c2s", handler: "lib/project-sessions.js", description: "Set effort level for the current session" },

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -115,6 +115,9 @@ var schema = {
   "elicitation_request":      { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Structured form elicitation request from assistant" },
   "elicitation_response":     { direction: "c2s", handler: "lib/project-sessions.js", description: "User response to an elicitation form" },
   "elicitation_resolved":     { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Elicitation request resolved" },
+  "user_dialog_request":      { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Host dialog request from assistant (SDK request_user_dialog)" },
+  "user_dialog_response":     { direction: "c2s", handler: "lib/project-sessions.js", description: "User response to a host dialog request" },
+  "user_dialog_resolved":     { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Host dialog request resolved" },
 
   // -----------------------------------------------------------------------
   // Stop / control

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -68,6 +68,8 @@ var schema = {
   "message_uuid":             { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "UUID assigned to a user or assistant message" },
   "prompt_suggestion":        { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Suggested follow-up prompt from the assistant" },
   "model_refusal":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Model declined the request (fallback to another model, or no fallback)" },
+  "informational":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Leveled informational message from the agent (info/notice/suggestion/warning)" },
+  "permission_denied":        { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "A tool call was denied; explains why" },
   "context_preview":          { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Preview of context sources included in a query" },
 
   // -----------------------------------------------------------------------

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -67,6 +67,7 @@ var schema = {
   "compacting":               { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Conversation compaction in progress (active: true/false)" },
   "message_uuid":             { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "UUID assigned to a user or assistant message" },
   "prompt_suggestion":        { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Suggested follow-up prompt from the assistant" },
+  "model_refusal":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Model declined the request (fallback to another model, or no fallback)" },
   "context_preview":          { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Preview of context sources included in a query" },
 
   // -----------------------------------------------------------------------

--- a/lib/yoke/adapters/claude-worker.js
+++ b/lib/yoke/adapters/claude-worker.js
@@ -272,6 +272,12 @@ function handleMessage(msg) {
     case "stop_task":
       handleStopTask(msg);
       break;
+    case "reload_skills":
+      handleReloadSkills(msg);
+      break;
+    case "set_mcp_permission_mode_override":
+      handleSetMcpPermissionModeOverride(msg);
+      break;
     case "rewind_files":
       handleRewindFiles(msg);
       break;
@@ -665,6 +671,24 @@ async function handleStopTask(msg) {
   // Also abort as fallback (matches daemon behavior)
   if (abortController) {
     abortController.abort();
+  }
+}
+
+async function handleReloadSkills(msg) {
+  if (!queryInstance || typeof queryInstance.reloadSkills !== "function") return;
+  try {
+    await queryInstance.reloadSkills();
+  } catch (e) {
+    console.error("[sdk-worker] reloadSkills error:", e.message);
+  }
+}
+
+async function handleSetMcpPermissionModeOverride(msg) {
+  if (!queryInstance || typeof queryInstance.setMcpPermissionModeOverride !== "function") return;
+  try {
+    await queryInstance.setMcpPermissionModeOverride(msg.serverName, msg.mode);
+  } catch (e) {
+    console.error("[sdk-worker] setMcpPermissionModeOverride error:", e.message);
   }
 }
 

--- a/lib/yoke/adapters/claude-worker.js
+++ b/lib/yoke/adapters/claude-worker.js
@@ -99,6 +99,7 @@ var abortController = null;
 var pendingPermissions = {};  // requestId -> resolve
 var pendingAskUser = {};      // toolUseId -> resolve
 var pendingElicitations = {}; // requestId -> resolve
+var pendingUserDialogs = {};  // requestId -> resolve
 var pendingMcpToolCalls = {}; // requestId -> { resolve, reject }
 var conn = null;
 var buffer = "";
@@ -283,6 +284,9 @@ function handleMessage(msg) {
     case "elicitation_response":
       handleElicitationResponse(msg);
       break;
+    case "user_dialog_response":
+      handleUserDialogResponse(msg);
+      break;
     case "mcp_tool_result":
       handleMcpToolResult(msg);
       break;
@@ -343,6 +347,27 @@ function onElicitation(request, opts) {
   });
 }
 
+// --- onUserDialog: delegates to daemon via IPC ---
+function onUserDialog(request, opts) {
+  var requestId = crypto.randomUUID();
+  sendToDaemon({
+    type: "user_dialog_request",
+    requestId: requestId,
+    dialogKind: request.dialogKind,
+    payload: request.payload || {},
+    toolUseId: request.toolUseID || null,
+  });
+  return new Promise(function(resolve) {
+    pendingUserDialogs[requestId] = resolve;
+    if (opts.signal) {
+      opts.signal.addEventListener("abort", function() {
+        delete pendingUserDialogs[requestId];
+        resolve({ behavior: "cancelled" });
+      });
+    }
+  });
+}
+
 function handlePermissionResponse(msg) {
   var resolve = pendingPermissions[msg.requestId];
   if (resolve) {
@@ -363,6 +388,14 @@ function handleElicitationResponse(msg) {
   var resolve = pendingElicitations[msg.requestId];
   if (resolve) {
     delete pendingElicitations[msg.requestId];
+    resolve(msg.result);
+  }
+}
+
+function handleUserDialogResponse(msg) {
+  var resolve = pendingUserDialogs[msg.requestId];
+  if (resolve) {
+    delete pendingUserDialogs[msg.requestId];
     resolve(msg.result);
   }
 }
@@ -476,6 +509,11 @@ async function handleQueryStart(msg) {
   };
   options.onElicitation = function(request, elicitOpts) {
     return onElicitation(request, elicitOpts);
+  };
+  // supportedDialogKinds arrives serialized via msg.options (already on `options`);
+  // the callback is non-serializable so we wire it here.
+  options.onUserDialog = function(request, dialogOpts) {
+    return onUserDialog(request, dialogOpts);
   };
 
   perf("creating query instance");

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -517,13 +517,16 @@ function spawnWorker(linuxUser, workerScriptPath, cwd) {
     console.log("[yoke/claude] Spawning worker: uid=" + userInfo.uid + " gid=" + userInfo.gid + " cwd=" + cwd + " socket=" + socketPath);
     console.log("[yoke/claude] Worker script: " + workerScriptPath);
     console.log("[yoke/claude] Node: " + process.execPath);
-    worker.process = spawn(process.execPath, [workerScriptPath, socketPath], {
+    // Route through setpriv when group inheritance is enabled so the worker
+    // (and the agent CLI it spawns) inherits the user's supplementary groups.
+    var workerSpawn = require("../../os-users").wrapSpawnAsUser(process.execPath, [workerScriptPath, socketPath], {
       uid: userInfo.uid,
       gid: userInfo.gid,
       env: workerEnv,
       cwd: cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    worker.process = spawn(workerSpawn.command, workerSpawn.args, workerSpawn.options);
 
     worker.process.stdout.on("data", function(data) {
       console.log("[sdk-worker:" + linuxUser + "] " + data.toString().trim());

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -12,6 +12,12 @@ var crypto = require("crypto");
 var { spawn } = require("child_process");
 var { resolveOsUserInfo } = require("../../os-users");
 
+// SDK-specific knowledge stays in the adapter (not the relay): the host dialog
+// kinds this client can render, declared to the SDK when an onUserDialog
+// callback is wired. The CLI fails closed — kinds not listed here are never
+// emitted. Keep in sync with the client's generic user-dialog renderer.
+var SUPPORTED_DIALOG_KINDS = ["refusal_fallback_prompt"];
+
 // --- SDK loading ---
 // Async loader (ESM dynamic import, same pattern as current project.js getSDK)
 var _sdkPromise = null;
@@ -180,6 +186,27 @@ function flattenEvent(raw) {
       base.lastToolName = raw.last_tool_name || null;
       base.description = raw.description || "";
       base.summary = raw.summary || null;
+      return base;
+    }
+    // Model refusal: the model declined and the CLI either fell back to
+    // another model or ended the turn. Translate to a vendor-neutral
+    // yokeType so the relay never sees SDK subtype strings.
+    if (raw.subtype === "model_refusal_fallback") {
+      base.yokeType = "model_refusal";
+      base.refusalKind = "fallback";
+      base.originalModel = raw.original_model || null;
+      base.fallbackModel = raw.fallback_model || null;
+      base.direction = raw.direction || null;
+      base.category = raw.api_refusal_category || null;
+      return base;
+    }
+    if (raw.subtype === "model_refusal_no_fallback") {
+      base.yokeType = "model_refusal";
+      base.refusalKind = "no_fallback";
+      base.originalModel = raw.original_model || null;
+      base.category = raw.api_refusal_category || null;
+      base.explanation = raw.api_refusal_explanation || null;
+      base.content = raw.content || null;
       return base;
     }
     // Catch-all system event
@@ -1236,8 +1263,10 @@ function createClaudeAdapter(opts) {
       if (queryOpts.toolServers) sdkOptions.mcpServers = queryOpts.toolServers;
       if (queryOpts.canUseTool) sdkOptions.canUseTool = queryOpts.canUseTool;
       if (queryOpts.onElicitation) sdkOptions.onElicitation = queryOpts.onElicitation;
-      if (queryOpts.onUserDialog) sdkOptions.onUserDialog = queryOpts.onUserDialog;
-      if (queryOpts.supportedDialogKinds) sdkOptions.supportedDialogKinds = queryOpts.supportedDialogKinds;
+      if (queryOpts.onUserDialog) {
+        sdkOptions.onUserDialog = queryOpts.onUserDialog;
+        sdkOptions.supportedDialogKinds = SUPPORTED_DIALOG_KINDS;
+      }
       if (queryOpts.resumeSessionId) sdkOptions.resume = queryOpts.resumeSessionId;
 
       // Claude-specific options from adapterOptions.CLAUDE
@@ -1413,7 +1442,7 @@ function createClaudeAdapter(opts) {
     if (claudeOpts.settings) queryOptions.settings = claudeOpts.settings;
 
     if (queryOpts.toolServerDescriptors) queryOptions.mcpServerDescriptors = queryOpts.toolServerDescriptors;
-    if (queryOpts.supportedDialogKinds) queryOptions.supportedDialogKinds = queryOpts.supportedDialogKinds;
+    if (queryOpts.onUserDialog) queryOptions.supportedDialogKinds = SUPPORTED_DIALOG_KINDS;
     if (queryOpts.model) queryOptions.model = queryOpts.model;
     if (queryOpts.effort) queryOptions.effort = queryOpts.effort;
     if (queryOpts.resumeSessionId) queryOptions.resume = queryOpts.resumeSessionId;

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -209,6 +209,26 @@ function flattenEvent(raw) {
       base.content = raw.content || null;
       return base;
     }
+    // Informational system message (render-leveled: info/notice/suggestion/warning).
+    if (raw.subtype === "informational") {
+      base.yokeType = "informational";
+      base.level = raw.level || "info";
+      base.content = raw.content || "";
+      base.toolUseId = raw.tool_use_id || null;
+      base.preventContinuation = !!raw.prevent_continuation;
+      return base;
+    }
+    // A tool call was denied (by classifier, rule, mode, or async agent).
+    if (raw.subtype === "permission_denied") {
+      base.yokeType = "permission_denied";
+      base.toolName = raw.tool_name || "";
+      base.toolUseId = raw.tool_use_id || null;
+      base.agentId = raw.agent_id || null;
+      base.reasonType = raw.decision_reason_type || null;
+      base.reason = raw.decision_reason || null;
+      base.message = raw.message || "";
+      return base;
+    }
     // Catch-all system event
     base.yokeType = "system";
     base.subtype = raw.subtype;

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -209,6 +209,13 @@ function flattenEvent(raw) {
       base.content = raw.content || null;
       return base;
     }
+    // Live thinking-token estimate (ephemeral progress).
+    if (raw.subtype === "thinking_tokens") {
+      base.yokeType = "thinking_tokens";
+      base.estimatedTokens = raw.estimated_tokens || 0;
+      base.estimatedTokensDelta = raw.estimated_tokens_delta || 0;
+      return base;
+    }
     // Informational system message (render-leveled: info/notice/suggestion/warning).
     if (raw.subtype === "informational") {
       base.yokeType = "informational";
@@ -383,6 +390,20 @@ function createQueryHandle(rawQuery, messageQueue, abortController) {
         return rawQuery.stopTask(taskId);
       }
       return Promise.resolve();
+    },
+
+    reloadSkills: function() {
+      if (rawQuery && typeof rawQuery.reloadSkills === "function") {
+        return rawQuery.reloadSkills();
+      }
+      return Promise.resolve(null);
+    },
+
+    setMcpPermissionModeOverride: function(serverName, mode) {
+      if (rawQuery && typeof rawQuery.setMcpPermissionModeOverride === "function") {
+        return rawQuery.setMcpPermissionModeOverride(serverName, mode);
+      }
+      return Promise.resolve(null);
     },
 
     getContextUsage: function() {
@@ -982,6 +1003,16 @@ function createWorkerQueryHandle(worker, canUseTool, onElicitation, callMcpTool,
     stopTask: function(taskId) {
       worker.send({ type: "stop_task", taskId: taskId });
       return Promise.resolve();
+    },
+
+    reloadSkills: function() {
+      worker.send({ type: "reload_skills" });
+      return Promise.resolve(null);
+    },
+
+    setMcpPermissionModeOverride: function(serverName, mode) {
+      worker.send({ type: "set_mcp_permission_mode_override", serverName: serverName, mode: mode });
+      return Promise.resolve(null);
     },
 
     getContextUsage: function() {

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -684,7 +684,7 @@ function serializeWorkerValue(value, seen) {
 // in-process QueryHandle. This allows processQueryStream to iterate a worker
 // query identically to an in-process query.
 
-function createWorkerQueryHandle(worker, canUseTool, onElicitation, callMcpTool) {
+function createWorkerQueryHandle(worker, canUseTool, onElicitation, callMcpTool, onUserDialog) {
   // Async iterable state
   var iterQueue = [];
   var iterWaiting = null;
@@ -779,6 +779,24 @@ function createWorkerQueryHandle(worker, canUseTool, onElicitation, callMcpTool)
           }).catch(function(e) {
             console.error("[yoke/claude] elicitation_response send failed:", e.message || e);
           });
+        }
+        break;
+
+      case "user_dialog_request":
+        if (onUserDialog) {
+          onUserDialog({
+            dialogKind: msg.dialogKind,
+            payload: msg.payload || {},
+            toolUseID: msg.toolUseId || undefined,
+          }, {
+            signal: { addEventListener: function() {} },
+          }).then(function(result) {
+            worker.send({ type: "user_dialog_response", requestId: msg.requestId, result: result });
+          }).catch(function(e) {
+            console.error("[yoke/claude] user_dialog_response send failed:", e.message || e);
+          });
+        } else {
+          worker.send({ type: "user_dialog_response", requestId: msg.requestId, result: { behavior: "cancelled" } });
         }
         break;
 
@@ -1218,6 +1236,8 @@ function createClaudeAdapter(opts) {
       if (queryOpts.toolServers) sdkOptions.mcpServers = queryOpts.toolServers;
       if (queryOpts.canUseTool) sdkOptions.canUseTool = queryOpts.canUseTool;
       if (queryOpts.onElicitation) sdkOptions.onElicitation = queryOpts.onElicitation;
+      if (queryOpts.onUserDialog) sdkOptions.onUserDialog = queryOpts.onUserDialog;
+      if (queryOpts.supportedDialogKinds) sdkOptions.supportedDialogKinds = queryOpts.supportedDialogKinds;
       if (queryOpts.resumeSessionId) sdkOptions.resume = queryOpts.resumeSessionId;
 
       // Claude-specific options from adapterOptions.CLAUDE
@@ -1366,7 +1386,7 @@ function createClaudeAdapter(opts) {
     }
 
     // Create the worker query handle (sets up message handler on worker)
-    var handle = createWorkerQueryHandle(worker, queryOpts.canUseTool, queryOpts.onElicitation, queryOpts.callMcpTool);
+    var handle = createWorkerQueryHandle(worker, queryOpts.canUseTool, queryOpts.onElicitation, queryOpts.callMcpTool, queryOpts.onUserDialog);
 
     // Wait for worker to be ready before sending query_start
     if (!reusingWorker) {
@@ -1393,6 +1413,7 @@ function createClaudeAdapter(opts) {
     if (claudeOpts.settings) queryOptions.settings = claudeOpts.settings;
 
     if (queryOpts.toolServerDescriptors) queryOptions.mcpServerDescriptors = queryOpts.toolServerDescriptors;
+    if (queryOpts.supportedDialogKinds) queryOptions.supportedDialogKinds = queryOpts.supportedDialogKinds;
     if (queryOpts.model) queryOptions.model = queryOpts.model;
     if (queryOpts.effort) queryOptions.effort = queryOpts.effort;
     if (queryOpts.resumeSessionId) queryOptions.resume = queryOpts.resumeSessionId;

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -209,6 +209,20 @@ function flattenEvent(raw) {
       base.content = raw.content || null;
       return base;
     }
+    // Slash-command list changed mid-session (e.g. skills discovered dynamically).
+    if (raw.subtype === "commands_changed") {
+      base.yokeType = "commands_changed";
+      base.commandNames = Array.isArray(raw.commands)
+        ? raw.commands.map(function(c) { return (c && typeof c === "object") ? c.name : c; }).filter(Boolean)
+        : [];
+      return base;
+    }
+    // The session worker is shutting down (reason is a host-set snake_case code).
+    if (raw.subtype === "worker_shutting_down") {
+      base.yokeType = "worker_shutting_down";
+      base.reason = raw.reason || "";
+      return base;
+    }
     // Live thinking-token estimate (ephemeral progress).
     if (raw.subtype === "thinking_tokens") {
       base.yokeType = "thinking_tokens";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "clay-server",
-  "version": "2.36.2-beta.9",
+  "version": "2.44.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clay-server",
-      "version": "2.36.2-beta.9",
+      "version": "2.44.1-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.132",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.196",
         "@lydell/node-pty": "^1.2.0-beta.3",
         "@openai/codex": "^0.124.0",
         "imapflow": "^1.3.1",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.0.tgz",
-      "integrity": "sha512-zYt6cz+ivnTmiT/ksRVriMBOiuoUpDCJJlZ5KPl2/FRdvwU3f7MPh9qftvbkXJThragzUZieit2nyHUyw53Seg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -83,35 +83,33 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.132.tgz",
-      "integrity": "sha512-3hCkfbHi6d73QcNqgrjU9zXGdNs3BrwWnxV90p+DDFARtnwbszkkEm4nz9c80af3nzGBRVvKNZPVCqVaBrkO0g==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.196.tgz",
+      "integrity": "sha512-yqsp1/04T2/tJ54jz+7YLsTZOPeQ/myUCrv17/IVZ9dbl+izIMP9ULuLpPCH5pj5msXxR80es+hpVgHoFuNm0A==",
       "license": "SEE LICENSE IN README.md",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.81.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.132"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.196",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.196",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.196",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.196",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.196",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.196",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.196",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.196"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.132.tgz",
-      "integrity": "sha512-wrGxeqsnhw3JSU25v78FSw85guN0FGqLA7LuAzLe+KVZqJElJvhtae1ceCvgF8e8Bc/RUrniNxRrTur+8vIZYQ==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.196.tgz",
+      "integrity": "sha512-k1MKRDhSiNKpkTwhtU8QKGzfuRfr3YXS6oqsTuldMROX56L5iMXjzC7AYU1/KmPTeMl3SCQBQeDu0i8ciA0hQA==",
       "cpu": [
         "arm64"
       ],
@@ -122,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.132.tgz",
-      "integrity": "sha512-qiutRtM+cz6FPA2AX2fKaINkLpMO9W48d3s4CTcWPT014uJTRxZZRb5TBxnjdxRLIt6njsqvvvh0XzQLGpblBA==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.196.tgz",
+      "integrity": "sha512-bBwx/7yKZMQ9NSUt4bg8P+zp6pgd/O/DTkzdqsRIivBvARmwo1QY/2qGrLO8RH0T8CG2lTjFNfDfOlJWbAkvAg==",
       "cpu": [
         "x64"
       ],
@@ -135,9 +133,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.132.tgz",
-      "integrity": "sha512-fWyjKRg+qfThhY9iI5GJRNtBW7qBoV20yn8kJ9RoKG4c6yn3Q+QJX+ybkfgXM45RyrO4SPmdhDeTCTG9LJSN3w==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.196.tgz",
+      "integrity": "sha512-fR5fy+pSQSpKZK0zTtAl3LZEGQTuwVK7svutH1bZUS5RGT2HdUWc71oltSZgW4upGaslj+gyusHGJHA5eAc+dw==",
       "cpu": [
         "arm64"
       ],
@@ -148,9 +146,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.132.tgz",
-      "integrity": "sha512-Gu4JCAkXA/XChcrTixtnurSn445O/1EHt2TAlX/rq2gP/wCijKU3eQyZ+YWx2UMud0f9e+E4W/CHhwtCVzgqgw==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.196.tgz",
+      "integrity": "sha512-BhLxfx4j6mC3Uzmve1IbhFS1uvNlwATeo6uWyYDOMW4n3XKjiSgjD8bTfkamijrxCMvJo5swLju2y14ayDsokA==",
       "cpu": [
         "arm64"
       ],
@@ -161,9 +159,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.132.tgz",
-      "integrity": "sha512-AAThetjWjCRWQ7IcDTjXLltUB9DJS4S4HpPmTpCOM8muOFWOwpgTmOHe1DJc9uVXbAgFO/WEASDbD4qrsdn0rw==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.196.tgz",
+      "integrity": "sha512-9spZON7/tn0q9J+jICrdfHi7o7Fmjs9pIohCCxL+Yv7HbBXWVtEYJbYipBGLTl8ICG3mgPeEVMNsvOuh/jDTuA==",
       "cpu": [
         "x64"
       ],
@@ -174,9 +172,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.132.tgz",
-      "integrity": "sha512-Ri7RQkbjOVox0TXTN4g04oiO5bU8WLCH9SdChxaZtS/K76Yu1vV6fYyB/wRoYWuvRLHjOANWUFIGs6O/wK5s0w==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.196.tgz",
+      "integrity": "sha512-EOiNbxCXQLYzV7SQhMWkUC1ScWyTw/Qp+JyV2sEmIbzl/e7KMOxNE9J20k+lpPs6CXdxVzuMwH7yAGuDu5y+IQ==",
       "cpu": [
         "x64"
       ],
@@ -187,9 +185,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.132.tgz",
-      "integrity": "sha512-8m5L6MlMqIzvx2V/J1gJwhXt9iMfXFvLOmtm1nhzyslc7czJWZQtHUQ8Tr/1rW32t2oEpXqrDhbjrlHgGp9xBQ==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.196.tgz",
+      "integrity": "sha512-0xXkAWlDof/qFi3k5KJZ5WYbgp1X8hZHjyasOWTZWAmldoYaENI0vkL+PVMarvoAFYRRqcWoS81FSgm0QgH2sA==",
       "cpu": [
         "arm64"
       ],
@@ -200,9 +198,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.132.tgz",
-      "integrity": "sha512-NNbAHtl/Bew6HUvOW8R27r/pwwctZbScGAKAxt/p4GiYa0oLKvxq/CGLv+wscRVlebeI0hA6DwC0DtnB0KnA1Q==",
+      "version": "0.3.196",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.196.tgz",
+      "integrity": "sha512-FxWLA3aOYgDf2J0o6Ov1/wgg9X6RkrgnX4ifUWO1i3+6mbc4efNLHkDZLxCHEnQgW8yBidX+iro19f9k64vV8A==",
       "cpu": [
         "x64"
       ],
@@ -213,12 +211,14 @@
       ]
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
-      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.107.0.tgz",
+      "integrity": "sha512-RWDWyvIeZnatUTzyX8+ayFzAqqLyoDHKnDEODFyW8H89zH+qEsh5h6XAmnbHY5DCoa58o3rjuNe3F3Hg851ayA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -233,13 +233,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -258,10 +258,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -278,10 +279,11 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.14.1"
       },
@@ -290,23 +292,23 @@
       }
     },
     "node_modules/@lydell/node-pty": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.3.tgz",
-      "integrity": "sha512-ngGAItlRhmJXrhspxt8kX13n1dVFqzETOq0m/+gqSkO8NJBvNMwP7FZckMwps2UFySdr4yxCXNGu/bumg5at6A==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==",
       "license": "MIT",
       "optionalDependencies": {
-        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.3",
-        "@lydell/node-pty-darwin-x64": "1.2.0-beta.3",
-        "@lydell/node-pty-linux-arm64": "1.2.0-beta.3",
-        "@lydell/node-pty-linux-x64": "1.2.0-beta.3",
-        "@lydell/node-pty-win32-arm64": "1.2.0-beta.3",
-        "@lydell/node-pty-win32-x64": "1.2.0-beta.3"
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.12"
       }
     },
     "node_modules/@lydell/node-pty-darwin-arm64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-owcv+e1/OSu3bf9ZBdUQqJsQF888KyuSIiPYFNn0fLhgkhm9F3Pvha76Kj5mCPnodf7hh3suDe7upw7GPRXftQ==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==",
       "cpu": [
         "arm64"
       ],
@@ -317,9 +319,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-darwin-x64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-k38O+UviWrWdxtqZBBc/D8NJU11Rey8Y2YMwSWNxLv3eXZZdF5IVpbBkI/2RmLsV5nCcciqLPbukxeZnEfPlwA==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q==",
       "cpu": [
         "x64"
       ],
@@ -330,9 +332,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-linux-arm64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-HUwRpGu3O+4sv9DAQFKnyW5LYhyYu2SDUa/bdFO/t4dIFCM4uDJEq47wfRM7+aYtJTi1b3lakN8SlWeuFQqJQQ==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw==",
       "cpu": [
         "arm64"
       ],
@@ -343,9 +345,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-linux-x64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-+RRY0PoCUeQaCvPR7/UnkGbxulwbFtoTWJfe+o4T1RcNtngrgaI55I9nl8CD8uqhGrB3smKuyvPM5UtwGhASUw==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ==",
       "cpu": [
         "x64"
       ],
@@ -356,9 +358,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-win32-arm64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-UEDd9ASp2M3iIYpIzfmfBlpyn4+K1G4CAjYcHWStptCkefoSVXWTiUBIa1KjBjZi3/xmsHIDpBEYTkGWuvLt2Q==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g==",
       "cpu": [
         "arm64"
       ],
@@ -369,9 +371,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-win32-x64": {
-      "version": "1.2.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.3.tgz",
-      "integrity": "sha512-TpdqSFYx7/Rj+68tuP6F/lkRYrHCYAIJgaS1bx3SctTkb5QAQCFwOKHd4xlsivmEOMT2LdhkJggPxwX9PAO5pQ==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw==",
       "cpu": [
         "x64"
       ],
@@ -386,6 +388,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -538,16 +541,16 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
-      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^11.0.3",
         "@octokit/request-error": "^7.0.2",
         "@octokit/types": "^16.0.0",
-        "fast-content-type-parse": "^3.0.0",
+        "content-type": "^2.0.0",
         "json-with-bigint": "^3.5.3",
         "universal-user-agent": "^7.0.2"
       },
@@ -566,6 +569,20 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@octokit/types": {
@@ -737,9 +754,9 @@
       "license": "ISC"
     },
     "node_modules/@pnpm/npm-conf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
-      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.3.tgz",
+      "integrity": "sha512-//0sR/cow/s4ICQaYoAobOl4aU8cjU6x/V24V7XkKotb9+O+3zySIYp146vpaobYHnxa4pZX8NkV54Z5AwbDKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -955,9 +972,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "12.0.6",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.6.tgz",
-      "integrity": "sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA==",
+      "version": "12.0.8",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.8.tgz",
+      "integrity": "sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -969,8 +986,8 @@
         "aggregate-error": "^5.0.0",
         "debug": "^4.3.4",
         "dir-glob": "^3.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
+        "http-proxy-agent": "^9.0.0",
+        "https-proxy-agent": "^9.0.0",
         "issue-parser": "^7.0.0",
         "lodash-es": "^4.17.21",
         "mime": "^4.0.0",
@@ -1129,9 +1146,9 @@
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.0.tgz",
-      "integrity": "sha512-CcyDRk7xq+ON/20YNR+1I/jP7BYKICr1uKd1HHpROSnnTdGqOTburi4jcRiTYz0cpfhxSloQO3cGhnoot7IEkA==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-14.1.1.tgz",
+      "integrity": "sha512-Pbd2e2XRMUD0OxehHpgd5/YghsE76cddkRHSoDvKLK+OCy4Ewxn49rWR631MEUU01lgwF/uyVXvbnVuu6+Z6VA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1140,9 +1157,7 @@
         "conventional-commits-filter": "^5.0.0",
         "conventional-commits-parser": "^6.0.0",
         "debug": "^4.0.0",
-        "get-stream": "^7.0.0",
         "import-from-esm": "^2.0.0",
-        "into-stream": "^7.0.0",
         "lodash-es": "^4.17.21",
         "read-package-up": "^11.0.0"
       },
@@ -1151,19 +1166,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
-      "integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/hosted-git-info": {
@@ -1291,6 +1293,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
@@ -1299,37 +1308,13 @@
       "license": "MIT"
     },
     "node_modules/@zone-eu/mailsplit": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
-      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
+      "version": "5.4.13",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.13.tgz",
+      "integrity": "sha512-j40NeNlSAivqnKEjzZYsGP/bKWr2zwuyb8XOYsC3i0ZlfM5UnTYTa7aCRkE8rYQvVzE1dRjVYdvZ1Epi6x+h6w==",
       "license": "(MIT OR EUPL-1.1+)",
       "dependencies": {
         "libbase64": "1.3.0",
-        "libmime": "5.3.7",
-        "libqp": "2.1.1"
-      }
-    },
-    "node_modules/@zone-eu/mailsplit/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@zone-eu/mailsplit/node_modules/libmime": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
-      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
-      "license": "MIT",
-      "dependencies": {
-        "encoding-japanese": "2.2.0",
-        "iconv-lite": "0.6.3",
-        "libbase64": "1.3.0",
+        "libmime": "5.4.0",
         "libqp": "2.1.1"
       }
     },
@@ -1338,6 +1323,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -1347,12 +1333,13 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
     "node_modules/aggregate-error": {
@@ -1370,10 +1357,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1390,6 +1378,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -1501,27 +1490,42 @@
       "license": "Apache-2.0"
     },
     "node_modules/bn.js": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-      "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
+      "version": "4.12.4",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
+      "integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1561,6 +1565,7 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1570,6 +1575,7 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1583,6 +1589,7 @@
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1723,9 +1730,9 @@
       }
     },
     "node_modules/cli-highlight/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1866,10 +1873,11 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1883,14 +1891,15 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
-      "integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1931,9 +1940,9 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1965,6 +1974,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1974,6 +1984,7 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1990,6 +2001,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
       "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -2003,9 +2015,9 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
-      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2123,6 +2135,7 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2158,6 +2171,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -2190,7 +2204,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2211,6 +2226,7 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2407,6 +2423,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -2416,15 +2433,17 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -2446,7 +2465,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
@@ -2466,6 +2486,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2475,6 +2496,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
       "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
@@ -2483,10 +2505,11 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2523,6 +2546,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2562,12 +2586,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2579,33 +2604,24 @@
         "express": ">= 4.11"
       }
     },
-    "node_modules/fast-content-type-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",
@@ -2616,7 +2632,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -2652,6 +2669,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -2716,6 +2734,7 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -2725,25 +2744,15 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
     "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2760,6 +2769,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2788,9 +2798,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2805,6 +2815,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2829,6 +2840,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2869,11 +2881,22 @@
         "traverse": "0.6.8"
       }
     },
+    "node_modules/git-log-parser/node_modules/split2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+      "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "through2": "~2.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2889,9 +2912,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2925,6 +2948,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2933,10 +2957,11 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2955,10 +2980,11 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2977,9 +3003,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3003,6 +3029,7 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
         "inherits": "~2.0.4",
@@ -3019,30 +3046,33 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 20"
       }
     },
     "node_modules/human-signals": {
@@ -3072,26 +3102,26 @@
       }
     },
     "node_modules/imapflow": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.1.tgz",
-      "integrity": "sha512-DKwpMDR1EWXpV5T7adqQAccN7n684AX3poEZ5F3YoPlm2MyGeKavpRgNr3qptdEQaK+x5SlZ9jigT+cMs4geBA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.4.3.tgz",
+      "integrity": "sha512-UNimp06TINpFLx7g5nXh/8+oykfaHy6zgvLuQseLifGrQUSqDexuSKrksM+uA9mQw1cYJTOVrFPRTHkK+W/tpw==",
       "license": "MIT",
       "dependencies": {
-        "@zone-eu/mailsplit": "5.4.8",
+        "@zone-eu/mailsplit": "5.4.13",
         "encoding-japanese": "2.2.0",
         "iconv-lite": "0.7.2",
         "libbase64": "1.3.0",
-        "libmime": "5.3.8",
+        "libmime": "5.4.0",
         "libqp": "2.1.1",
-        "nodemailer": "8.0.5",
+        "nodemailer": "9.0.1",
         "pino": "10.3.1",
-        "socks": "2.8.7"
+        "socks": "2.8.9"
       }
     },
     "node_modules/imapflow/node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -3185,27 +3215,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/into-stream": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
-      "integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "from2": "^2.3.0",
-        "p-is-promise": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3216,6 +3229,7 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -3274,7 +3288,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
@@ -3316,9 +3331,9 @@
       "license": "ISC"
     },
     "node_modules/issue-parser": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
-      "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+      "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3343,10 +3358,11 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3359,10 +3375,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3390,6 +3416,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "ts-algebra": "^2.0.0"
@@ -3402,13 +3429,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/json-with-bigint": {
       "version": "3.5.8",
@@ -3418,9 +3447,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3458,9 +3487,9 @@
       "license": "MIT"
     },
     "node_modules/libmime": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
-      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.4.0.tgz",
+      "integrity": "sha512-MAWyU2qYtCsrZ6GClgukz2jx73NQrzA6ASo9qzThuTG+A7+H3lWQuBsjoy9lls+v6q/epAeBdEMJ3T0f4b+uRw==",
       "license": "MIT",
       "dependencies": {
         "encoding-japanese": "2.2.0",
@@ -3527,16 +3556,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3576,9 +3605,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -3643,6 +3672,7 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3652,6 +3682,7 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -3674,6 +3705,7 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3723,6 +3755,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3732,6 +3765,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
       "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -3791,6 +3825,7 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3850,9 +3885,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.0.tgz",
-      "integrity": "sha512-z9nC87iaZXXySbWWtTHfCFJyFvKaUAW6lODhikG7ILSbVgmwuFjUqkgnheHvAUcGedO29e2QGBRXMUD64aurqQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-9.0.1.tgz",
+      "integrity": "sha512-ARftfC5HdUNu9jJeL8pHj8debUIHA2b91FizCoMzY4lG6dDX13jdvTK0TBe24IBDRf2HvJSzzwEPvmbkQWHRSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3863,9 +3898,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.0.tgz",
-      "integrity": "sha512-xPhOap4ZbJWyd7DAOukP564WFwNSGu/2FeTRFHhiiKthcauxhH/NpkJAQm24xD+cAn8av5tQ00phi98DqtfLsg==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -3944,8 +3979,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.2",
-        "@npmcli/config": "^10.8.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -3963,46 +3998,46 @@
         "fs-minipass": "^3.0.3",
         "glob": "^13.0.6",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^9.0.2",
+        "hosted-git-info": "^9.0.3",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.5",
-        "libnpmexec": "^10.2.5",
-        "libnpmfund": "^7.0.19",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.5",
-        "libnpmpublish": "^11.1.3",
+        "libnpmpack": "^9.1.11",
+        "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
-        "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.4",
+        "libnpmversion": "^8.0.4",
+        "make-fetch-happen": "^15.0.6",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.4.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.5.0",
+        "pacote": "^21.5.1",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -4075,7 +4110,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "4.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4091,7 +4126,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.2",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4139,7 +4174,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.8.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4333,7 +4368,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.2.0",
+      "version": "3.2.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -4342,7 +4377,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -4381,13 +4416,13 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0"
       },
       "engines": {
@@ -4456,7 +4491,7 @@
       }
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "6.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4484,7 +4519,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4553,7 +4588,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -4609,7 +4644,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -4677,7 +4712,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4776,7 +4811,7 @@
       }
     },
     "node_modules/npm/node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4785,12 +4820,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -4858,12 +4893,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.5",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -4877,13 +4912,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.5",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -4900,12 +4935,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.19",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4925,12 +4960,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.5",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -4940,7 +4975,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "11.1.3",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4984,7 +5019,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5000,7 +5035,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.5.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -5009,7 +5044,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.5",
+      "version": "15.0.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5032,12 +5067,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5085,34 +5120,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -5193,7 +5210,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5201,12 +5218,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -5317,13 +5334,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -5370,7 +5387,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5431,7 +5448,7 @@
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
+      "version": "7.1.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5528,7 +5545,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5552,17 +5569,17 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.1",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "@sigstore/sign": "^4.1.0",
-        "@sigstore/tuf": "^4.0.1",
-        "@sigstore/verify": "^3.1.0"
+        "@sigstore/sign": "^4.1.1",
+        "@sigstore/tuf": "^4.0.2",
+        "@sigstore/verify": "^3.1.1"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -5579,12 +5596,12 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.8.7",
+      "version": "2.8.9",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -5653,7 +5670,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -5681,13 +5698,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.17",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5714,7 +5731,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5746,6 +5763,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.27.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -5822,6 +5848,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5843,6 +5870,7 @@
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -5855,6 +5883,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5920,16 +5949,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-is-promise": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -5957,9 +5976,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6075,6 +6094,7 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6103,6 +6123,7 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
       "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -6126,9 +6147,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6179,15 +6200,6 @@
         "split2": "^4.0.0"
       }
     },
-    "node_modules/pino-abstract-transport/node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
@@ -6199,6 +6211,7 @@
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -6268,12 +6281,31 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
       }
     },
     "node_modules/qrcode-terminal": {
@@ -6285,12 +6317,14 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -6306,12 +6340,17 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -6319,6 +6358,7 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
       "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
@@ -6364,9 +6404,9 @@
       }
     },
     "node_modules/read-package-up/node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -6400,9 +6440,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
-      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
+      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -6444,13 +6484,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -6488,6 +6521,7 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6507,6 +6541,7 @@
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -6519,23 +6554,9 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
@@ -6554,9 +6575,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
-      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
+      "version": "25.0.5",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.5.tgz",
+      "integrity": "sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6679,9 +6700,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6709,6 +6730,7 @@
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
@@ -6735,6 +6757,7 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
       "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -6753,7 +6776,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6777,14 +6801,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -6796,13 +6821,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6816,6 +6842,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6834,6 +6861,7 @@
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -6991,12 +7019,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -7067,13 +7095,23 @@
       "license": "CC0-1.0"
     },
     "node_modules/split2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
-      "integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
-      "dev": true,
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "through2": "~2.0.0"
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {
@@ -7081,6 +7119,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7105,13 +7144,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -7324,16 +7356,22 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
-      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
       "license": "MIT",
       "dependencies": {
-        "real-require": "^0.2.0"
+        "real-require": "^1.0.0"
       },
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
     },
     "node_modules/through2": {
       "version": "2.0.5",
@@ -7363,14 +7401,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7398,9 +7436,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7428,6 +7466,7 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -7449,7 +7488,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -7475,17 +7515,36 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/uglify-js": {
@@ -7503,9 +7562,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7573,6 +7632,7 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7610,6 +7670,7 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -7631,6 +7692,28 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/web-worker": {
@@ -7725,12 +7808,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -7851,10 +7935,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -7864,6 +7949,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/chadbyte/clay#readme",
   "author": "Chad",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.132",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.196",
     "@lydell/node-pty": "^1.2.0-beta.3",
     "@openai/codex": "^0.124.0",
     "imapflow": "^1.3.1",


### PR DESCRIPTION
## Summary

Bumps `@anthropic-ai/claude-agent-sdk` from `^0.2.132` to `^0.3.196` and adopts the actionable parts of the 0.2.133 → 0.3.196 delta. All SDK-specific knowledge stays in the yoke adapter; the relay only handles vendor-neutral yokeTypes and yoke handle methods.

## SDK upgrade
- `chore(deps)`: bump to `0.3.196` (clean lockfile reinstall; peers resolve to `@anthropic-ai/sdk@0.107.0`, `@modelcontextprotocol/sdk@1.29.0`, `zod@4.4.3`). No removed `Options` keys and no references to any removed SDK symbol, so existing call sites are unaffected.
- Tracker `docs/ongoing/SDK-UPGRADE.md` extended with the 0.2.133 → 0.3.196 delta (items #68–90), a top "Current Focus" section, and completed history moved to an Archive.

## New SDK surface (all routed through yoke)
- **#72** Host user dialogs via `onUserDialog` + `supportedDialogKinds` (in-process + worker + client). Generic, defensive renderer; unknown kinds answer `{behavior:"cancelled"}`. (Covers tool-driven dialogs like the refusal-fallback prompt — not the login OAuth flow, which uses separate dedicated control requests.)
- **#73–74** Model-refusal messages (fallback / no-fallback) → neutral `model_refusal` yokeType, rendered client-side.
- **#75** `permission_denied` — surface why a tool call was blocked.
- **#79** `informational` — leveled system messages (info/notice/suggestion/warning).
- **#76** `reloadSkills()` — hot-reload skills without a session restart; wired to skill install/uninstall in the UI.
- **#77** `setMcpPermissionModeOverride()` — per-server MCP permission mode; "Ask / Auto-approve" selector in the MCP server rows (session-scoped).
- **#78** Live thinking-token estimate annotated on the active thinking block.
- **#82** `commands_changed` — refresh the slash-command palette mid-session.
- **#83** `worker_shutting_down` — surface non-routine teardown reasons.
- Deferred: #80 toolAliases, #81 backgroundTasks (no driver in Clay), #85 (experimental usage API). #84 verified — unknown built-in tool names render via existing generic fallbacks.

## Bug fixes
- `fix(ask-user)`: native AskUserQuestion answers were dropped in 0.3.x (the built-in no longer reads `updatedInput.answers`, so the model saw "no answer"). Now resolved by denying with the formatted answer as the tool result so the choice reaches the model in the same turn.
- `fix(tui)`: a TUI session being actively viewed no longer banners itself on every reply. The "Claude responded" notification is now gated at the source (skip when any connected client has the session active), instead of relying on unreliable client-side `activeSessionId` suppression.

## Notes
- Includes one pre-existing commit `fix(os-users): inherit supplementary groups in spawned sessions` (828a7d8) that this branch was based on and which isn't on `main` yet.
- Validation so far is static (client-import + `node --check` + module require smoke) and architecture-purity checks. **Runtime verification of the new message handlers, the AskUserQuestion fix, and the TUI banner gating is still pending.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)