### PR TITLE
feat(deps): bump claude-agent-sdk to 0.3.198 for Claude Fable 5 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "clay-server",
-  "version": "2.45.0-beta.1",
+  "version": "2.45.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clay-server",
-      "version": "2.45.0-beta.1",
+      "version": "2.45.0-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.196",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.198",
         "@lydell/node-pty": "^1.2.0-beta.3",
         "@openai/codex": "^0.142.4",
         "imapflow": "^1.3.1",
@@ -83,22 +83,22 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.196.tgz",
-      "integrity": "sha512-yqsp1/04T2/tJ54jz+7YLsTZOPeQ/myUCrv17/IVZ9dbl+izIMP9ULuLpPCH5pj5msXxR80es+hpVgHoFuNm0A==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
+      "integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.196",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.196"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.196.tgz",
-      "integrity": "sha512-k1MKRDhSiNKpkTwhtU8QKGzfuRfr3YXS6oqsTuldMROX56L5iMXjzC7AYU1/KmPTeMl3SCQBQeDu0i8ciA0hQA==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
+      "integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.196.tgz",
-      "integrity": "sha512-bBwx/7yKZMQ9NSUt4bg8P+zp6pgd/O/DTkzdqsRIivBvARmwo1QY/2qGrLO8RH0T8CG2lTjFNfDfOlJWbAkvAg==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
+      "integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +133,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.196.tgz",
-      "integrity": "sha512-fR5fy+pSQSpKZK0zTtAl3LZEGQTuwVK7svutH1bZUS5RGT2HdUWc71oltSZgW4upGaslj+gyusHGJHA5eAc+dw==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
+      "integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.196.tgz",
-      "integrity": "sha512-BhLxfx4j6mC3Uzmve1IbhFS1uvNlwATeo6uWyYDOMW4n3XKjiSgjD8bTfkamijrxCMvJo5swLju2y14ayDsokA==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
+      "integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
       "cpu": [
         "arm64"
       ],
@@ -159,9 +159,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.196.tgz",
-      "integrity": "sha512-9spZON7/tn0q9J+jICrdfHi7o7Fmjs9pIohCCxL+Yv7HbBXWVtEYJbYipBGLTl8ICG3mgPeEVMNsvOuh/jDTuA==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
+      "integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
       "cpu": [
         "x64"
       ],
@@ -172,9 +172,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.196.tgz",
-      "integrity": "sha512-EOiNbxCXQLYzV7SQhMWkUC1ScWyTw/Qp+JyV2sEmIbzl/e7KMOxNE9J20k+lpPs6CXdxVzuMwH7yAGuDu5y+IQ==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
+      "integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
       "cpu": [
         "x64"
       ],
@@ -185,9 +185,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.196.tgz",
-      "integrity": "sha512-0xXkAWlDof/qFi3k5KJZ5WYbgp1X8hZHjyasOWTZWAmldoYaENI0vkL+PVMarvoAFYRRqcWoS81FSgm0QgH2sA==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
+      "integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
       "cpu": [
         "arm64"
       ],
@@ -198,9 +198,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.196",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.196.tgz",
-      "integrity": "sha512-FxWLA3aOYgDf2J0o6Ov1/wgg9X6RkrgnX4ifUWO1i3+6mbc4efNLHkDZLxCHEnQgW8yBidX+iro19f9k64vV8A==",
+      "version": "0.3.198",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
+      "integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://github.com/chadbyte/clay#readme",
   "author": "Chad",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.196",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.198",
     "@lydell/node-pty": "^1.2.0-beta.3",
     "@openai/codex": "^0.142.4",
     "imapflow": "^1.3.1",


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/claude-agent-sdk` from 0.3.196 to 0.3.198 (bundled Claude Code CLI 2.1.196 → 2.1.198).
- CLI 2.1.198's `supportedModels()` returns Claude Fable 5 (`claude-fable-5[1m]`, display name "Fable", effort low–max, adaptive thinking).
- No application code changes: Clay resolves the local `claude` binary via `pathToClaudeCodeExecutable` and renders the model picker from the dynamic `supportedModels()` list, so Fable appears automatically.

## Verification
- Ran `supportedModels()` through the updated SDK against CLI 2.1.198: Fable is present in the returned list with correct capability flags (`supportsEffort`, `supportedEffortLevels: [low..max]`, `supportsAdaptiveThinking`, no `supportsFastMode`, as expected for Fable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)