### PR TITLE
Auto-open a modal login terminal when not logged in

### DIFF
--- a/lib/project-user-message.js
+++ b/lib/project-user-message.js
@@ -145,7 +145,8 @@ function attachUserMessage(ctx) {
           return true;
         }
       }
-      var t = tm.create(msg.cols || 80, msg.rows || 24, getOsUserInfoForWs(ws), ws);
+      var t = tm.create(msg.cols || 80, msg.rows || 24, getOsUserInfoForWs(ws), ws,
+        msg.initialCommand ? { initialInput: String(msg.initialCommand) } : undefined);
       if (!t) {
         sendTo(ws, { type: "term_error", error: "Cannot create terminal (node-pty not available or limit reached)" });
         return true;

--- a/lib/public/css/tui-attention.css
+++ b/lib/public/css/tui-attention.css
@@ -349,6 +349,12 @@ body.tui-suspended #tui-resume-bar {
   border: 1px solid var(--border);
   box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
 }
+/* Compact variant for short content (e.g. login wizard): smaller box so the
+   terminal hugs the content instead of leaving a tall empty area below. */
+.tui-modal.tui-modal-compact {
+  width: min(720px, 96%);
+  height: min(480px, 90%);
+}
 .tui-modal-header {
   display: flex;
   align-items: center;

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -29,7 +29,7 @@ import { updateSettingsModels, updateSettingsStats, updateDaemonConfig, handleSe
 import { handleTermList, handleTermCreated, sendTerminalCommand, handleTermOutput, handleTermResized, handleTermExited, handleTermClosed } from './terminal.js';
 import { attachTuiView, detachTuiView, setTuiSuspendedView, tuiHandleTermOutput, tuiHandleTermResized, tuiHandleTermExited, tuiHandleTermClosed } from './session-tui-view.js';
 import { handleTuiTranscriptState } from './tui-grab.js';
-import { tuiModalHandleTermOutput, tuiModalHandleTermResized, tuiModalHandleTermExited, tuiModalHandleTermClosed } from './tui-attention.js';
+import { tuiModalHandleTermOutput, tuiModalHandleTermResized, tuiModalHandleTermExited, tuiModalHandleTermClosed, openTuiModal } from './tui-attention.js';
 import { updateTerminalList, handleContextSourcesState, updateEmailAccountList, updateEmailUnreadCounts, handleEmailTestResult, handleEmailAddResult, handleEmailRemoveResult, handleEmailDefaults } from './context-sources.js';
 import { refreshEmailSettings } from './user-settings.js';
 import { handleNotesList, handleNoteCreated, handleNoteUpdated, handleNoteDeleted } from './sticky-notes.js';
@@ -57,7 +57,7 @@ import { handleRemoteCursorMove, handleRemoteCursorLeave, handleRemoteSelection,
 import { showLoopBanner, updateLoopBanner, updateLoopInputVisibility, showRalphApprovalBar, updateRalphApprovalStatus, openRalphPreviewModal, showExecModal, updateExecModalStatus } from './app-loop-ui.js';
 import { showDebateSticky, showDebateConcludeConfirm, showDebateUserFloor, exitDebateFloorMode, exitDebateConcludeMode, exitDebateEndedMode, updateDebateRound, renderDebateUserFloorDone } from './app-debate-ui.js';
 import { handleSkillInstallWs } from './app-skills-install.js';
-import { handleNotificationsState, handleNotificationCreated, handleNotificationDismissed, handleNotificationDismissedAll, showUpdateBanner } from './app-notifications.js';
+import { handleNotificationsState, handleNotificationCreated, handleNotificationDismissed, handleNotificationDismissedAll, showUpdateBanner, autoStartLoginIfNeeded } from './app-notifications.js';
 import { handleDebatePreparing, handleDebateBriefReady, renderDebateBriefReady, handleDebateStarted, renderDebateStarted, handleDebateTurn, handleDebateActivity, handleDebateStream, handleDebateTurnDone, handleDebateCommentQueued, handleDebateCommentInjected, renderDebateCommentInjected, handleDebateResumed, handleDebateEnded, renderDebateEnded, handleDebateError, isDebateActive, renderMcpDebateProposal, renderDebateUserResume } from './debate.js';
 import { handleMentionStart, handleMentionActivity, handleMentionStream, handleMentionDone, handleMentionError, renderMentionUser, renderMentionResponse, renderUserMention } from './mention.js';
 
@@ -1156,6 +1156,9 @@ export function processMessage(msg) {
         appendDelta((msg.text || "Authentication required.") + "\n");
         setStatus("connected");
         if (!store.get('loopActive')) enableMainInput();
+        // Auto-open the login modal terminal when the session can self-login.
+        // No-op otherwise (the auth_required banner remains the manual path).
+        autoStartLoginIfNeeded(msg);
         break;
 
       case "rate_limit":
@@ -1338,6 +1341,18 @@ export function processMessage(msg) {
         break;
 
       case "term_created":
+        // Login-modal path: the terminal was created with the login command as
+        // its initial input; attach the modal dialog to it (replays scrollback
+        // so the login URL is visible) instead of the sidebar terminal.
+        if (store.get('pendingLoginModal')) {
+          var _lm = store.get('pendingLoginModal');
+          store.set({ pendingLoginModal: null });
+          openTuiModal(msg.id, _lm.slug, {
+            sessionTitle: (_lm.vendor === "codex" ? "Codex" : "Claude") + " login",
+            projectName: _lm.slug,
+          });
+          break;
+        }
         handleTermCreated(msg);
         if (store.get('pendingTermCommand')) {
           var cmd = store.get('pendingTermCommand');

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -1350,6 +1350,7 @@ export function processMessage(msg) {
           openTuiModal(msg.id, _lm.slug, {
             sessionTitle: (_lm.vendor === "codex" ? "Codex" : "Claude") + " login",
             projectName: _lm.slug,
+            compact: true,
           });
           break;
         }

--- a/lib/public/modules/app-notifications.js
+++ b/lib/public/modules/app-notifications.js
@@ -317,12 +317,23 @@ function showBanner(notif, autoDismissMs) {
 // scrollback and the user sees the login URL / prompts immediately.
 // Falls back to the sidebar terminal if the current project slug is unknown
 // (the modal needs a slug to open its own WS to the project).
+function currentProjectSlug() {
+  var slug = store.get('currentSlug') || "";
+  if (slug) return slug;
+  // Fallback: derive from the URL (/p/<slug>/...).
+  try {
+    var m = (window.location.pathname || "").match(/^\/p\/([a-z0-9_-]+)/);
+    if (m) return m[1];
+  } catch (e) {}
+  return "";
+}
+
 function startLoginInModal(loginCommand, vendor) {
   if (authReminderVisible) return;
   var ws = getWs();
   if (!ws || ws.readyState !== 1) return;
   var cmd = loginCommand || (vendor === "codex" ? "codex login --device-auth" : "claude login");
-  var slug = store.get('currentSlug') || "";
+  var slug = currentProjectSlug();
   if (!slug) { startLoginCommand(cmd); return; }
   store.set({ pendingLoginModal: { slug: slug, vendor: vendor || "claude" } });
   ws.send(JSON.stringify({
@@ -345,13 +356,13 @@ function startLoginCommand(loginCommand) {
 }
 
 // Auto-open the login modal and run the login command when the server reports
-// the vendor isn't logged in. Only fires when the session can actually
-// self-login (canAutoLogin) — e.g. single-user, or an OS-isolation user with a
-// mapped linux account / admin. Otherwise we leave the manual "Open terminal &
-// log in" banner as the path. Idempotent: startLoginInModal is guarded by
-// authReminderVisible so repeat auth_required events no-op.
+// the vendor isn't logged in. The popup terminal runs as the connected user's
+// own OS identity (term_create -> getOsUserInfoForWs), so login always targets
+// the right account — we pop it unconditionally rather than gating on
+// canAutoLogin. Idempotent: startLoginInModal is guarded by authReminderVisible
+// so repeat auth_required events no-op.
 export function autoStartLoginIfNeeded(msg) {
-  if (!msg || !msg.canAutoLogin) return false;
+  if (!msg) return false;
   if (authReminderVisible) return false;
   var vendor = msg.vendor || "claude";
   var cmd = msg.loginCommand
@@ -594,6 +605,11 @@ export function handleNotificationCreated(msg) {
   notifications.unshift(notif);
   unreadCount = msg.unreadCount;
   updateBadge();
+
+  // auth_required no longer pops a banner: the login terminal modal opens
+  // automatically (see autoStartLoginIfNeeded). Keep the notification in the
+  // center (above) for history, but don't show the redundant banner.
+  if (notif.type === "auth_required") return;
 
   // tui_attention drives the project icon shake and the favicon blink —
   // same visual cues the SDK already produces from pendingPermissions /

--- a/lib/public/modules/app-notifications.js
+++ b/lib/public/modules/app-notifications.js
@@ -252,7 +252,7 @@ function showBanner(notif, autoDismissMs) {
           removeBanner(banner);
           dismissNotif(notif.id);
           var authMeta = notif.meta || {};
-          startLoginCommand(authMeta.loginCommand || ((authMeta.vendor || "claude") === "codex" ? "codex login --device-auth" : "claude login"));
+          startLoginInModal(authMeta.loginCommand || ((authMeta.vendor || "claude") === "codex" ? "codex login --device-auth" : "claude login"), authMeta.vendor || "claude");
           showLoginReminderBanner();
         });
       }
@@ -311,13 +311,54 @@ function showBanner(notif, autoDismissMs) {
   }
 }
 
+// Open the login terminal as a modal dialog (the same modal used for TUI
+// attention), running the vendor login command. The terminal is created with
+// the command as its initial input, so when the modal attaches it replays the
+// scrollback and the user sees the login URL / prompts immediately.
+// Falls back to the sidebar terminal if the current project slug is unknown
+// (the modal needs a slug to open its own WS to the project).
+function startLoginInModal(loginCommand, vendor) {
+  if (authReminderVisible) return;
+  var ws = getWs();
+  if (!ws || ws.readyState !== 1) return;
+  var cmd = loginCommand || (vendor === "codex" ? "codex login --device-auth" : "claude login");
+  var slug = store.get('currentSlug') || "";
+  if (!slug) { startLoginCommand(cmd); return; }
+  store.set({ pendingLoginModal: { slug: slug, vendor: vendor || "claude" } });
+  ws.send(JSON.stringify({
+    type: "term_create",
+    cols: 100,
+    rows: 30,
+    initialCommand: cmd + "\n",
+  }));
+}
+
+// Sidebar-terminal fallback (used when no slug is available for the modal).
 function startLoginCommand(loginCommand) {
+  if (authReminderVisible) return;
   var ws = getWs();
   if (!ws || ws.readyState !== 1) return;
   var termCommand = (loginCommand || "claude login") + "\n";
   store.set({ pendingTermCommand: termCommand });
   ws.send(JSON.stringify({ type: "term_create", cols: 80, rows: 24 }));
   openTerminal();
+}
+
+// Auto-open the login modal and run the login command when the server reports
+// the vendor isn't logged in. Only fires when the session can actually
+// self-login (canAutoLogin) — e.g. single-user, or an OS-isolation user with a
+// mapped linux account / admin. Otherwise we leave the manual "Open terminal &
+// log in" banner as the path. Idempotent: startLoginInModal is guarded by
+// authReminderVisible so repeat auth_required events no-op.
+export function autoStartLoginIfNeeded(msg) {
+  if (!msg || !msg.canAutoLogin) return false;
+  if (authReminderVisible) return false;
+  var vendor = msg.vendor || "claude";
+  var cmd = msg.loginCommand
+    || (vendor === "codex" ? "codex login --device-auth" : "claude login");
+  startLoginInModal(cmd, vendor);
+  showLoginReminderBanner();
+  return true;
 }
 
 function showLoginReminderBanner() {

--- a/lib/public/modules/tui-attention.js
+++ b/lib/public/modules/tui-attention.js
@@ -147,6 +147,12 @@ export function openTuiModal(terminalId, sourceSlug, info) {
   });
   modalEl.classList.remove("hidden");
 
+  // Compact sizing for short, content-light terminals (e.g. the login
+  // wizard) so the box hugs the content instead of leaving a tall empty
+  // black area below it. Full-size for live TUI sessions that fill the screen.
+  var boxEl = modalEl.querySelector(".tui-modal");
+  if (boxEl) boxEl.classList.toggle("tui-modal-compact", !!infoObj.compact);
+
   var bodyEl = modalEl.querySelector(".tui-modal-body");
   bodyEl.innerHTML = "";
   modalXterm = new Terminal({


### PR DESCRIPTION
## Summary

When Claude or Codex reports it isn't logged in, Clay now **auto-pops a modal terminal dialog running the login command** so the user completes login in place. Popup-first: the old "not logged in" banner is suppressed.

## Behavior
- `auth_required` (client) → `autoStartLoginIfNeeded(msg)` → opens the modal login terminal and runs the vendor login command (`claude login` / `codex login --device-auth`).
- The terminal is created with the login command as its `initialCommand` (→ PTY `initialInput`); the modal attaches and `terminal-manager` replays scrollback, so the login URL/prompt shows immediately.
- Reuses the existing `openTuiModal` (the modal dialog used for TUI attention), **not** the sidebar terminal.
- Runs as the connected user's own OS identity (`term_create` → `getOsUserInfoForWs`), so login always targets the right account — popped unconditionally (no `canAutoLogin` gate).
- The redundant `auth_required` banner is suppressed (kept in the notification center for history).
- **Compact modal**: the login wizard is short, so a `tui-modal-compact` variant (720×480) is used so the box hugs the content instead of leaving a tall black area. Full-size modal unchanged for live TUI sessions.

## Safeguards
- `authReminderVisible` guards `startLoginInModal` so repeat `auth_required` events / the manual button can't open a second terminal.
- Falls back to the sidebar terminal if the project slug can't be resolved (from store or the URL).

## Files
- `lib/public/modules/app-notifications.js` — `startLoginInModal`, `autoStartLoginIfNeeded`, slug fallback, banner suppression.
- `lib/public/modules/app-messages.js` — auto-trigger on `auth_required`; `term_created` opens the compact login modal.
- `lib/public/modules/tui-attention.js` + `lib/public/css/tui-attention.css` — `compact` modal option.
- `lib/project-user-message.js` — `term_create` accepts `initialCommand` → PTY `initialInput`.

## Validation
Client-import check + `node --check` on all touched files. **Runtime confirmed** by the author: modal pops, `claude login` runs, wizard renders; compact sizing applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)