### PR TITLE
feat(codex): add GPT-5.6 sol/terra/luna models

### DIFF
--- a/lib/public/modules/app-panels.js
+++ b/lib/public/modules/app-panels.js
@@ -108,6 +108,7 @@ var CODEX_WEBSEARCH_OPTIONS = [
 var KNOWN_CONTEXT_WINDOWS = {
   "opus-4-6": 1000000,
   "claude-sonnet-4": 1000000,
+  "gpt-5.6": 272000,
   "gpt-5.5": 1048576,
   "gpt-5.4": 1048576,
   "gpt-5.3": 1048576,

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -620,7 +620,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
     done: false,
     aborted: false,
     loopStarted: false,
-    model: queryOpts.model || "gpt-5.5",
+    model: queryOpts.model || "gpt-5.6-terra",
     // Track incremental text deltas
     textBlocks: {},     // itemId -> true (text_start sent)
     textLengths: {},    // itemId -> last sent length
@@ -865,7 +865,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
 
       // Start or resume thread
       var threadParams = {
-        model: queryOpts.model || "gpt-5.5",
+        model: queryOpts.model || "gpt-5.6-terra",
         sandbox: queryOpts.sandboxMode || "workspace-write",
         approvalPolicy: queryOpts.approvalPolicy || "on-failure",
         cwd: queryOpts.cwd,
@@ -1086,6 +1086,9 @@ function createCodexAdapter(opts) {
   // slow/failed `initialize` leaves the picker empty and the chip shows the
   // previous vendor's model.
   var CODEX_MODELS = [
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
@@ -1131,7 +1134,7 @@ function createCodexAdapter(opts) {
   function buildReadyResponse(skillNames) {
     return {
       models: _cachedModels,
-      defaultModel: "gpt-5.5",
+      defaultModel: "gpt-5.6-terra",
       skills: skillNames || [],
       slashCommands: skillNames || [],
       fastModeState: null,
@@ -1428,7 +1431,7 @@ function createCodexAdapter(opts) {
         throw new Error("[yoke/codex] Adapter not initialized. Call init() first.");
       }
 
-      var model = queryOpts.model || "gpt-5.5";
+      var model = queryOpts.model || "gpt-5.6-terra";
       var ac = queryOpts.abortController || new AbortController();
       var activeEntry = {
         abort: function() {


### PR DESCRIPTION
## Summary
Adds the GPT-5.6 model family (released 2026-07-09) to the Codex adapter so users can select the new tiers, and makes `gpt-5.6-terra` the default (5.5-class quality at ~2x lower cost).

## Changes
- `lib/yoke/adapters/codex.js`
  - Add `gpt-5.6-terra`, `gpt-5.6-sol`, `gpt-5.6-luna` to `CODEX_MODELS` (older ids kept as selectable options)
  - Flip the default model fallbacks (3 sites) and `defaultModel` from `gpt-5.5` to `gpt-5.6-terra`
- `lib/public/modules/app-panels.js`
  - Register `gpt-5.6` context window (272000) in `KNOWN_CONTEXT_WINDOWS` so the context panel reports usage correctly instead of the 200000 fallback

## Model tiers
| Tier | id | Notes |
|------|----|-------|
| Sol | `gpt-5.6-sol` | Flagship, deepest reasoning |
| Terra | `gpt-5.6-terra` | Balanced, ~5.5 quality at 2x lower cost (new default) |
| Luna | `gpt-5.6-luna` | Fast/cheap, high-volume |

## Verification
- The bundled `@openai/codex` 0.144.4 native binary contains all three `gpt-5.6-*` model id strings, confirming the CLI recognizes them (support landed in codex 0.143.0).
- Syntax check passes on both files.

## Notes
- `codex.js` internal subagent still uses `gpt-5.4-mini` (valid, unchanged; could move to `gpt-5.6-luna` later).
- A full end-to-end run against an authenticated Codex session was not performed here (no auth in this environment); binary-level id verification stands in for it.