### PR TITLE
test(yoke): add adapter SDK regression harness

### DIFF
--- a/docs/guides/CODEX-INTEGRATION.md
+++ b/docs/guides/CODEX-INTEGRATION.md
@@ -220,9 +220,9 @@ When changing Codex adapter code:
 
 - [ ] Text response streams in real time (`item/agentMessage/delta`)
 - [ ] Thinking indicator shows and clears
-- [ ] Bash command with `approval: on-failure` shows approval UI, responds correctly to Sure/Always/No
+- [ ] Bash command with `approval: on-request` shows approval UI, responds correctly to Sure/Always/No
 - [ ] File change outside workspace shows approval UI
-- [ ] MCP tool (filesystem) with `approval: on-failure` shows approval UI, executes after approval
+- [ ] MCP tool (filesystem) with `approval: on-request` shows approval UI, executes after approval
 - [ ] Multi-turn conversation works (2nd message sends to same thread)
 - [ ] Session resume works after server restart
 - [ ] Switching between Codex and Claude sessions shows correct slash commands for each

--- a/lib/codex-defaults.js
+++ b/lib/codex-defaults.js
@@ -1,12 +1,20 @@
 var CODEX_DEFAULTS = {
-  approval: "on-failure",
+  approval: "on-request",
   sandbox: "danger-full-access",
   webSearch: "live",
 };
 
