### PR TITLE
Upgrade @openai/codex to 0.142.4

### DIFF
--- a/docs/ongoing/CODEX-UPGRADE.md
+++ b/docs/ongoing/CODEX-UPGRADE.md
@@ -1,8 +1,8 @@
 # Codex App-Server Upgrade Tracker
 
-Installed: `@openai/codex@0.124.0`
-Latest: `@openai/codex@0.128.0` (npm)
-Updated: 2026-05-08
+Installed: `@openai/codex@0.142.4`
+Latest: `@openai/codex@0.142.4` (npm)
+Updated: 2026-07-01
 
 Tracks Clay's integration against the OpenAI Codex CLI / `codex app-server` JSON-RPC protocol. Mirrors the structure of `SDK-UPGRADE.md` so the same review cadence applies.
 
@@ -107,7 +107,9 @@ These are the `Codex: x` rows in `SDK-UPGRADE.md`. When the platform-common feat
 
 ### Codex-specific items (no SDK counterpart)
 
-Empty for now. Fill as we encounter Codex protocol behaviors with no Claude analog.
+| Item | Version range | Status | Notes |
+|------|---------------|--------|-------|
+| Binary layout moved `vendor/<triple>/codex/` → `vendor/<triple>/bin/` | 0.124 → 0.142 | **Fixed** | `findCodexPath()` in `codex-app-server.js` would not find the binary after the bump (Codex fails to launch entirely). Resolver now probes both layouts (`bin/codex` then `codex/codex`) and returns the first that exists. |
 
 
 ---
@@ -138,13 +140,13 @@ For protocol-level diagnosis, the codex app-server speaks JSON-RPC 2.0; you can 
 
 ## Upgrade Steps
 
-### 0.124.0 -> 0.128.0 (next)
+### 0.124.0 -> 0.142.4 (done, npm bump + binary-path fix; UI matrix pending)
 
-1. Run the verification matrix above against `0.128.0`.
-2. `npm install @openai/codex@0.128.0`
-3. Update `package.json` semver caret if breaking; otherwise let the caret pick it up.
-4. Smoke test the matrix above end to end.
-5. If protocol fields changed, update `lib/yoke/adapters/codex.js` `convertItemToEvents` mapping and add a row in this file.
+1. ~~`npm install @openai/codex@^0.142.4` (package.json caret bumped to `^0.142.4`).~~
+2. ~~**Breaking:** binary moved to `vendor/<triple>/bin/codex`. Fixed `findCodexPath()` to probe both layouts (see Codex-specific items).~~
+3. ~~Headless protocol smoke: spawn `app-server`, `initialize` handshake succeeds (response `userAgent` reports `0.142.4`). Core JSON-RPC protocol intact.~~
+4. **Pending (needs runtime/UI):** the full verification matrix above — approval, file edit, plan, MCP tool, compaction, interrupt, rewind. The headless smoke only covers spawn + initialize.
+5. If any matrix step regresses, update `lib/yoke/adapters/codex.js` `convertItemToEvents` and add a row here.
 
 ### Future bumps
 

--- a/lib/yoke/codex-app-server.js
+++ b/lib/yoke/codex-app-server.js
@@ -7,6 +7,7 @@
 var { spawn } = require("child_process");
 var readline = require("readline");
 var path = require("path");
+var fs = require("fs");
 var { createRequire } = require("module");
 
 // --- Find the codex binary path ---
