### PR TITLE
Default Mates off (opt-in)

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -703,7 +703,7 @@ var relay = createServer({
       osUsers: !!config.osUsers,
       inheritGroups: config.inheritGroups !== false,
       chatLayout: config.chatLayout || "channel",
-      matesEnabled: config.matesEnabled !== false,
+      matesEnabled: config.matesEnabled === true,
       pinEnabled: !!config.pinHash,
       platform: process.platform,
       hostname: os2.hostname(),

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -287,7 +287,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     cachedMatesList: [],
     cachedDmFavorites: [],
     cachedAvailableBuiltins: [],
-    matesEnabled: true,
+    matesEnabled: false,
     returningFromMateDm: false,
     pendingMateInterview: null,
     pendingTermCommand: null,

--- a/lib/public/modules/profile.js
+++ b/lib/public/modules/profile.js
@@ -590,8 +590,8 @@ export function initProfile(_ctx) {
 
     // Apply Mates UI gate at boot so the sidebar avatars / DM picker
     // entry / home-hub strip are hidden before the user opens settings.
-    // Default true: only flip the body class off when explicitly false.
-    var matesOn = data.matesEnabled !== false;
+    // Default OFF: Mates is opt-in, so only enable when explicitly true.
+    var matesOn = data.matesEnabled === true;
     store.set({ matesEnabled: matesOn });
     if (document.body) document.body.classList.toggle('mates-disabled', !matesOn);
   }).catch(function(err) {

--- a/lib/public/modules/user-settings.js
+++ b/lib/public/modules/user-settings.js
@@ -468,8 +468,8 @@ function populateAccount() {
     if (data.mateOnboardingShown) {
       try { localStorage.setItem("clay-mate-onboarding-shown", "1"); } catch (e) {}
     }
-    // Mates UI toggle: default true; treat any missing/non-false value as on
-    var matesOn = data.matesEnabled !== false;
+    // Mates UI toggle: default OFF (opt-in); enable only when explicitly true
+    var matesOn = data.matesEnabled === true;
     var matesToggle = document.getElementById('us-mates-enabled');
     if (matesToggle) matesToggle.checked = matesOn;
     store.set({ matesEnabled: matesOn });

--- a/lib/server-settings.js
+++ b/lib/server-settings.js
@@ -29,7 +29,7 @@ function attachSettings(ctx) {
         profile.autoContinueOnRateLimit = !!mu.autoContinueOnRateLimit;
         profile.chatLayout = mu.chatLayout || "channel";
         profile.mateOnboardingShown = !!mu.mateOnboardingShown;
-        profile.matesEnabled = mu.matesEnabled !== false;
+        profile.matesEnabled = mu.matesEnabled === true;
         try { profile.terminalFont = users.getTerminalFont(mu.id); } catch (e) {}
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(JSON.stringify(profile));
@@ -52,7 +52,7 @@ function attachSettings(ctx) {
         profile.autoContinueOnRateLimit = !!dc.autoContinueOnRateLimit;
         profile.chatLayout = dc.chatLayout || "channel";
         profile.mateOnboardingShown = !!dc.mateOnboardingShown;
-        profile.matesEnabled = dc.matesEnabled !== false;
+        profile.matesEnabled = dc.matesEnabled === true;
         if (dc.terminalFont && typeof dc.terminalFont === "object") {
           profile.terminalFont = {
             family: dc.terminalFont.family || "'SF Mono', Menlo, Monaco, 'Courier New', monospace",

--- a/lib/users-preferences.js
+++ b/lib/users-preferences.js
@@ -334,20 +334,21 @@ function attachPreferences(deps) {
 
   // --- Per-user Mates UI toggle ---
   //
-  // When false, the entire Mates surface (sidebar avatars, DM "Create a
-  // Mate" entry, home-hub mates strip) is hidden for this user. Default
-  // is ON: Mates is opt-out, not opt-in. Stored as `matesEnabled`; we
-  // treat any value other than the literal `false` as enabled so brand-
-  // new users (no field set) get the default-on experience.
+  // When disabled, the entire Mates surface (sidebar avatars, DM "Create a
+  // Mate" entry, home-hub mates strip) is hidden for this user; multi-user
+  // and the rest of the sidebar are unaffected. Default is OFF: Mates is
+  // opt-in, not opt-out. Stored as `matesEnabled`; only the literal `true`
+  // enables it, so brand-new users (no field set) get the default-off
+  // experience and must turn Mates on explicitly in settings.
 
   function getMatesEnabled(userId) {
     var data = loadUsers();
     for (var i = 0; i < data.users.length; i++) {
       if (data.users[i].id === userId) {
-        return data.users[i].matesEnabled !== false;
+        return data.users[i].matesEnabled === true;
       }
     }
-    return true;
+    return false;
   }
 
   function setMatesEnabled(userId, enabled) {


### PR DESCRIPTION
## Summary

Flips Mates from opt-out to **opt-in**: a fresh/unset `matesEnabled` now resolves to **off**, and Mates only shows when a user explicitly turns it on in settings. This softens the planned Mates sunset to a quiet default-off now that the user-economy concern was reversed.

## What changed
Default resolution flipped from `matesEnabled !== false` (default on) to `matesEnabled === true` (default off) at every layer:
- `lib/users-preferences.js` — per-user `getMatesEnabled` (multi-user); unset → off.
- `lib/daemon.js` — single-user/daemon config status.
- `lib/server-settings.js` — multi-user and single-user profile payloads.
- `lib/public/app.js` — client store initial default (`matesEnabled: false`) to avoid a pre-fetch flash.
- `lib/public/modules/profile.js`, `lib/public/modules/user-settings.js` — boot/settings reads enable only on explicit `true`.

## Multi-user is preserved
`matesEnabled` only gates the **Mates surface** (sidebar avatars, DM "Create a Mate" entry, home-hub strip). When off, the existing `renderMatesDisabledLayout()` path still renders the user list and the rest of the sidebar — multi-user is untouched. Users who want Mates re-enable it via the existing settings toggle.

## Validation
Static only so far: `node --check` on all touched server/client files, client-import resolution check, and a grep confirming no `matesEnabled !== false` default-on reads remain. Runtime check (fresh user sees no Mates UI, multi-user sidebar intact, toggle re-enables) still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)