+var CODEX_APPROVAL_POLICIES = ["untrusted", "on-request", "granular", "never"];
+
+function normalizeCodexApproval(value) {
+  if (value === "on-failure") return CODEX_DEFAULTS.approval;
+  if (CODEX_APPROVAL_POLICIES.indexOf(value) === -1) return CODEX_DEFAULTS.approval;
+  return value;
+}
+
 function getCodexConfig(sm) {
   return {
-    approval: (sm && sm.codexApproval) || CODEX_DEFAULTS.approval,
+    approval: normalizeCodexApproval(sm && sm.codexApproval),
     sandbox: (sm && sm.codexSandbox) || CODEX_DEFAULTS.sandbox,
     webSearch: (sm && sm.codexWebSearch) || CODEX_DEFAULTS.webSearch,
   };
@@ -14,5 +22,7 @@ function getCodexConfig(sm) {
 
 module.exports = {
   CODEX_DEFAULTS: CODEX_DEFAULTS,
+  CODEX_APPROVAL_POLICIES: CODEX_APPROVAL_POLICIES,
+  normalizeCodexApproval: normalizeCodexApproval,
   getCodexConfig: getCodexConfig,
 };

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -1084,7 +1084,7 @@ function attachSessions(ctx) {
 
     // Codex-specific settings (stored on sessionManager, passed to adapter via adapterOptions)
     if (msg.type === "set_codex_approval") {
-      sm.codexApproval = msg.approval || CODEX_DEFAULTS.approval;
+      sm.codexApproval = getCodexConfig({ codexApproval: msg.approval }).approval;
       send(Object.assign({ type: "codex_config" }, getCodexConfig(sm)));
       return true;
     }

--- a/lib/public/modules/app-panels.js
+++ b/lib/public/modules/app-panels.js
@@ -93,7 +93,7 @@ var EFFORT_LEVELS_BY_VENDOR = {
 var THINKING_OPTIONS = ["disabled", "adaptive", "budget"];
 var CODEX_APPROVAL_OPTIONS = [
   { value: "never", label: "Auto" },
-  { value: "on-failure", label: "On Fail" },
+  { value: "untrusted", label: "Untrusted" },
   { value: "on-request", label: "Ask" },
 ];
 var CODEX_SANDBOX_OPTIONS = [

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -1737,4 +1737,9 @@ function createClaudeAdapter(opts) {
 module.exports = {
   createClaudeAdapter: createClaudeAdapter,
   createMessageQueue: createMessageQueue,
+  contractTestKit: {
+    createMessageQueue: createMessageQueue,
+    createQueryHandle: createQueryHandle,
+    normalizeEvent: flattenEvent,
+  },
 };

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -597,6 +597,27 @@ function flattenEvent(notification, state) {
   return events;
 }
 
+function createEventState(model) {
+  return {
+    blockCounter: 0,
+    threadId: null,
+    turnStarted: false,
+    lastUsage: null,
+    lastInputTokens: null,
+    done: false,
+    aborted: false,
+    loopStarted: false,
+    model: model || "gpt-5.6-terra",
+    textBlocks: {},
+    textLengths: {},
+    thinkingBlocks: {},
+    thinkingLengths: {},
+    toolBlocks: {},
+    commandInputs: {},
+    planTexts: {},
+  };
+}
+
 // --- QueryHandle ---
 
 function createCodexQueryHandle(appServer, queryOpts) {
@@ -611,25 +632,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
     return state.aborted || (abortController && abortController.signal && abortController.signal.aborted);
   }
 
-  var state = {
-    blockCounter: 0,
-    threadId: null,
-    turnStarted: false,
-    lastUsage: null,
-    lastInputTokens: null, // from thread/tokenUsage/updated
-    done: false,
-    aborted: false,
-    loopStarted: false,
-    model: queryOpts.model || "gpt-5.6-terra",
-    // Track incremental text deltas
-    textBlocks: {},     // itemId -> true (text_start sent)
-    textLengths: {},    // itemId -> last sent length
-    thinkingBlocks: {}, // itemId -> blockId
-    thinkingLengths: {}, // itemId -> last sent length
-    toolBlocks: {},     // itemId -> blockId (for tool_start dedup)
-    commandInputs: {},  // itemId -> command captured from approval/start events
-    planTexts: {},      // itemId -> streamed plan text
-  };
+  var state = createEventState(queryOpts.model);
 
   // Internal event buffer for async iterator
   var eventBuffer = [];
@@ -867,7 +870,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
       var threadParams = {
         model: queryOpts.model || "gpt-5.6-terra",
         sandbox: queryOpts.sandboxMode || "workspace-write",
-        approvalPolicy: queryOpts.approvalPolicy || "on-failure",
+        approvalPolicy: queryOpts.approvalPolicy || "on-request",
         cwd: queryOpts.cwd,
         skipGitRepoCheck: true,
       };
@@ -1463,7 +1466,7 @@ function createCodexAdapter(opts) {
       if (queryOpts.toolPolicy === "allow-all") {
         handleOpts.approvalPolicy = "never";
       } else {
-        handleOpts.approvalPolicy = codexOpts.approvalPolicy || "on-failure";
+        handleOpts.approvalPolicy = codexOpts.approvalPolicy || "on-request";
       }
 
       // Sandbox mode
@@ -1590,4 +1593,9 @@ function createCodexAdapter(opts) {
 
 module.exports = {
   createCodexAdapter: createCodexAdapter,
+  contractTestKit: {
+    createEventState: createEventState,
+    createQueryHandle: createCodexQueryHandle,
+    normalizeEvent: flattenEvent,
+  },
 };

--- a/lib/yoke/adapters/kiro.js
+++ b/lib/yoke/adapters/kiro.js
@@ -377,6 +377,29 @@ function finalToolContent(state, callId, update) {
   return extractRawOutput(update.rawOutput);
 }
 
+function createEventState(opts) {
+  opts = opts || {};
+  return {
+    blockCounter: 0,
+    sessionId: opts.resumeSessionId || null,
+    model: opts.model || "auto",
+    engine: opts.engine || KIRO_DEFAULTS.engine,
+    lastInputTokens: null,
+    contextWindow: opts.contextWindow || null,
+    done: false,
+    aborted: false,
+    loopStarted: false,
+    loadingSession: false,
+    textBlockOpen: false,
+    textBlockId: null,
+    thinkBlockOpen: false,
+    thinkBlockId: null,
+    toolBlocks: {},
+    toolMeta: {},
+    toolContent: {},
+  };
+}
+
 // --- QueryHandle ---
 
 function createKiroQueryHandle(acp, queryOpts) {
@@ -389,26 +412,7 @@ function createKiroQueryHandle(acp, queryOpts) {
     return state.aborted || (abortController && abortController.signal && abortController.signal.aborted);
   }
 
-  var state = {
-    blockCounter: 0,
-    sessionId: queryOpts.resumeSessionId || null,
-    model: queryOpts.model || "auto",
-    engine: queryOpts.engine || KIRO_DEFAULTS.engine,
-    lastInputTokens: null,
-    contextWindow: queryOpts.contextWindow || null,
-    done: false,
-    aborted: false,
-    loopStarted: false,
-    loadingSession: false,
-    // per-turn block tracking (reset each turn)
-    textBlockOpen: false,
-    textBlockId: null,
-    thinkBlockOpen: false,
-    thinkBlockId: null,
-    toolBlocks: {},
-    toolMeta: {},
-    toolContent: {},
-  };
+  var state = createEventState(queryOpts);
 
   // Async iterator plumbing
   var eventBuffer = [];
@@ -1153,4 +1157,9 @@ function createKiroAdapter(opts) {
 
 module.exports = {
   createKiroAdapter: createKiroAdapter,
+  contractTestKit: {
+    createEventState: createEventState,
+    createQueryHandle: createKiroQueryHandle,
+    normalizeEvent: flattenUpdate,
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "clay-server",
-  "version": "2.45.0-beta.4",
+  "version": "2.47.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clay-server",
-      "version": "2.45.0-beta.4",
+      "version": "2.47.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.198",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.233",
         "@lydell/node-pty": "^1.2.0-beta.3",
-        "@openai/codex": "^0.142.4",
+        "@openai/codex": "^0.147.0",
         "imapflow": "^1.3.1",
         "nodemailer": "^6.10.1",
         "qrcode-terminal": "^0.12.0",
@@ -83,22 +83,22 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.198.tgz",
-      "integrity": "sha512-xt469sSCyclTPtzpLAg0Aschy665GiRMgZKabSmESbGUA5/H56HcILVOiFxclXswkeMUk2fQxfHJUY9UZfiTnA==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.233.tgz",
+      "integrity": "sha512-Dy+YqhggwtbezDy3Ap2pb1sK3bOqnI+sLNnsVjB3AUWvR0QlGnjjrjORXY03Y50I+B1eFRNEcYPAZKRYlCkSLQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.198",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.198"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.233",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.233"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.198.tgz",
-      "integrity": "sha512-ZmiAybQKIKcP1qEAE/vfXvfxtKxG9CnJn98QTXC5Zxiwuy7Mllx2ALXh9dfmsf0V87CGEodlZQmMgUJotNIsUw==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.233.tgz",
+      "integrity": "sha512-4WDiBZgcrmvTDJjS8RNZwoxGgMz/0EpOM+sYa6EtyjwHTd6It1H/+k5zBckCmBajbgS5/ASCJqdwZzi7dwBl0Q==",
       "cpu": [
         "arm64"
       ],
@@ -120,9 +120,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.198.tgz",
-      "integrity": "sha512-XwH5vgN46WSwg8aC1OagNofnJpV/G1ciEu118GEKer8ZhVkq/dvK/DqShxMkb6r1jV7u5IJ7zPXu9uKliyNJAw==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.233.tgz",
+      "integrity": "sha512-RaaEfNrbqSh77H5NdVF9cJQ0xhAUO92aOv71LSKSdAYModMeUvJN0k22Q7gvmx0TlmqJ+aVyCG8J8gVfgSL9mg==",
       "cpu": [
         "x64"
       ],
@@ -133,9 +133,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.198.tgz",
-      "integrity": "sha512-qmz8dxEtDIlKntU5qYe0R4aWTxTue5S7zIQknatLX7aJ6HN/nq1aCNXWn5smTH2FViBkUPPR+sCIsNwSk6AT6Q==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.233.tgz",
+      "integrity": "sha512-Az9HjQthYQqRjJCacBtDIAHX3TRGK9WlACNb/UOGAK3JndNzZMprM2mK/t6YmP2cRLJsGyorxL7HZmR9R9HYaw==",
       "cpu": [
         "arm64"
       ],
@@ -146,9 +146,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.198.tgz",
-      "integrity": "sha512-Q7lKVNjIrUQ2B/AR77OvRf0zeOdEjonFVaR9FYrrwtzGeEqum69WSht5nM7Y7el3wjbNi0/eV0QTUM0DlsTEfw==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.233.tgz",
+      "integrity": "sha512-Z3uZdzt6xgJ3f4NIgO6lzBYSELULKSq6AL4OsNLBzuaEpVW0iYs1kUCaD9rcMlMrf3cV+Dk/GA/lTCGMgbucjQ==",
       "cpu": [
         "arm64"
       ],
@@ -159,9 +159,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.198.tgz",
-      "integrity": "sha512-Zqxyz2AT1UM5WlOOoLJhLssZDgZo8rBK5ku6daveK12zp+UTJGZhGsjFghz1/ASxH08KqOTbUePNTORnPhHAEQ==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.233.tgz",
+      "integrity": "sha512-jpbhV+n9PnxLiyheQ/HjtHIg/E5/jVsk2Vdu132BSoL/3bsObSmMqKgsqoMutzwRZvtpqRs2RPVcjsC8G4A9Zw==",
       "cpu": [
         "x64"
       ],
@@ -172,9 +172,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.198.tgz",
-      "integrity": "sha512-h1SrWVIMjLInYNPlf+TxXuKTOdoiOfJLBSoQG97315Z2Nh0IpBfqWExlqYTtPCgKE7q2iga31U283QfHpIDlSQ==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.233.tgz",
+      "integrity": "sha512-kYBIAQCu2f1YITcGbpUN2jfrkAzs59TVAragAhE2z+GrkIcxcpZwmaRY6heMBtaSY8SuyrwgqbCW9hJALYFnEg==",
       "cpu": [
         "x64"
       ],
@@ -185,9 +185,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.198.tgz",
-      "integrity": "sha512-mjIHf1HFiRuXefewWTaNZFlTZlCaEt/xsRjc1nSTCEEpFolZayVhrDKz+O2QFVcDtPl8x8GeYSL0kiikg1DZjQ==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.233.tgz",
+      "integrity": "sha512-aO2MaNdmQofyPLKszE4s+Ope/sLJPeI/ZlGdCcjYp7qhji2hgZ4bRWWsOrx5eKjz0gFK5CFFltILkFcNcxCsVg==",
       "cpu": [
         "arm64"
       ],
@@ -198,9 +198,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.198",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.198.tgz",
-      "integrity": "sha512-y3HLuCCz1kDwUrhd6OnqO+d5BUpTFSzNUsPT9kf3r1vk9HYKF+eMC9eIlcOhiW2kX491kxEvuEOfqgIkGx15cg==",
+      "version": "0.3.233",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.233.tgz",
+      "integrity": "sha512-TcAYyWPXS5mREZGUksuCZsLIRQjbo/Vriur2PqIhAmgZ1oiqBZO27a90sX60EUczD7yV8wpwOVhVLhUxO0kAEg==",
       "cpu": [
         "x64"
       ],
@@ -596,9 +596,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.142.4",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4.tgz",
-      "integrity": "sha512-BW9+3Cs7tChgkc0QhUsZIDm6XgpSDSeJkljRSHhJZqDwlaxDnNVhRP/sZwhgrTn3f2jPn3jc4WTKfLOTk+g5pA==",
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0.tgz",
+      "integrity": "sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -607,19 +607,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.142.4-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.142.4-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.142.4-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.142.4-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.142.4-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.142.4-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.147.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.147.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.147.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.147.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.147.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.147.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.4-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-darwin-arm64.tgz",
-      "integrity": "sha512-CfXp5jilBOxD8zLuG6Nk7w5ZPP3roE3s1rsr60za9PQKI7kaJ/5G+oP3Z0N1CoB4mpy+5JHkMLTZAZZPGFlSgQ==",
+      "version": "0.147.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
+      "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
       "cpu": [
         "arm64"
       ],
@@ -634,9 +634,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.142.4-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-darwin-x64.tgz",
-      "integrity": "sha512-H9ia31pkJFtBk+UrREAfJiTUfcvgactKbG4W4SF2LFfJOTRsrsJZGtscHQ8/lLGeKEfOk/psrbSOPDyrZnxvnQ==",
+      "version": "0.147.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
+      "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
       "cpu": [
         "x64"
       ],
@@ -651,9 +651,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.4-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-linux-arm64.tgz",
-      "integrity": "sha512-/bBcEm+OKmlGHH0c88jrVgYMRyaNC/hGOW/znP/PiHQEeIf4UdsUGQ7x4FAZm648140cgaeKYIBoRBbHizS+5w==",
+      "version": "0.147.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
+      "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
       "cpu": [
         "arm64"
       ],
@@ -668,9 +668,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.142.4-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-linux-x64.tgz",
-      "integrity": "sha512-t3tNOkDdiO5/gRqkTmuMcAj5JjCbeWotOJzxV7pPkD2u2KvzVRrk7jPAjuy+85wPc12lsIupYgxHlK7CkVLOjA==",
+      "version": "0.147.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
+      "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
       "cpu": [
         "x64"
       ],
@@ -685,9 +685,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.142.4-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-win32-arm64.tgz",
-      "integrity": "sha512-QBGeoYk3pmVscVIxeW21cvPJIjsnmD5dOTqMAzypXGik5soNIKHbps2Kj1LBKOjVbbx5qoDEbTwDfYmnjfqgdQ==",
+      "version": "0.147.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
+      "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==",
       "cpu": [
         "arm64"
       ],
@@ -702,9 +702,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.142.4-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.142.4-win32-x64.tgz",
-      "integrity": "sha512-W0rSPT0t7FnKlJYNu9/HpHzaSOutuSSYjIVunKorYmrScXk9pQxBEhEuyn16JOtywc/2nX8nHEmWsuj2sd8suw==",
+      "version": "0.147.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
+      "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   "homepage": "https://github.com/chadbyte/clay#readme",
   "author": "Chad",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.198",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.233",
     "@lydell/node-pty": "^1.2.0-beta.3",
-    "@openai/codex": "^0.142.4",
+    "@openai/codex": "^0.147.0",
     "imapflow": "^1.3.1",
     "nodemailer": "^6.10.1",
     "qrcode-terminal": "^0.12.0",

--- a/test/codex-defaults.test.js
+++ b/test/codex-defaults.test.js
@@ -1,0 +1,17 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+var codexDefaults = require("../lib/codex-defaults");
+
+test("Codex approval policy accepts current SDK values", function() {
+  var policies = codexDefaults.CODEX_APPROVAL_POLICIES;
+  for (var i = 0; i < policies.length; i++) {
+    assert.strictEqual(codexDefaults.normalizeCodexApproval(policies[i]), policies[i]);
+  }
+});
+
+test("Codex approval policy migrates removed and invalid values", function() {
+  assert.strictEqual(codexDefaults.normalizeCodexApproval("on-failure"), "on-request");
+  assert.strictEqual(codexDefaults.normalizeCodexApproval("invalid"), "on-request");
+  assert.strictEqual(codexDefaults.normalizeCodexApproval(), "on-request");
+});

--- a/test/helpers/yoke-adapter-fixtures.js
+++ b/test/helpers/yoke-adapter-fixtures.js
@@ -1,0 +1,186 @@
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+
+var claudeModule = require("../../lib/yoke/adapters/claude");
+var codexModule = require("../../lib/yoke/adapters/codex");
+var kiroModule = require("../../lib/yoke/adapters/kiro");
+var CodexAppServer = require("../../lib/yoke/codex-app-server").CodexAppServer;
+
+function emptyAsyncQuery() {
+  return {
+    [Symbol.asyncIterator]: function() {
+      return { next: function() { return Promise.resolve({ done: true }); } };
+    },
+    setModel: function() { return Promise.resolve(); },
+    setPermissionMode: function() { return Promise.resolve(); },
+    stopTask: function() { return Promise.resolve(); },
+    getContextUsage: function() { return Promise.resolve(null); },
+    close: function() {},
+  };
+}
+
+function createClaudeHandle() {
+  var kit = claudeModule.contractTestKit;
+  return kit.createQueryHandle(emptyAsyncQuery(), kit.createMessageQueue(), new AbortController());
+}
+
+function createCodexHandle() {
+  var server = {
+    started: true,
+    eventHandler: null,
+    send: function() { return Promise.resolve({}); },
+    notify: function() {},
+    respond: function() {},
+  };
+  return codexModule.contractTestKit.createQueryHandle(server, {
+    cwd: process.cwd(),
+    model: "contract-model",
+    abortController: new AbortController(),
+  });
+}
+
+function createKiroHandle() {
+  var handlers = [];
+  var server = {
+    started: true,
+    addHandler: function(fn) {
+      var entry = { sessionId: null, fn: fn };
+      handlers.push(entry);
+      return entry;
+    },
+    removeHandler: function(entry) {
+      var index = handlers.indexOf(entry);
+      if (index !== -1) handlers.splice(index, 1);
+    },
+    send: function() { return Promise.resolve({}); },
+    notify: function() {},
+    respond: function() {},
+  };
+  return kiroModule.contractTestKit.createQueryHandle(server, {
+    cwd: process.cwd(),
+    model: "auto",
+    abortController: new AbortController(),
+  });
+}
+
+function requireFunctions(target, names) {
+  for (var i = 0; i < names.length; i++) {
+    if (typeof target[names[i]] !== "function") {
+      throw new Error("Missing required function: " + names[i]);
+    }
+  }
+}
+
+function createFixtures() {
+  return [
+    {
+      vendor: "claude",
+      createAdapter: function() { return claudeModule.createClaudeAdapter({ cwd: process.cwd() }); },
+      createHandle: createClaudeHandle,
+      createState: function() { return null; },
+      normalize: claudeModule.contractTestKit.normalizeEvent,
+      rawEvents: [
+        { type: "stream_event", event: { type: "content_block_start", index: 0, content_block: { type: "text" } } },
+        { type: "stream_event", event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hello" } } },
+        { type: "stream_event", event: { type: "content_block_start", index: 1, content_block: { type: "thinking" } } },
+        { type: "stream_event", event: { type: "content_block_delta", index: 1, delta: { type: "thinking_delta", thinking: "why" } } },
+        { type: "stream_event", event: { type: "content_block_start", index: 2, content_block: { type: "tool_use", id: "tool-1", name: "Bash" } } },
+        { type: "result", session_id: "claude-session" },
+      ],
+      expectedEvents: [
+        { yokeType: "text_start", blockId: "blk_0" },
+        { yokeType: "text_delta", blockId: "blk_0", text: "hello" },
+        { yokeType: "thinking_start", blockId: "blk_1" },
+        { yokeType: "thinking_delta", blockId: "blk_1", text: "why" },
+        { yokeType: "tool_start", blockId: "blk_2", toolId: "tool-1", toolName: "Bash" },
+        { yokeType: "result", sessionId: "claude-session" },
+      ],
+      verifyDependency: async function() {
+        var sdk = await import("@anthropic-ai/claude-agent-sdk");
+        requireFunctions(sdk, ["query", "createSdkMcpServer", "tool", "getSessionInfo", "listSessions", "renameSession", "forkSession"]);
+      },
+    },
+    {
+      vendor: "codex",
+      createAdapter: function() { return codexModule.createCodexAdapter({ cwd: process.cwd() }); },
+      createHandle: createCodexHandle,
+      createState: function() { return codexModule.contractTestKit.createEventState("contract-model"); },
+      normalize: codexModule.contractTestKit.normalizeEvent,
+      rawEvents: [
+        { method: "thread/started", params: { thread: { id: "codex-session" } } },
+        { method: "item/agentMessage/delta", params: { itemId: "msg-1", delta: "hello" } },
+        { method: "item/completed", params: { item: { id: "reason-1", type: "reasoning", text: "why" } } },
+        { method: "item/started", params: { item: { id: "tool-1", type: "commandExecution", command: "pwd" } } },
+        { method: "item/completed", params: { item: { id: "tool-1", type: "commandExecution", command: "pwd", aggregated_output: "/tmp", status: "completed" } } },
+        { method: "turn/completed", params: {} },
+      ],
+      expectedEvents: [
+        { yokeType: "text_start", blockId: "blk_1" },
+        { yokeType: "text_delta", blockId: "blk_1", text: "hello" },
+        { yokeType: "thinking_start", blockId: "blk_2" },
+        { yokeType: "thinking_delta", blockId: "blk_2", text: "why" },
+        { yokeType: "thinking_stop", blockId: "blk_2" },
+        { yokeType: "tool_start", blockId: "blk_3", toolId: "tool-1", toolName: "Bash" },
+        { yokeType: "tool_executing", blockId: "blk_3", toolId: "tool-1", toolName: "Bash" },
+        { yokeType: "tool_result", blockId: "blk_3", toolId: "tool-1", content: "/tmp", isError: false },
+        { yokeType: "result", sessionId: "codex-session" },
+      ],
+      verifyDependency: async function() {
+        var codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "clay-codex-contract-"));
+        var server = new CodexAppServer(null, {
+          cwd: process.cwd(),
+          env: { CODEX_HOME: codexHome },
+        });
+        try {
+          await server.start();
+          var result = await server.send("initialize", {
+            clientInfo: { name: "clay-contract-harness", title: "Clay Contract Harness", version: "1.0.0" },
+            capabilities: { experimentalApi: true },
+          }, 10000);
+          if (!result || !result.userAgent) throw new Error("Codex initialize response is missing userAgent");
+          server.notify("initialized", {});
+          var thread = await server.send("thread/start", {
+            model: "gpt-5.4-mini",
+            sandbox: "read-only",
+            approvalPolicy: "on-request",
+            cwd: process.cwd(),
+            skipGitRepoCheck: true,
+          }, 10000);
+          if (!thread || !thread.thread || !thread.thread.id) {
+            throw new Error("Codex thread/start response is missing a thread id");
+          }
+        } finally {
+          server.stop();
+          fs.rmSync(codexHome, { recursive: true, force: true });
+        }
+      },
+    },
+    {
+      vendor: "kiro",
+      createAdapter: function() { return kiroModule.createKiroAdapter({ cwd: process.cwd(), _binaryPath: "/contract/kiro-cli" }); },
+      createHandle: createKiroHandle,
+      createState: function() { return kiroModule.contractTestKit.createEventState({ model: "auto" }); },
+      normalize: kiroModule.contractTestKit.normalizeEvent,
+      rawEvents: [
+        { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "hello" } },
+        { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "why" } },
+        { sessionUpdate: "tool_call", toolCallId: "tool-1", kind: "execute", title: "Run", rawInput: { command: "pwd" } },
+        { sessionUpdate: "tool_call_update", toolCallId: "tool-1", content: [{ type: "content", content: { type: "text", text: "/tmp" } }] },
+        { sessionUpdate: "tool_call_update", toolCallId: "tool-1", status: "completed", rawOutput: { output: "/tmp" } },
+      ],
+      expectedEvents: [
+        { yokeType: "text_start", blockId: "blk_1" },
+        { yokeType: "text_delta", blockId: "blk_1", text: "hello" },
+        { yokeType: "thinking_start", blockId: "blk_2" },
+        { yokeType: "thinking_delta", blockId: "blk_2", text: "why" },
+        { yokeType: "tool_start", blockId: "blk_3", toolId: "tool-1", toolName: "Bash" },
+        { yokeType: "tool_executing", blockId: "blk_3", toolId: "tool-1", toolName: "Bash" },
+        { yokeType: "tool_result", blockId: "blk_3", toolId: "tool-1", content: "/tmp", isError: false },
+      ],
+      verifyDependency: function() { return Promise.resolve(); },
+    },
+  ];
+}
+
+module.exports = { createFixtures: createFixtures };

--- a/test/yoke-adapter-contract.test.js
+++ b/test/yoke-adapter-contract.test.js
@@ -1,0 +1,58 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+var iface = require("../lib/yoke/interface");
+var fixtures = require("./helpers/yoke-adapter-fixtures").createFixtures();
+
+var SNAPSHOT_KEYS = [
+  "yokeType",
+  "blockId",
+  "text",
+  "toolId",
+  "toolName",
+  "content",
+  "isError",
+  "sessionId",
+];
+
+function projectEvent(event) {
+  var projected = {};
+  for (var i = 0; i < SNAPSHOT_KEYS.length; i++) {
+    var key = SNAPSHOT_KEYS[i];
+    if (event[key] !== undefined) projected[key] = event[key];
+  }
+  return projected;
+}
+
+function normalizeFixture(fixture) {
+  var state = fixture.createState();
+  var events = [];
+  for (var i = 0; i < fixture.rawEvents.length; i++) {
+    var normalized = fixture.normalize(fixture.rawEvents[i], state);
+    var batch = Array.isArray(normalized) ? normalized : [normalized];
+    for (var j = 0; j < batch.length; j++) {
+      if (batch[j]) events.push(projectEvent(batch[j]));
+    }
+  }
+  return events;
+}
+
+for (var i = 0; i < fixtures.length; i++) {
+  (function(fixture) {
+    test(fixture.vendor + " adapter satisfies the shared YOKE contract", function() {
+      var adapter = fixture.createAdapter();
+      var handle = fixture.createHandle();
+      iface.validateAdapter(adapter);
+      iface.validateQueryHandle(handle);
+      handle.close();
+    });
+
+    test(fixture.vendor + " protocol snapshot normalizes to stable YOKE events", function() {
+      assert.deepStrictEqual(normalizeFixture(fixture), fixture.expectedEvents);
+    });
+
+    test(fixture.vendor + " runtime dependency exposes the required surface", async function() {
+      await fixture.verifyDependency();
+    });
+  })(fixtures[i]);
+}


### PR DESCRIPTION
## Summary
- add one table-driven YOKE adapter contract harness for Claude, Codex, and Kiro
- pin the current stable Claude Agent SDK 0.3.233 and Codex 0.147.0 dependency ranges
- exercise Codex app-server initialization and thread creation in an isolated CODEX_HOME
- migrate the removed Codex on-failure approval policy to on-request, including stored legacy values and UI options

## Why
Vendor protocol and SDK changes must be caught at the shared adapter boundary. The Codex upgrade demonstrated this by rejecting the former on-failure approval policy.

## Impact
The harness is static and account-independent. It validates adapter/query interfaces, fixed raw-protocol normalization snapshots, and packaged runtime surfaces. Existing Codex approval settings using on-failure are normalized to on-request.

## Verification
- npm test (55/55)
- clean temporary checkout: npm ci --ignore-scripts, then npm test (55/55)
- shared adapter contract harness (9/9)
- Codex live smoke through the adapter with on-request and read-only sandbox
- all 81 client imports resolve
- syntax checks and git diff --check