@@ -48,7 +49,17 @@ function findCodexPath() {
     var platformPkgJson = codexRequire.resolve(platformPkg + "/package.json");
     var vendorRoot = path.join(path.dirname(platformPkgJson), "vendor");
     var binaryName = process.platform === "win32" ? "codex.exe" : "codex";
-    return path.join(vendorRoot, triple, "codex", binaryName);
+    // The binary layout changed across versions: 0.142+ ships it under
+    // vendor/<triple>/bin/, older builds used vendor/<triple>/codex/.
+    // Try the known layouts and return the first that exists.
+    var candidates = [
+      path.join(vendorRoot, triple, "bin", binaryName),
+      path.join(vendorRoot, triple, "codex", binaryName),
+    ];
+    for (var i = 0; i < candidates.length; i++) {
+      if (fs.existsSync(candidates[i])) return candidates[i];
+    }
+    throw new Error("codex binary not found in any known layout under " + path.join(vendorRoot, triple));
   } catch (e) {
     throw new Error("Could not find codex binary: " + e.message);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "clay-server",
-  "version": "2.44.1-beta.1",
+  "version": "2.45.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clay-server",
-      "version": "2.44.1-beta.1",
+      "version": "2.45.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.196",
         "@lydell/node-pty": "^1.2.0-beta.3",
-        "@openai/codex": "^0.124.0",
+        "@openai/codex": "^0.142.4",
         "imapflow": "^1.3.1",
         "nodemailer": "^6.10.1",
         "qrcode-terminal": "^0.12.0",
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0.tgz",
-      "integrity": "sha512-1EVAuPyAQZ8zIVMw3bPJ6a4R8ifLAZ7LGsOyknj5c2he9AFXVRCmWx12WrdZJ25wcBvOEKt1n1Zx+QAj0EVGbQ==",
+      "version": "0.142.4",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4.tgz",
+      "integrity": "sha512-BW9+3Cs7tChgkc0QhUsZIDm6XgpSDSeJkljRSHhJZqDwlaxDnNVhRP/sZwhgrTn3f2jPn3jc4WTKfLOTk+g5pA==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -607,19 +607,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.124.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.124.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.124.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.124.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.124.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.124.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.4-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.4-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.4-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.4-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.4-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.4-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.124.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-darwin-arm64.tgz",
-      "integrity": "sha512-lnuqeAdl+RjPWsqVZ8rrPskRIOZmzlyr8e5q/wFVEnMPsm9dWgjRW1PKa84UmDSQVOuz9GObF28DEHFyC4A8NA==",
+      "version": "0.142.4-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-darwin-arm64.tgz",
+      "integrity": "sha512-CfXp5jilBOxD8zLuG6Nk7w5ZPP3roE3s1rsr60za9PQKI7kaJ/5G+oP3Z0N1CoB4mpy+5JHkMLTZAZZPGFlSgQ==",
       "cpu": [
         "arm64"
       ],
@@ -634,9 +634,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.124.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-darwin-x64.tgz",
-      "integrity": "sha512-Br+VlL83IOu96Urw+mkZ1PQXLsQXGAYEH6kXNt4ULuVt7qAdQY2FKYwIgLLVLl0vpMk8qWxdfdVMqhiu2uCHlg==",
+      "version": "0.142.4-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-darwin-x64.tgz",
+      "integrity": "sha512-H9ia31pkJFtBk+UrREAfJiTUfcvgactKbG4W4SF2LFfJOTRsrsJZGtscHQ8/lLGeKEfOk/psrbSOPDyrZnxvnQ==",
       "cpu": [
         "x64"
       ],
@@ -651,9 +651,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.124.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-linux-arm64.tgz",
-      "integrity": "sha512-QXafFVQJxPfU1LSCI5afuHsF5evKAcbQpFuKou0Kl241/HG/zYHdwoWj546zH844gJgegIPAxPf36+RSkUsbbA==",
+      "version": "0.142.4-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-linux-arm64.tgz",
+      "integrity": "sha512-/bBcEm+OKmlGHH0c88jrVgYMRyaNC/hGOW/znP/PiHQEeIf4UdsUGQ7x4FAZm648140cgaeKYIBoRBbHizS+5w==",
       "cpu": [
         "arm64"
       ],
@@ -668,9 +668,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.124.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-linux-x64.tgz",
-      "integrity": "sha512-cJ4QfQIrz2gkXVWephiGo9JDyD3qLKhvkTTLk7gI8rKd7MZpVXn9/1e7pZCQnJVA7Dk6ocA5G+sxnR78SoIejw==",
+      "version": "0.142.4-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-linux-x64.tgz",
+      "integrity": "sha512-t3tNOkDdiO5/gRqkTmuMcAj5JjCbeWotOJzxV7pPkD2u2KvzVRrk7jPAjuy+85wPc12lsIupYgxHlK7CkVLOjA==",
       "cpu": [
         "x64"
       ],
@@ -685,9 +685,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.124.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-win32-arm64.tgz",
-      "integrity": "sha512-oDSI/CQh0kagBwWVPG9EiUBfHiY27ju3LPrjTVZg4VMpVJVNA31JTK8rHMZ6G/2gfNmOl6DMBA6+0ICxSkkshg==",
+      "version": "0.142.4-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-win32-arm64.tgz",
+      "integrity": "sha512-QBGeoYk3pmVscVIxeW21cvPJIjsnmD5dOTqMAzypXGik5soNIKHbps2Kj1LBKOjVbbx5qoDEbTwDfYmnjfqgdQ==",
       "cpu": [
         "arm64"
       ],
@@ -702,9 +702,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.124.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-win32-x64.tgz",
-      "integrity": "sha512-t+lAwmCWwIWQKk6dKaYetRhQsmA+uDmQy1NLka1xAAv3PlNOH8iNz9Lsisr3qYkBR8Tf7tbQlt+pl9tw/A5mfA==",
+      "version": "0.142.4-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-win32-x64.tgz",
+      "integrity": "sha512-W0rSPT0t7FnKlJYNu9/HpHzaSOutuSSYjIVunKorYmrScXk9pQxBEhEuyn16JOtywc/2nX8nHEmWsuj2sd8suw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.196",
     "@lydell/node-pty": "^1.2.0-beta.3",
-    "@openai/codex": "^0.124.0",
+    "@openai/codex": "^0.142.4",
     "imapflow": "^1.3.1",
     "nodemailer": "^6.10.1",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
## Summary

Bumps `@openai/codex` from `^0.124.0` to `^0.142.4`.

## Breaking change fixed
The codex binary moved: `0.142` ships it at `vendor/<triple>/bin/codex` (older builds used `vendor/<triple>/codex/codex`). `findCodexPath()` in `codex-app-server.js` still looked for the old path, so after the bump Codex failed to launch entirely (`spawn .../codex/codex ENOENT`). The resolver now probes both layouts (`bin/codex` then `codex/codex`) and returns the first that exists.

## Validation
- Headless protocol smoke: `app-server` spawns and the `initialize` handshake succeeds (response `userAgent` reports `0.142.4`). Core JSON-RPC protocol intact.
- Tracker `docs/ongoing/CODEX-UPGRADE.md` updated (header, breaking-change row, Upgrade Steps).
- **Pending (runtime/UI matrix):** approval, file edit, plan, MCP tool, compaction, interrupt, rewind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)