### PR TITLE
What's New: "GUI is back" + stop popping superseded entries

### DIFF
--- a/lib/whats-new-content.js
+++ b/lib/whats-new-content.js
@@ -27,6 +27,7 @@ var ENTRIES = [
     title: "TUI becomes the default for Claude sessions",
     publishedAt: "2026-05-25",
     image: null,
+    popup: false, // superseded by "GUI is back"; keep in the home feed only
     summary: "Anthropic is splitting Claude billing into Interactive and Programmatic buckets on June 15. To keep working with your existing plan, Clay opens Claude sessions in the embedded claude CLI by default from that date.",
     body: '' +
       '<p><strong>2026-06-15 Anthropic billing change.</strong> Claude subscriptions split into two buckets:</p>' +
@@ -55,6 +56,7 @@ var ENTRIES = [
     title: "Mates leaves the official feature set",
     publishedAt: "2026-05-25",
     image: null,
+    popup: false, // superseded by "GUI is back"; keep in the home feed only
     summary: "June 15 will be Mates' last day as a first-class Clay feature. It continues as a separate standalone project so Clay can focus fully on being a developer tool.",
     body: '' +
       '<p>On <strong>2026-06-15</strong>, Mates leaves Clay\'s official feature set. Your existing Mates and their knowledge files will remain on disk; we will share migration instructions and a link to the new standalone project before the cutover.</p>' +
@@ -62,6 +64,20 @@ var ENTRIES = [
       '<p>Mates grew into something broader than a coding companion - personas, debates, DMs, identity files. That is a different product shape than a focused dev tool, and trying to be both was slowing each side down.</p>' +
       '<p>We are formally positioning Clay as a <strong>developer tool</strong>. From here on, every roadmap decision is judged by a single question: does it make Clay the sleekest, sharpest workspace on the AI-coding frontier? Mates no longer fits that bar cleanly, so it gets its own home where it can evolve on its own terms.</p>' +
       '<p>Thanks for being here. Clay only gets sharper from here.</p>',
+  },
+  {
+    id: "2026-07-gui-is-back",
+    title: "GUI is back as the default",
+    publishedAt: "2026-07-01",
+    image: null,
+    summary: "Anthropic reversed the June 15 billing split, so SDK usage is no longer billed separately. Clay opens Claude sessions in the GUI chat again by default. Mates is now off by default as it winds down.",
+    body: '' +
+      '<p><strong>Good news: Anthropic walked back the June 15 billing change.</strong> The planned Interactive vs. Programmatic split (which would have charged Claude Agent SDK usage at full API rates) is off the table, so the reason we moved everyone to the TUI is gone.</p>' +
+      '<h3>GUI is the default again</h3>' +
+      '<p>New Claude sessions open in the <strong>GUI chat</strong> (SDK) by default, the way they did before. The embedded <code>claude</code> <strong>TUI</strong> is still there whenever you want it &mdash; toggle <strong>"Open Claude as terminal (TUI)"</strong> in Settings.</p>' +
+      '<h3>Mates is off by default</h3>' +
+      '<p>As announced, <strong>Mates</strong> is no longer a first-class Clay feature. It is now <strong>off by default</strong> so Clay stays focused as a developer tool. Your existing Mates and their knowledge files remain on disk &mdash; if you still use them, re-enable Mates in <strong>Settings</strong>.</p>' +
+      '<p>Clay only gets sharper from here.</p>',
   },
 ];
 

--- a/lib/whats-new.js
+++ b/lib/whats-new.js
@@ -26,6 +26,9 @@ function getStateForUser(userId) {
   var seen = (typeof users.getWhatsNewSeenIds === "function" && userId) ? users.getWhatsNewSeenIds(userId) : [];
   var unseenIds = [];
   for (var i = 0; i < entries.length; i++) {
+    // popup:false entries stay in the home feed (entries) as history but never
+    // auto-pop in the carousel, so superseded announcements don't resurface.
+    if (entries[i] && entries[i].popup === false) continue;
     if (entries[i] && entries[i].id && seen.indexOf(entries[i].id) === -1) {
       unseenIds.push(entries[i].id);
     }


### PR DESCRIPTION
## Summary

Adds a new What's New entry and makes superseded announcements stop auto-popping.

## New entry — "GUI is back as the default" (2026-07-01)
- Anthropic reversed the June 15 Interactive/Programmatic billing split, so SDK usage is no longer billed separately.
- Claude sessions default to the **GUI (SDK) chat** again; the embedded TUI stays available via Settings.
- **Mates is off by default** as it winds down; existing Mates/knowledge files stay on disk and can be re-enabled in Settings.

## Per-entry `popup` flag
The two earlier entries — "TUI becomes the default" and "Mates leaves the official feature set" — are now contradicted by the reversal, so they shouldn't keep popping in the carousel. Added a `popup: false` flag:
- `whats-new-content.js`: mark both old entries `popup: false`.
- `whats-new.js`: `getStateForUser` excludes `popup:false` entries from `unseenIds` (the carousel/popup queue) but keeps them in `entries` (the home feed history).

Result: only "GUI is back" auto-pops; the old entries remain visible in the home feed as history.

## Validation
`node --check` on both files; verified `getStateForUser` returns all 3 entries in the feed but only the new id in `unseenIds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)