### PR TITLE
Show model picker for Claude GUI sessions

### DIFF
--- a/lib/public/modules/app-panels.js
+++ b/lib/public/modules/app-panels.js
@@ -178,25 +178,21 @@ function hasBeta(name) {
 function rebuildModelList() {
   if (!configModelList) return;
   // Picker visibility by vendor+mode:
-  //   Claude TUI -> shown (Claude TUI accepts mid-thread model swaps).
-  //   Claude GUI -> hidden (Agent SDK binds model at session creation;
-  //                 changing mid-thread breaks tool schemas and cache reuse).
-  //   Codex GUI  -> shown but locked after the first message (Codex protocol
-  //                 binds model at thread creation; sdk-bridge setModel
-  //                 already stores into sm.currentModel when there's no
-  //                 active queryInstance, so picks made before the first
-  //                 message do take effect on thread start).
+  //   Claude TUI -> shown, free (Claude TUI accepts mid-thread model swaps).
+  //   GUI (Claude SDK + Codex) -> shown, but locked once the session has
+  //                 history. Both bind the model at session creation and
+  //                 changing mid-thread breaks tool schemas / cache reuse,
+  //                 so we allow the pick only before the first message.
+  //                 sdk-bridge setModel stores into sm.currentModel when
+  //                 there's no active queryInstance, so a pick made before
+  //                 the first message takes effect on session start.
   var modelSection = configModelList.parentElement;
   var s = store.snap();
   var vendor = s.currentVendor || "claude";
-  var hideModelPicker = s.activeSessionMode === "gui" && vendor === "claude";
-  if (modelSection) modelSection.style.display = hideModelPicker ? "none" : "";
+  if (modelSection) modelSection.style.display = "";
   configModelList.innerHTML = "";
-  if (hideModelPicker) return;
 
-  var lockedForCodex = vendor === "codex"
-    && s.activeSessionMode === "gui"
-    && !!s.sessionHasHistory;
+  var lockedForGui = s.activeSessionMode === "gui" && !!s.sessionHasHistory;
 
   var list = s.currentModels.length > 0 ? s.currentModels : (s.currentModel ? [{ value: s.currentModel, displayName: s.currentModel }] : []);
   for (var i = 0; i < list.length; i++) {
@@ -207,12 +203,12 @@ function rebuildModelList() {
     var btn = document.createElement("button");
     btn.className = "config-radio-item";
     if (value === s.currentModel) btn.classList.add("active");
-    if (lockedForCodex) btn.classList.add("locked");
+    if (lockedForGui) btn.classList.add("locked");
     btn.dataset.model = value;
     btn.textContent = label;
-    if (lockedForCodex) {
+    if (lockedForGui) {
       btn.disabled = true;
-      btn.title = "Model is locked after the first message in a Codex session. Start a new session to change it.";
+      btn.title = "Model is locked after the first message in a GUI session. Start a new session to change it.";
     } else {
       btn.addEventListener("click", function () {
         var model = this.dataset.model;
@@ -227,7 +223,7 @@ function rebuildModelList() {
     configModelList.appendChild(btn);
   }
 
-  if (lockedForCodex) {
+  if (lockedForGui) {
     var hint = document.createElement("div");
     hint.className = "config-model-hint";
     hint.textContent = "Locked after first message — start a new session to change.";


### PR DESCRIPTION
## Problem

In Claude **GUI (SDK) sessions the model picker was hidden entirely** (`hideModelPicker = activeSessionMode === "gui" && vendor === "claude"`), so the model couldn't be selected at all — only the locked dropdown label showed.

## Fix

Unify with the existing Codex GUI behavior: **show the picker, lock it only once the session has history.**

- GUI sessions (Claude SDK + Codex): picker is visible; selectable before the first message, locked after (both bind the model at session creation; mid-thread swaps break tool schemas / cache reuse).
- A pick made **before the first message still takes effect** at session start — `sdk-bridge.setModel` stores into `sm.currentModel` when there's no active query, and `startQuery` reads `sm.currentModel`.
- Claude **TUI** is unchanged (free mid-thread swaps).

Replaced the Claude-GUI hide + Codex-only lock with a single `lockedForGui = activeSessionMode === "gui" && sessionHasHistory`, and made the lock copy vendor-neutral.

## Validation

Static: `node --check` on `app-panels.js`, client-import resolution check, and grep confirming no `hideModelPicker`/`lockedForCodex` refs remain. Runtime check (new Claude GUI session lets you pick a model, it applies on first message, then locks) still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)