### PR TITLE
feat(sessions): agent-driven session spawning with context inheritance

### DIFF
--- a/docs/guides/MODULE_MAP.md
+++ b/docs/guides/MODULE_MAP.md
@@ -48,6 +48,8 @@ Wires all modules, sets up session manager and SDK bridge, dispatches messages.
 | `project-http.js` | All HTTP routes: image serving, file upload, push, skills, git status, info |
 | `project-image.js` | `hydrateImageRefs`, `saveImageFile`, image directory setup |
 | `project-file-watch.js` | File and directory fs.watch wrappers |
+| `project-session-spawn.js` | Agent-driven sibling session creation, safety policy, and concurrency queue |
+| `session-spawn-mcp-server.js` | SDK-free `clay-sessions` MCP tool definitions for spawning and checking sessions |
 | `sdk-bridge.js` | SDK bridge coordinator: createSDKBridge factory, worker lifecycle, query stream, tool permissions, mention sessions |
 | `sdk-skill-discovery.js` | Skill directory scanning, shell segment splitting, SDK/filesystem skill merging |
 | `safe-bash-commands.js` | **Single source of truth** for auto-approved bash commands. Consumed by sdk-bridge.js (`isSafeBashSegment`) and claude-hook-installer.js (`buildClayBashAllowPatterns`) - do not duplicate command lists elsewhere |

--- a/docs/ongoing/session-spawn-handoff.md
+++ b/docs/ongoing/session-spawn-handoff.md
@@ -1,6 +1,6 @@
 # Handoff: agent-driven session spawning (issue #358)
 
-**Status:** proposed / ready to implement
+**Status:** MVP implemented (commit 5fc36eb, session-bound tool servers included) / phase 2 ready to implement
 **Author:** handoff from Chad + Claude, 2026-08-15
 **Branch:** start from `main`
 **Issue:** https://github.com/chadbyte/clay/issues/358 ("I have 10 issues and
@@ -144,21 +144,134 @@ later if asked). In `getLocalMcpServers()` no dynamic condition is needed
 beyond that static gate, but keep the hook in mind if spawn ever becomes
 config-gated.
 
-### What the MVP does NOT include (phase 2, do not build now)
+### Delivered by the MVP (commit 5fc36eb)
 
-- `forkFromCurrent`: seeding children with parent context via
-  `sdk.forkSession`. Claude-only (capability `fork`), interacts with uuid
-  selection ("fork from the latest message"). Design note: when built, gate
-  on `sm.capabilitiesByVendor[vendor].fork` and require child vendor ===
-  parent vendor.
-- Sidebar grouping of children under the parent (the loop-group UI in
-  `sidebar-sessions.js` is the template). MVP children are ordinary
-  sessions with clear titles.
-- Parent auto-notification when all children finish (a system message into
-  the parent session). `check_spawned_sessions` polling covers the MVP.
-- Issue #357 (vendor handoff) builds on this: new session + first-message
-  injection is the shared core. Keep `spawnOne(opts)` factored so a future
-  handoff path can call it with a context package.
+Everything above is implemented, plus one correction over this document's
+original text: tool servers are **bound per query** to the calling session
+(`getLocalMcpServers(forSession)` in `lib/project.js`,
+`getMcpServers(session)` in `lib/sdk-bridge.js:1334`). Never resolve the
+caller via `sm.getActiveSession()` — that is the project-global "last
+viewed" session and breaks the depth guard; the unbound descriptor-listing
+instance fails closed by design. Keep this invariant in phase 2.
+
+### Out of scope for phase 2 as well (do not build)
+
+- Sidebar grouping of children under the parent (loop-group UI is the
+  template when it happens).
+- Parent auto-notification when all children finish; polling covers it.
+- Worktree-per-child isolation. In Clay a worktree is a separate project
+  (own slug and project context, see `lib/daemon-projects.js`), so spawning
+  into worktrees is cross-project orchestration — a phase 3 design of its
+  own. Phase 2 children share the parent's cwd; the tool description
+  should keep advising analysis-style parallelism over concurrent edits.
+- Issue #357 (vendor handoff) still builds on `spawnOne`; unchanged.
+
+---
+
+## Phase 2: `forkFromCurrent` (context-inheriting spawn)
+
+**Goal:** the pattern promised in issue #358's thread (Karamorf's fork
+workflow, endorsed by the maintainer comment): load context once into the
+parent, then fan out children that START with that context, no re-explaining.
+
+### Existing fork pipeline (verified, reuse it)
+
+The UI fork already does everything per child; steal its recipe from
+`lib/project-sessions.js:1220-1266`:
+
+1. `sdk.forkSession(session, uuid)` -> resolves `{ sessionId: <new
+   cliSessionId>, useLocalHistory: <bool> }` (`forkSessionUnified`,
+   `lib/sdk-bridge.js:1065`, which calls
+   `adapter.forkSession(session.cliSessionId, { upToMessageId: uuid, dir: cwd })`).
+2. If `useLocalHistory`: copy the parent's local `history` (the UI trims to
+   the uuid's `historyIndex`; for full-context spawn just copy
+   `session.history.slice()`), rebuild `messageUUIDs` from `message_uuid`
+   entries, set `forked.cliSessionId = result.sessionId`.
+3. Else: `require("./cli-sessions").readCliSessionHistory(resolveSessionHome(session), cwd, result.sessionId)`
+   provides the display history.
+4. A later `startQuery` on the child resumes the forked CLI session because
+   `resumeSessionId: session.cliSessionId` (`lib/sdk-bridge.js` queryOpts) —
+   that is what actually gives the agent the parent context. The local
+   history copy is only for the transcript UI.
+
+### Tool surface change
+
+Add one optional input to `spawn_sessions`:
+
+- `forkFromCurrent` (boolean, default false): "Children start with a copy
+  of this session's full conversation context."
+
+No new tool. `check_spawned_sessions` unchanged.
+
+### Implementation in `attachSessionSpawn`
+
+In `spawn(args, caller)` when `args.forkFromCurrent` is true, validate
+BEFORE creating anything:
+
+1. `caller.cliSessionId` must exist (the parent has completed at least one
+   turn). Error text: "forkFromCurrent requires the calling session to have
+   at least one completed turn".
+2. Capability gate: `sm.capabilitiesByVendor[vendor]` must have
+   `fork: true`. Note the capabilities map is only populated after adapter
+   init (the parent is mid-query, so its own vendor is always initialized —
+   but guard anyway and fail with a clear error).
+3. Vendor lock: an explicit `args.vendor` different from `caller.vendor`
+   is an error ("forkFromCurrent children must use the parent's vendor") —
+   a fork is a CLI-native session copy and cannot change runtime.
+4. Fork uuid: use the LAST entry of `caller.messageUUIDs` (full context).
+   If `messageUUIDs` is empty but `cliSessionId` exists, still call
+   forkSession with the last uuid absent — check what
+   `adapter.forkSession` does with `upToMessageId: undefined` before
+   relying on it; if it throws, treat as error (1) instead.
+
+Then per child, BEFORE queueing (serially, in batch order):
+
+- `await sdk.forkSession(caller, lastUuid)` -> `{ sessionId, useLocalHistory }`.
+- Create the child exactly as the MVP does, then set
+  `child.cliSessionId = sessionId` and copy the display history per the
+  recipe above (both `useLocalHistory` branches).
+- The queued `start()` is unchanged: push the task prompt as a
+  `user_message` and `startQuery` — the query resumes the forked CLI
+  session, so the agent sees parent context + its task prompt.
+
+Failure handling: fork the children serially; if fork N fails, stop there
+and return a tool result containing both `spawned` (the ones that made it,
+already queued) and `failed: { index, error }`. Do not attempt rollback:
+orphaned forked CLI sessions are inert JSONL copies and Clay sessions
+already created are visible/deletable in the sidebar. The agent gets an
+honest partial report.
+
+Concurrency note: `sdk.forkSession` calls are awaited one at a time before
+`queue.add` — do not interleave them with running child queries writing to
+the same parent JSONL.
+
+### Tests to add (extend `test/session-spawn.test.js`)
+
+1. forkFromCurrent happy path: fake `sdk.forkSession` returning
+   `{ sessionId: "cli-fork-N", useLocalHistory: true }`; assert each child
+   gets its own `cliSessionId`, a copied history array (not the same
+   reference as the parent's), and that the task prompt is appended AFTER
+   the copied history when `start()` runs.
+2. Parent without `cliSessionId` -> exact error, nothing created.
+3. Capability gate: `capabilitiesByVendor` lacking `fork` -> error.
+4. Vendor mismatch with `forkFromCurrent` -> error.
+5. Partial failure: `forkSession` rejects on the 2nd child -> result lists
+   1 spawned + the failure; queue only received the 1st task.
+6. All existing tests stay green (default `forkFromCurrent: false` path
+   must be byte-for-byte the MVP behavior).
+
+### Phase 2 acceptance criteria
+
+1. Live: load a plan into a parent session, spawn 3 children with
+   `forkFromCurrent: true`, and each child demonstrably knows the plan
+   without it appearing in its task prompt (ask each child "what plan are
+   you working from?").
+2. Child transcripts in the UI show the inherited conversation followed by
+   their own task prompt.
+3. Fresh-spawn path (default) behaves exactly as before.
+4. Error paths above verified; `npm test` green; sweeps green.
+5. Issue #358 can be closed referencing both the MVP and this phase
+   (draft the closing comment for Chad's approval — never post without it).
 
 ---
 

--- a/docs/ongoing/session-spawn-handoff.md
+++ b/docs/ongoing/session-spawn-handoff.md
@@ -307,3 +307,26 @@ awkward) and test:
    new suite; all static sweeps green.
 5. No auto-approve entries added anywhere for `mcp__clay-sessions__*`.
 6. `docs/guides/MODULE_MAP.md` gains rows for the two new files.
+
+---
+
+## Verification log
+
+### 2026-08-16 — phase 2 verified
+
+- 78/78 tests (6 new fork tests), syntax sweeps and import check green.
+- Code-verified the fork semantics the implementation relies on: Claude SDK
+  `ForkSessionOptions.upToMessageId` "If omitted, full copy" (sdk.d.ts:708),
+  Codex `thread/fork` ignores the uuid option (codex.js:1567),
+  `readCliSessionHistory` resolves [] on errors (no spurious fork failures).
+- Live E2E on the dev daemon: context planted in a parent ("Spiderman"
+  codename + three rules), two forkFromCurrent children spawned via the
+  spawn_sessions permission card; both children knew the codename and rules
+  without them appearing in their task prompts. Depth guard and permission
+  prompt behaved as designed.
+- Known cosmetic limitation: codex forkFromCurrent children resume with full
+  context but their Clay transcript shows only the task prompt (codex fork
+  reads no local JSONL); same behavior as the existing UI fork on codex.
+- Gotcha reconfirmed: server-side changes need a daemon restart; a stale
+  daemon leaves the tools unmounted and the agent improvises with
+  `claude --fork-session` in Bash.

--- a/docs/ongoing/session-spawn-handoff.md
+++ b/docs/ongoing/session-spawn-handoff.md
@@ -1,0 +1,196 @@
+# Handoff: agent-driven session spawning (issue #358)
+
+**Status:** proposed / ready to implement
+**Author:** handoff from Chad + Claude, 2026-08-15
+**Branch:** start from `main`
+**Issue:** https://github.com/chadbyte/clay/issues/358 ("I have 10 issues and
+I want a session per issue... I want one session to create 10 new ones")
+
+---
+
+## Mission
+
+Let an agent session create N sibling sessions, each with its own title and
+starting prompt, so a user can say "make one session per issue" and have the
+parent fan the work out. MVP is an in-app MCP tool; every building block
+already exists in the codebase and is listed below with file:line.
+
+## Constraints (same as every clay handoff)
+
+- Root `CLAUDE.md`: `var` only, no arrow functions, CommonJS server-side,
+  English comments/commits, Angular commits, modules under 500 lines, no
+  inline logic in `project.js` handleMessage, read
+  `docs/guides/MODULE_MAP.md` first.
+- Do not commit/push/PR without explicit approval from Chad.
+- Keep green: `npm test`, both `node --check` sweeps,
+  `node scripts/check-client-imports.js`.
+
+---
+
+## Existing building blocks (verified)
+
+| Mechanic | Where | Note |
+|---|---|---|
+| Programmatic session creation | `sm.createSession(sessionOpts)` — used by loop (`lib/project-loop.js:415`) and debate (`lib/project-debate.js:529`) | `sessionOpts` supports `ownerId`, `vendor`, `sessionVisibility` |
+| Start a session with a prompt | `sdk.startQuery(session, promptText, undefined, linuxUser)` (`lib/project-loop.js:511`) | linuxUser via the same resolution loop uses (`getLinuxUserForSession`) |
+| Completion hook | `session.onQueryComplete = function(completedSession) {...}` — loop uses it (`lib/project-loop.js:435`); consumed at `lib/sdk-bridge.js:950,968` | drives the concurrency queue below |
+| In-app MCP tool pattern | `lib/debate-mcp-server.js` (SDK-free tool defs + `buildShape` zod helper) wired in `lib/project.js:482-501` via `adapter.createToolServer({ name, version, tools })` | copy this shape exactly |
+| Per-project MCP gating | `getLocalMcpServers()` (`lib/project.js:643-660`) filters servers by availability | add the spawn gate here |
+| Session fork (phase 2) | `fork_session` WS flow (`lib/project-sessions.js:1220`), `sdk.forkSession(session, uuid)` -> `forkSessionUnified` (`lib/sdk-bridge.js:1065`), adapter capability `fork` (claude: true) | fork carries parent context into the child |
+| Vendor validity | `adapters[vendor]` presence + `sm.capabilitiesByVendor`, plus the vendor registry (`lib/yoke/vendor-registry.js`): `osUserIsolation` gates kiro for isolated users | reuse, do not re-hardcode vendor names |
+
+No new WS message types are needed for the MVP: children appear through the
+existing `session_list` broadcast (`sm.broadcastSessionList()`), and the tool
+result returns their ids to the parent agent.
+
+---
+
+## Design
+
+### New files
+
+1. **`lib/session-spawn-mcp-server.js`** (SDK-free, mirrors
+   `debate-mcp-server.js`): tool definitions only, handlers delegate to
+   callbacks injected from the attach module.
+
+2. **`lib/project-session-spawn.js`**: `attachSessionSpawn(ctx)` owning all
+   orchestration state. Exposes `{ createMcpServer }`. `ctx` needs: `sm`,
+   `getSdk` (late-bound; the sdk bridge is created after mcpServers in
+   project.js, so inject a getter, not the instance), `send`, `isMate`,
+   `usersModule`, `getSessionForWs` is NOT needed (MCP handlers do not have
+   a ws; resolve the calling session instead, see "parent resolution").
+
+### Tools (MCP server name: `clay-sessions`)
+
+**`spawn_sessions`**
+- Input: `sessions` (JSON string, array of `{ "title": string, "prompt":
+  string }`), `vendor` (optional string; default = parent session's vendor,
+  else project default). JSON-string array input follows the
+  `propose_debate` precedent (`debate-mcp-server.js:45`) because
+  `buildShape` only supports flat primitives.
+- Validates, creates each session, queues their queries, returns
+  `{ spawned: [{ localId, title }], queued: n, running: n }` as the tool
+  text (JSON stringified).
+
+**`check_spawned_sessions`**
+- No input (or optional `parentOnly` boolean, default true).
+- Returns each child of the calling session: `{ localId, title, status:
+  "running" | "done" | "error", turnCount, lastActivity }`. Status: running
+  = `isProcessing`; error = last history entries contain `type: "error"` or
+  `done` with code 1 (same heuristic as `lib/project-loop.js:441-449`);
+  else done. This closes the loop: the parent can poll and summarize.
+
+### Parent resolution
+
+MCP tool handlers receive only tool args, no session. Resolve the caller the
+same way debate does: the tool server is per-project and the handler runs
+during a specific session's turn. Follow how `_pendingDebateProposals` +
+`tool_executing` correlate, or simpler: thread the calling session through
+`createToolServer` if the adapter supports per-session tool context. If
+neither is clean, fall back to what ask-user does (`lib/project.js:521+`,
+stateless post). REQUIRED: the implementing agent must read how
+`propose_debate`'s handler learns which session called it, and use the same
+mechanism. Do not guess; if the answer is "the project's active session",
+document that limitation in the tool description.
+
+### Session record
+
+Children get:
+
+```js
+session.spawn = {
+  parentId: <parent localId>,
+  index: i,            // position in the batch
+  batchId: "sp_" + Date.now().toString(36),
+};
+session.title = args title (trimmed, fallback "Spawned task " + (i+1));
+session.ownerId / visibility inherited from parent;
+session.vendor = resolved vendor;
+```
+
+Persist with `sm.saveSessionFile(session)` and broadcast once per batch.
+
+### Safety rails (all hard requirements)
+
+1. **No grandchildren.** If the calling session has `session.spawn`, the
+   tool returns an error ("spawned sessions cannot spawn further sessions").
+   This is the fan-out bomb guard.
+2. **Caps.** Max 10 sessions per call, max 20 live children per parent
+   (count children whose `spawn.parentId` matches). Constants at the top of
+   `project-session-spawn.js`.
+3. **Concurrency queue.** Do not start 10 SDK queries at once. Start at most
+   `SPAWN_CONCURRENCY = 3`; queue the rest; on each child's
+   `onQueryComplete`, start the next queued one. Children are fresh sessions
+   so the `onQueryComplete` slot is free (loop/auto-continue only set it on
+   their own sessions; see `lib/sdk-bridge.js:950`).
+4. **Permissions.** Do NOT add `mcp__clay-sessions__*` to the auto-approve
+   block in `lib/sdk-bridge.js` (the clay-history/email pattern) and do NOT
+   add it to `CLAY_MANAGED_ALLOW` in `lib/claude-hook-installer.js`.
+   Spawning is powerful; the default permission prompt must fire. In
+   allow-all/bypass sessions it will auto-run, which is consistent with what
+   the user opted into.
+5. **Vendor guards.** Reject a vendor with no adapter in `adapters`; reject
+   a vendor whose registry entry has `osUserIsolation: false` when the
+   parent runs as an isolated linuxUser (mirror `lib/sdk-bridge.js:1111`
+   semantics through the registry, never `vendor === "kiro"`).
+6. **linuxUser inheritance.** Children run as the parent's Linux user (same
+   resolution loop uses: owner's linuxUser in multi-user mode).
+
+### Gating
+
+In `lib/project.js` mcpServers block: register `clay-sessions` only when
+`!isMate` (mate DMs are conversations, not work fan-out surfaces; revisit
+later if asked). In `getLocalMcpServers()` no dynamic condition is needed
+beyond that static gate, but keep the hook in mind if spawn ever becomes
+config-gated.
+
+### What the MVP does NOT include (phase 2, do not build now)
+
+- `forkFromCurrent`: seeding children with parent context via
+  `sdk.forkSession`. Claude-only (capability `fork`), interacts with uuid
+  selection ("fork from the latest message"). Design note: when built, gate
+  on `sm.capabilitiesByVendor[vendor].fork` and require child vendor ===
+  parent vendor.
+- Sidebar grouping of children under the parent (the loop-group UI in
+  `sidebar-sessions.js` is the template). MVP children are ordinary
+  sessions with clear titles.
+- Parent auto-notification when all children finish (a system message into
+  the parent session). `check_spawned_sessions` polling covers the MVP.
+- Issue #357 (vendor handoff) builds on this: new session + first-message
+  injection is the shared core. Keep `spawnOne(opts)` factored so a future
+  handoff path can call it with a context package.
+
+---
+
+## Tests
+
+`test/session-spawn.test.js` (node:test, CommonJS). Extract the pure logic
+(cap checks, depth guard, batch parsing/validation, queue advancement) into
+exported helpers on `project-session-spawn.js` (or a small
+`lib/session-spawn-policy.js` if attach-ctx coupling makes direct testing
+awkward) and test:
+
+1. Batch parse: valid JSON array accepted; non-array / missing prompt /
+   more than 10 entries rejected with the exact error strings.
+2. Depth guard: a session with `spawn.parentId` cannot spawn.
+3. Children cap: 20th child allowed, 21st rejected.
+4. Queue: with concurrency 3 and 5 tasks, 3 start immediately; completing
+   one starts the 4th; completing all leaves the queue empty.
+5. Vendor guard: unknown vendor rejected; isolated-user + registry
+   `osUserIsolation: false` vendor rejected (use the real registry).
+
+---
+
+## Acceptance criteria
+
+1. In a normal project session, asking the agent to "create three sessions,
+   one per X" produces a `spawn_sessions` permission prompt; approving
+   creates 3 titled sessions that appear in the sidebar and start running
+   (max 3 concurrent), each answering its own prompt.
+2. `check_spawned_sessions` from the parent reports running/done/error
+   correctly after the children finish.
+3. A spawned child asking to spawn gets the depth-guard error.
+4. Caps and vendor guards behave per the tests; `npm test` green with the
+   new suite; all static sweeps green.
+5. No auto-approve entries added anywhere for `mcp__clay-sessions__*`.
+6. `docs/guides/MODULE_MAP.md` gains rows for the two new files.

--- a/lib/project-session-spawn.js
+++ b/lib/project-session-spawn.js
@@ -1,5 +1,8 @@
 var yoke = require("./yoke");
 var sessionSpawnMcp = require("./session-spawn-mcp-server");
+var cliSessions = require("./cli-sessions");
+var os = require("os");
+var osUsers = require("./os-users");
 
 var MAX_SESSIONS_PER_CALL = 10;
 var MAX_CHILDREN_PER_PARENT = 20;
@@ -139,10 +142,57 @@ function toolError(err) {
   });
 }
 
+function rebuildMessageUUIDs(history) {
+  var messageUUIDs = [];
+  for (var i = 0; i < history.length; i++) {
+    if (history[i].type === "message_uuid") {
+      messageUUIDs.push({
+        uuid: history[i].uuid,
+        type: history[i].messageType,
+        historyIndex: i,
+      });
+    }
+  }
+  return messageUUIDs;
+}
+
 function attachSessionSpawn(ctx) {
   var sm = ctx.sm;
   var queue = createSpawnQueue(SPAWN_CONCURRENCY);
   var adapters = ctx.adapters || {};
+  var readCliSessionHistory = ctx.readCliSessionHistory || cliSessions.readCliSessionHistory;
+
+  function resolveSessionHome(session) {
+    var linuxUser = ctx.getLinuxUserForSession(session);
+    if (linuxUser) {
+      try {
+        var info = osUsers.resolveOsUserInfo(linuxUser);
+        if (info && info.home) return info.home;
+      } catch (e) {}
+    }
+    return os.homedir();
+  }
+
+  function validateFork(parent, vendor, explicitVendor) {
+    if (!parent.cliSessionId) {
+      throw new Error("forkFromCurrent requires the calling session to have at least one completed turn");
+    }
+    var capabilities = sm.capabilitiesByVendor && sm.capabilitiesByVendor[vendor];
+    if (!capabilities || capabilities.fork !== true) {
+      throw new Error("forkFromCurrent is not supported by vendor: " + vendor);
+    }
+    var parentVendor = parent.vendor || sm.defaultVendor;
+    if (explicitVendor && explicitVendor !== parentVendor) {
+      throw new Error("forkFromCurrent children must use the parent's vendor");
+    }
+  }
+
+  function applyForkToTask(task, forkResult, history) {
+    task.session.cliSessionId = forkResult.sessionId;
+    task.session.history = history.slice();
+    task.session.messageUUIDs = rebuildMessageUUIDs(task.session.history);
+    sm.saveSessionFile(task.session);
+  }
 
   function spawnOne(parent, spec, index, batchId, vendor, linuxUser) {
     var create = typeof sm.createSessionRaw === "function" ? sm.createSessionRaw : sm.createSession;
@@ -193,7 +243,7 @@ function attachSessionSpawn(ctx) {
     };
   }
 
-  function spawn(args, caller) {
+  async function spawn(args, caller) {
     try {
       // The caller is bound per query in getLocalMcpServers (project.js), so
       // a child session resolving itself here is what makes the depth guard
@@ -203,20 +253,53 @@ function attachSessionSpawn(ctx) {
       if (!parent) throw new Error("spawn_sessions requires a session-bound tool server");
       var specs = parseBatch(args.sessions);
       assertSpawnAllowed(parent, sm.sessions, specs.length);
-      var vendor = (args.vendor && args.vendor.trim()) || parent.vendor || sm.defaultVendor;
+      var explicitVendor = args.vendor && args.vendor.trim();
+      var vendor = explicitVendor || parent.vendor || sm.defaultVendor;
       var linuxUser = ctx.getLinuxUserForSession(parent);
       validateVendor(vendor, adapters, linuxUser);
+      var forkFromCurrent = args.forkFromCurrent === true;
+      if (forkFromCurrent) validateFork(parent, vendor, explicitVendor);
       var batchId = "sp_" + Date.now().toString(36);
       var tasks = [];
       var spawned = [];
+      var failed = null;
+      var sdk = ctx.getSdk();
+      var lastMessage = parent.messageUUIDs && parent.messageUUIDs.length > 0
+        ? parent.messageUUIDs[parent.messageUUIDs.length - 1]
+        : null;
+      // Claude treats an omitted upToMessageId as a full-session fork;
+      // Codex forks the whole thread and ignores the UUID option.
+      var lastUuid = lastMessage ? lastMessage.uuid : undefined;
       for (var i = 0; i < specs.length; i++) {
+        var forkResult = null;
+        var forkHistory = null;
+        if (forkFromCurrent) {
+          try {
+            if (!sdk || typeof sdk.forkSession !== "function") throw new Error("SDK bridge is not ready");
+            forkResult = await sdk.forkSession(parent, lastUuid);
+            if (!forkResult || !forkResult.sessionId) throw new Error("Fork returned no session id");
+            if (forkResult.useLocalHistory) {
+              forkHistory = parent.history.slice();
+            } else {
+              forkHistory = await readCliSessionHistory(
+                resolveSessionHome(parent), ctx.cwd, forkResult.sessionId
+              );
+            }
+          } catch (e) {
+            failed = { index: i, error: e.message || String(e) };
+            break;
+          }
+        }
         var task = spawnOne(parent, specs[i], i, batchId, vendor, linuxUser);
+        if (forkResult) applyForkToTask(task, forkResult, forkHistory || []);
         tasks.push(task);
         spawned.push({ localId: task.session.localId, title: task.session.title });
       }
       var counts = queue.add(tasks);
-      sm.broadcastSessionList();
-      return toolResult({ spawned: spawned, queued: counts.queued, running: counts.running });
+      if (tasks.length > 0) sm.broadcastSessionList();
+      var result = { spawned: spawned, queued: counts.queued, running: counts.running };
+      if (failed) result.failed = failed;
+      return toolResult(result);
     } catch (e) {
       return toolError(e);
     }
@@ -278,5 +361,6 @@ module.exports = {
   validateVendor: validateVendor,
   createSpawnQueue: createSpawnQueue,
   hasSessionError: hasSessionError,
+  rebuildMessageUUIDs: rebuildMessageUUIDs,
   attachSessionSpawn: attachSessionSpawn,
 };

--- a/lib/project-session-spawn.js
+++ b/lib/project-session-spawn.js
@@ -1,0 +1,282 @@
+var yoke = require("./yoke");
+var sessionSpawnMcp = require("./session-spawn-mcp-server");
+
+var MAX_SESSIONS_PER_CALL = 10;
+var MAX_CHILDREN_PER_PARENT = 20;
+var SPAWN_CONCURRENCY = 3;
+
+function parseBatch(raw) {
+  var parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new Error("sessions must be a valid JSON array");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("sessions must be a valid JSON array");
+  }
+  if (parsed.length < 1 || parsed.length > MAX_SESSIONS_PER_CALL) {
+    throw new Error("sessions must contain between 1 and 10 entries");
+  }
+  var result = [];
+  for (var i = 0; i < parsed.length; i++) {
+    var entry = parsed[i];
+    if (!entry || typeof entry.prompt !== "string" || !entry.prompt.trim()) {
+      throw new Error("session " + (i + 1) + " must include a non-empty prompt");
+    }
+    var title = typeof entry.title === "string" ? entry.title.trim() : "";
+    result.push({
+      title: title || "Spawned task " + (i + 1),
+      prompt: entry.prompt.trim(),
+    });
+  }
+  return result;
+}
+
+function getSessionsArray(sessions) {
+  if (!sessions) return [];
+  if (typeof sessions.values === "function") return Array.from(sessions.values());
+  return sessions;
+}
+
+function assertSpawnAllowed(parent, sessions, requestedCount) {
+  if (!parent) throw new Error("no active parent session");
+  if (parent.spawn) throw new Error("spawned sessions cannot spawn further sessions");
+  var all = getSessionsArray(sessions);
+  var childCount = 0;
+  for (var i = 0; i < all.length; i++) {
+    if (all[i].spawn && all[i].spawn.parentId === parent.localId) childCount++;
+  }
+  if (childCount + requestedCount > MAX_CHILDREN_PER_PARENT) {
+    throw new Error("a parent session cannot have more than 20 children");
+  }
+  return childCount;
+}
+
+function validateVendor(vendor, adapters, linuxUser, getVendorInfo) {
+  if (!vendor || !adapters || !adapters[vendor]) {
+    throw new Error("vendor is not available: " + (vendor || "unknown"));
+  }
+  var lookup = getVendorInfo || yoke.getVendorInfo;
+  var info = lookup(vendor);
+  if (linuxUser && info && info.osUserIsolation === false) {
+    throw new Error((info.displayName || vendor) + " is not available for OS-isolated users");
+  }
+  return vendor;
+}
+
+function createSpawnQueue(concurrency) {
+  var limit = concurrency || SPAWN_CONCURRENCY;
+  var pending = [];
+  var running = [];
+
+  function startTask(task) {
+    task.state = "running";
+    running.push(task);
+    var finished = false;
+    function complete(err) {
+      if (finished) return;
+      finished = true;
+      var index = running.indexOf(task);
+      if (index !== -1) running.splice(index, 1);
+      task.state = err ? "error" : "done";
+      task.error = err || null;
+      pump();
+    }
+    try {
+      task.start(complete);
+    } catch (e) {
+      complete(e);
+    }
+  }
+
+  function pump() {
+    while (running.length < limit && pending.length > 0) {
+      var task = pending.shift();
+      startTask(task);
+    }
+  }
+
+  function add(tasks) {
+    for (var i = 0; i < tasks.length; i++) {
+      tasks[i].state = "queued";
+      pending.push(tasks[i]);
+    }
+    pump();
+    var queued = 0;
+    var active = 0;
+    for (var j = 0; j < tasks.length; j++) {
+      if (tasks[j].state === "queued") queued++;
+      if (tasks[j].state === "running") active++;
+    }
+    return { queued: queued, running: active };
+  }
+
+  return {
+    add: add,
+    get pendingCount() { return pending.length; },
+    get runningCount() { return running.length; },
+  };
+}
+
+function hasSessionError(session) {
+  var history = session.history || [];
+  var recent = history.slice(-3);
+  for (var i = 0; i < recent.length; i++) {
+    if (recent[i].type === "error" || (recent[i].type === "done" && recent[i].code === 1)) return true;
+  }
+  return false;
+}
+
+function toolResult(value) {
+  return Promise.resolve({ content: [{ type: "text", text: JSON.stringify(value) }] });
+}
+
+function toolError(err) {
+  return Promise.resolve({
+    content: [{ type: "text", text: "Error: " + (err.message || err) }],
+    isError: true,
+  });
+}
+
+function attachSessionSpawn(ctx) {
+  var sm = ctx.sm;
+  var queue = createSpawnQueue(SPAWN_CONCURRENCY);
+  var adapters = ctx.adapters || {};
+
+  function spawnOne(parent, spec, index, batchId, vendor, linuxUser) {
+    var create = typeof sm.createSessionRaw === "function" ? sm.createSessionRaw : sm.createSession;
+    var session = create.call(sm, {
+      ownerId: parent.ownerId || null,
+      sessionVisibility: parent.sessionVisibility || "shared",
+      vendor: vendor,
+    });
+    session.spawn = { parentId: parent.localId, index: index, batchId: batchId };
+    session.title = spec.title;
+    sm.saveSessionFile(session);
+
+    return {
+      session: session,
+      state: "created",
+      start: function (done) {
+        function finish(err) {
+          delete session.onQueryComplete;
+          delete session.singleTurn;
+          done(err);
+        }
+        var userMessage = { type: "user_message", text: spec.prompt };
+        session.history.push(userMessage);
+        sm.appendToSessionFile(session, userMessage);
+        session.isProcessing = true;
+        session.lastActivity = Date.now();
+        session.sentToolResults = {};
+        session.singleTurn = true;
+        session.onQueryComplete = function () {
+          finish(hasSessionError(session) ? new Error("child session failed") : null);
+        };
+        var sdk = ctx.getSdk();
+        if (!sdk || typeof sdk.startQuery !== "function") {
+          session.isProcessing = false;
+          finish(new Error("SDK bridge is not ready"));
+          return;
+        }
+        Promise.resolve(sdk.startQuery(session, spec.prompt, undefined, linuxUser)).then(function () {
+          if (!session.isProcessing && !session.queryInstance) {
+            finish(new Error("child session failed to start"));
+          }
+        }).catch(function (err) {
+          session.isProcessing = false;
+          session.history.push({ type: "error", text: err.message || String(err) });
+          finish(err);
+        });
+      },
+    };
+  }
+
+  function spawn(args, caller) {
+    try {
+      // The caller is bound per query in getLocalMcpServers (project.js), so
+      // a child session resolving itself here is what makes the depth guard
+      // sound. Never fall back to sm.getActiveSession(): that is the
+      // project-global "last viewed" session and can belong to someone else.
+      var parent = caller;
+      if (!parent) throw new Error("spawn_sessions requires a session-bound tool server");
+      var specs = parseBatch(args.sessions);
+      assertSpawnAllowed(parent, sm.sessions, specs.length);
+      var vendor = (args.vendor && args.vendor.trim()) || parent.vendor || sm.defaultVendor;
+      var linuxUser = ctx.getLinuxUserForSession(parent);
+      validateVendor(vendor, adapters, linuxUser);
+      var batchId = "sp_" + Date.now().toString(36);
+      var tasks = [];
+      var spawned = [];
+      for (var i = 0; i < specs.length; i++) {
+        var task = spawnOne(parent, specs[i], i, batchId, vendor, linuxUser);
+        tasks.push(task);
+        spawned.push({ localId: task.session.localId, title: task.session.title });
+      }
+      var counts = queue.add(tasks);
+      sm.broadcastSessionList();
+      return toolResult({ spawned: spawned, queued: counts.queued, running: counts.running });
+    } catch (e) {
+      return toolError(e);
+    }
+  }
+
+  function check(args, caller) {
+    try {
+      var parent = caller;
+      if (!parent) throw new Error("check_spawned_sessions requires a session-bound tool server");
+      var parentOnly = args.parentOnly !== false;
+      var all = getSessionsArray(sm.sessions);
+      var statuses = [];
+      for (var i = 0; i < all.length; i++) {
+        var session = all[i];
+        if (!session.spawn) continue;
+        if (parentOnly && session.spawn.parentId !== parent.localId) continue;
+        statuses.push({
+          localId: session.localId,
+          title: session.title || "New Session",
+          status: session.isProcessing ? "running" : (hasSessionError(session) ? "error" : "done"),
+          turnCount: session.turnCount || 0,
+          lastActivity: session.lastActivity || session.createdAt || 0,
+        });
+      }
+      return toolResult(statuses);
+    } catch (e) {
+      return toolError(e);
+    }
+  }
+
+  // boundSession: the session whose query this tool server instance is
+  // mounted into. Omitted for the static instance kept in the project's
+  // mcpServers map, which exists only so tool descriptors can be listed;
+  // its handlers fail closed if anything ever routes a call to them.
+  function createMcpServer(adapter, boundSession) {
+    if (ctx.isMate || !adapter || typeof adapter.createToolServer !== "function") return null;
+    return adapter.createToolServer({
+      name: "clay-sessions",
+      version: "1.0.0",
+      tools: sessionSpawnMcp.getToolDefs({
+        spawn: function (args) { return spawn(args, boundSession || null); },
+        check: function (args) { return check(args, boundSession || null); },
+      }),
+    });
+  }
+
+  return {
+    createMcpServer: createMcpServer,
+    spawnOne: spawnOne,
+  };
+}
+
+module.exports = {
+  MAX_SESSIONS_PER_CALL: MAX_SESSIONS_PER_CALL,
+  MAX_CHILDREN_PER_PARENT: MAX_CHILDREN_PER_PARENT,
+  SPAWN_CONCURRENCY: SPAWN_CONCURRENCY,
+  parseBatch: parseBatch,
+  assertSpawnAllowed: assertSpawnAllowed,
+  validateVendor: validateVendor,
+  createSpawnQueue: createSpawnQueue,
+  hasSessionError: hasSessionError,
+  attachSessionSpawn: attachSessionSpawn,
+};

--- a/lib/project.js
+++ b/lib/project.js
@@ -30,6 +30,7 @@ var { attachConnection } = require("./project-connection");
 var { attachMcp } = require("./project-mcp");
 var { createLocalMcp } = require("./mcp-local");
 var { attachEmail: attachEmailModule } = require("./project-email");
+var { attachSessionSpawn } = require("./project-session-spawn");
 // project-notifications is attached globally in server.js, passed via opts.notificationsModule
 
 // --- Context Sources persistence ---
@@ -475,9 +476,32 @@ function createProjectContext(opts) {
     },
   });
 
+  // The SDK bridge is created after local MCP servers. Session spawning uses
+  // a getter so tool handlers see the initialized bridge when they run.
+  var sdk = null;
+  var _sessionSpawn = attachSessionSpawn({
+    sm: sm,
+    getSdk: function () { return sdk; },
+    send: send,
+    isMate: isMate,
+    usersModule: usersModule,
+    adapters: adapters,
+    getLinuxUserForSession: getLinuxUserForSession,
+  });
+
   // --- MCP tool servers (created via YOKE adapter) ---
   var mcpServers = (function () {
     var servers = {};
+
+    // Agent-driven sibling session fan-out (main projects only).
+    if (!isMate) {
+      try {
+        var sessionSpawnMcpConfig = _sessionSpawn.createMcpServer(adapter);
+        if (sessionSpawnMcpConfig) servers[sessionSpawnMcpConfig.name || "clay-sessions"] = sessionSpawnMcpConfig;
+      } catch (e) {
+        console.error("[project] Failed to create session spawn MCP server:", e.message);
+      }
+    }
 
     // Debate MCP server (available to both mates and main project)
     try {
@@ -640,7 +664,12 @@ function createProjectContext(opts) {
   //
   //   clay-browser -> only when the Chrome extension is connected
   //   clay-email   -> only when the user has an account or server SMTP
-  function getLocalMcpServers() {
+  //
+  // forSession (optional): the session whose query these servers are mounted
+  // into. clay-sessions must know its caller (depth guard + child ownership),
+  // so it is re-instantiated bound to that session; the static instance in
+  // mcpServers only serves descriptor listing and fails closed on calls.
+  function getLocalMcpServers(forSession) {
     if (!mcpServers) return undefined;
     var extWs = browserState._extensionWs;
     var extConnected = !!(extWs && extWs.readyState === 1);
@@ -652,6 +681,15 @@ function createProjectContext(opts) {
       var name = keys[i];
       if (name === "clay-browser" && !extConnected) continue;
       if (name === "clay-email" && !emailAvailable) continue;
+      if (name === "clay-sessions" && forSession) {
+        try {
+          var boundSpawn = _sessionSpawn.createMcpServer(adapter, forSession);
+          if (boundSpawn) { filtered[name] = boundSpawn; hasAny = true; }
+        } catch (e) {
+          console.error("[project] Failed to bind session spawn MCP server:", e.message);
+        }
+        continue;
+      }
       filtered[name] = mcpServers[name];
       hasAny = true;
     }
@@ -659,7 +697,7 @@ function createProjectContext(opts) {
   }
 
   // --- SDK bridge ---
-  var sdk = createSDKBridge({
+  sdk = createSDKBridge({
     cwd: cwd,
     slug: slug,
     sessionManager: sm,

--- a/lib/project.js
+++ b/lib/project.js
@@ -480,6 +480,7 @@ function createProjectContext(opts) {
   // a getter so tool handlers see the initialized bridge when they run.
   var sdk = null;
   var _sessionSpawn = attachSessionSpawn({
+    cwd: cwd,
     sm: sm,
     getSdk: function () { return sdk; },
     send: send,

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -113,10 +113,11 @@ function createSDKBridge(opts) {
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
   // mcpServers may be either a static object or a getter function. The
   // getter form lets callers gate individual servers at call time (e.g.
-  // clay-browser is only exposed while the Chrome extension is connected).
+  // clay-browser is only exposed while the Chrome extension is connected)
+  // and bind session-scoped servers (clay-sessions) to the querying session.
   var _mcpServersSrc = opts.mcpServers || null;
-  function getMcpServers() {
-    if (typeof _mcpServersSrc === "function") return _mcpServersSrc() || null;
+  function getMcpServers(forSession) {
+    if (typeof _mcpServersSrc === "function") return _mcpServersSrc(forSession) || null;
     return _mcpServersSrc;
   }
   var getRemoteMcpServers = opts.getRemoteMcpServers || null;
@@ -1331,7 +1332,7 @@ function createSDKBridge(opts) {
 
     var codexConfig = getCodexConfig(sm);
     var kiroConfig = getKiroConfig(sm);
-    var mergedMcpServers = mergeMcpServers(getMcpServers(), getRemoteMcpServers) || undefined;
+    var mergedMcpServers = mergeMcpServers(getMcpServers(session), getRemoteMcpServers) || undefined;
 
     // Derive an explicit session title for fresh queries so the SDK records
     // it at session creation and skips its own auto-generation. This also

--- a/lib/session-spawn-mcp-server.js
+++ b/lib/session-spawn-mcp-server.js
@@ -27,10 +27,11 @@ function getToolDefs(handlers) {
   return [
     {
       name: "spawn_sessions",
-      description: "Create sibling work sessions in this project. Each child session starts with its own prompt and runs independently; results can be polled with check_spawned_sessions. Spawned children cannot spawn further sessions.",
+      description: "Create sibling work sessions in this project. Set forkFromCurrent to copy this session's full conversation context into every child. Children share the project's working directory, so prefer parallel analysis or other non-conflicting work over concurrent edits. Results can be polled with check_spawned_sessions; spawned children cannot spawn further sessions.",
       inputSchema: buildShape({
         sessions: { type: "string", description: "JSON array of objects: [{\"title\":\"Task title\",\"prompt\":\"Task instructions\"}]" },
         vendor: { type: "string", description: "Optional vendor id. Defaults to the parent session vendor, then the project default." },
+        forkFromCurrent: { type: "boolean", description: "Children start with a copy of this session's full conversation context. Defaults to false." },
       }, ["sessions"]),
       handler: function (args) {
         return handlers.spawn(args || {});

--- a/lib/session-spawn-mcp-server.js
+++ b/lib/session-spawn-mcp-server.js
@@ -1,0 +1,55 @@
+// Session Spawn MCP Server for Clay
+// Provides SDK-free tool definitions for agent-driven session fan-out.
+
+var z;
+try { z = require("zod"); } catch (e) { z = null; }
+
+function buildShape(props, required) {
+  if (!z) return {};
+  var shape = {};
+  var keys = Object.keys(props);
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    var prop = props[key];
+    var field;
+    if (prop.type === "number") field = z.number();
+    else if (prop.type === "boolean") field = z.boolean();
+    else if (prop.enum) field = z.enum(prop.enum);
+    else field = z.string();
+    if (prop.description) field = field.describe(prop.description);
+    if (!required || required.indexOf(key) === -1) field = field.optional();
+    shape[key] = field;
+  }
+  return shape;
+}
+
+function getToolDefs(handlers) {
+  return [
+    {
+      name: "spawn_sessions",
+      description: "Create sibling work sessions in this project. Each child session starts with its own prompt and runs independently; results can be polled with check_spawned_sessions. Spawned children cannot spawn further sessions.",
+      inputSchema: buildShape({
+        sessions: { type: "string", description: "JSON array of objects: [{\"title\":\"Task title\",\"prompt\":\"Task instructions\"}]" },
+        vendor: { type: "string", description: "Optional vendor id. Defaults to the parent session vendor, then the project default." },
+      }, ["sessions"]),
+      handler: function (args) {
+        return handlers.spawn(args || {});
+      },
+    },
+    {
+      name: "check_spawned_sessions",
+      description: "Check the status of sessions spawned by this session. By default only direct children of the calling session are returned.",
+      inputSchema: buildShape({
+        parentOnly: { type: "boolean", description: "When false, return all spawned sessions in this project. Defaults to true." },
+      }),
+      handler: function (args) {
+        return handlers.check(args || {});
+      },
+    },
+  ];
+}
+
+module.exports = {
+  buildShape: buildShape,
+  getToolDefs: getToolDefs,
+};

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -108,6 +108,7 @@ function createSessionManager(opts) {
       if (typeof session.favoriteOrder === "number") metaObj.favoriteOrder = session.favoriteOrder;
       if (session.lastRewindUuid) metaObj.lastRewindUuid = session.lastRewindUuid;
       if (session.loop) metaObj.loop = session.loop;
+      if (session.spawn) metaObj.spawn = session.spawn;
       if (session.debateState) metaObj.debateState = session.debateState;
       if (session.debateSetupMode) metaObj.debateSetupMode = true;
       var meta = JSON.stringify(metaObj);
@@ -207,6 +208,7 @@ function createSessionManager(opts) {
       };
       if (m.vendor) session.vendor = m.vendor;
       if (m.loop) session.loop = m.loop;
+      if (m.spawn) session.spawn = m.spawn;
       if (m.debateState) session.debateState = m.debateState;
       if (m.debateSetupMode) session.debateSetupMode = true;
       if (m.ownerId) session.ownerId = m.ownerId;
@@ -394,6 +396,7 @@ function createSessionManager(opts) {
       isProcessing: s.isProcessing,
       lastActivity: s.lastActivity || s.createdAt || 0,
       loop: loop,
+      spawn: s.spawn || null,
       ownerId: s.ownerId || null,
       sessionVisibility: s.sessionVisibility || "shared",
       bookmarked: !!s.bookmarked,

--- a/test/session-spawn.test.js
+++ b/test/session-spawn.test.js
@@ -1,0 +1,207 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+var spawnModule = require("../lib/project-session-spawn");
+var yoke = require("../lib/yoke");
+
+test("session spawn parses a valid batch", function() {
+  var batch = spawnModule.parseBatch(JSON.stringify([
+    { title: " First ", prompt: " Do the first task " },
+    { prompt: "Do the second task" },
+  ]));
+  assert.deepStrictEqual(batch, [
+    { title: "First", prompt: "Do the first task" },
+    { title: "Spawned task 2", prompt: "Do the second task" },
+  ]);
+});
+
+test("session spawn rejects a non-array batch", function() {
+  assert.throws(function() {
+    spawnModule.parseBatch("{}");
+  }, { message: "sessions must be a valid JSON array" });
+});
+
+test("session spawn rejects a missing prompt", function() {
+  assert.throws(function() {
+    spawnModule.parseBatch('[{"title":"No prompt"}]');
+  }, { message: "session 1 must include a non-empty prompt" });
+});
+
+test("session spawn rejects more than ten entries", function() {
+  var entries = [];
+  for (var i = 0; i < 11; i++) entries.push({ prompt: "Task " + i });
+  assert.throws(function() {
+    spawnModule.parseBatch(JSON.stringify(entries));
+  }, { message: "sessions must contain between 1 and 10 entries" });
+});
+
+test("spawned sessions cannot create grandchildren", function() {
+  assert.throws(function() {
+    spawnModule.assertSpawnAllowed({ localId: 7, spawn: { parentId: 2 } }, [], 1);
+  }, { message: "spawned sessions cannot spawn further sessions" });
+});
+
+test("twentieth child is allowed and twenty-first is rejected", function() {
+  var parent = { localId: 4 };
+  var children = [];
+  for (var i = 0; i < 19; i++) children.push({ spawn: { parentId: 4 } });
+  assert.strictEqual(spawnModule.assertSpawnAllowed(parent, children, 1), 19);
+  children.push({ spawn: { parentId: 4 } });
+  assert.throws(function() {
+    spawnModule.assertSpawnAllowed(parent, children, 1);
+  }, { message: "a parent session cannot have more than 20 children" });
+});
+
+test("spawn queue starts three tasks and advances on completion", function() {
+  var queue = spawnModule.createSpawnQueue(3);
+  var completions = [];
+  var started = [];
+  var tasks = [];
+  for (var i = 0; i < 5; i++) {
+    (function(index) {
+      tasks.push({
+        start: function(done) {
+          started.push(index);
+          completions[index] = done;
+        },
+      });
+    })(i);
+  }
+
+  var counts = queue.add(tasks);
+  assert.deepStrictEqual(counts, { queued: 2, running: 3 });
+  assert.deepStrictEqual(started, [0, 1, 2]);
+  completions[0]();
+  assert.deepStrictEqual(started, [0, 1, 2, 3]);
+  completions[1]();
+  completions[2]();
+  completions[3]();
+  completions[4]();
+  assert.strictEqual(queue.pendingCount, 0);
+  assert.strictEqual(queue.runningCount, 0);
+});
+
+test("session spawn MCP creates inherited background sessions and starts three", async function() {
+  var parent = {
+    localId: 1,
+    ownerId: "owner-1",
+    sessionVisibility: "private",
+    vendor: "claude",
+    history: [],
+  };
+  var sessions = new Map([[1, parent]]);
+  var nextId = 2;
+  var broadcasts = 0;
+  var starts = [];
+  var sm = {
+    sessions: sessions,
+    defaultVendor: "claude",
+    createSessionRaw: function(opts) {
+      var session = Object.assign({
+        localId: nextId++,
+        history: [],
+        sentToolResults: {},
+        isProcessing: false,
+        createdAt: Date.now(),
+      }, opts);
+      sessions.set(session.localId, session);
+      return session;
+    },
+    saveSessionFile: function() {},
+    appendToSessionFile: function() {},
+    broadcastSessionList: function() { broadcasts++; },
+  };
+  var sdk = {
+    startQuery: function(session, prompt, images, linuxUser) {
+      starts.push({ session: session, prompt: prompt, linuxUser: linuxUser });
+      session.queryInstance = {};
+      return Promise.resolve();
+    },
+  };
+  var fakeAdapter = {
+    createToolServer: function(def) {
+      return { name: def.name, tools: def.tools };
+    },
+  };
+  var attached = spawnModule.attachSessionSpawn({
+    sm: sm,
+    getSdk: function() { return sdk; },
+    isMate: false,
+    adapters: { claude: fakeAdapter },
+    getLinuxUserForSession: function() { return "clay-owner-1"; },
+  });
+  var server = attached.createMcpServer(fakeAdapter, parent);
+  var spawnTool = server.tools.filter(function(tool) { return tool.name === "spawn_sessions"; })[0];
+  var specs = [];
+  for (var i = 0; i < 5; i++) specs.push({ title: "Task " + (i + 1), prompt: "Prompt " + (i + 1) });
+  var response = await spawnTool.handler({ sessions: JSON.stringify(specs) });
+  var result = JSON.parse(response.content[0].text);
+
+  assert.strictEqual(result.spawned.length, 5);
+  assert.strictEqual(result.running, 3);
+  assert.strictEqual(result.queued, 2);
+  assert.strictEqual(starts.length, 3);
+  assert.strictEqual(broadcasts, 1);
+  assert.strictEqual(sessions.get(2).ownerId, "owner-1");
+  assert.strictEqual(sessions.get(2).sessionVisibility, "private");
+  assert.strictEqual(starts[0].linuxUser, "clay-owner-1");
+
+  starts[0].session.isProcessing = false;
+  starts[0].session.onQueryComplete(starts[0].session);
+  assert.strictEqual(starts.length, 4);
+  assert.strictEqual(starts[0].session.singleTurn, undefined);
+  assert.strictEqual(starts[0].session.onQueryComplete, undefined);
+});
+
+test("an unbound tool server fails closed instead of guessing the caller", async function() {
+  var fakeAdapter = {
+    createToolServer: function(def) { return { name: def.name, tools: def.tools }; },
+  };
+  var attached = spawnModule.attachSessionSpawn({
+    sm: { sessions: new Map() },
+    getSdk: function() { return null; },
+    isMate: false,
+    adapters: { claude: fakeAdapter },
+    getLinuxUserForSession: function() { return null; },
+  });
+  // No boundSession: this is the static descriptor-listing instance.
+  var server = attached.createMcpServer(fakeAdapter);
+  var spawnTool = server.tools[0];
+  var response = await spawnTool.handler({ sessions: '[{"prompt":"x"}]' });
+  assert.strictEqual(response.isError, true);
+  assert.ok(response.content[0].text.indexOf("session-bound") !== -1);
+});
+
+test("a bound child session is depth-guarded even while another session is viewed", async function() {
+  var child = { localId: 9, spawn: { parentId: 1 }, history: [] };
+  var fakeAdapter = {
+    createToolServer: function(def) { return { name: def.name, tools: def.tools }; },
+  };
+  var attached = spawnModule.attachSessionSpawn({
+    sm: { sessions: new Map([[9, child]]) },
+    getSdk: function() { return null; },
+    isMate: false,
+    adapters: { claude: fakeAdapter },
+    getLinuxUserForSession: function() { return null; },
+  });
+  // The tool server is bound to the child itself, so the guard checks the
+  // child regardless of which session the user currently has open.
+  var server = attached.createMcpServer(fakeAdapter, child);
+  var spawnTool = server.tools[0];
+  var response = await spawnTool.handler({ sessions: '[{"prompt":"x"}]' });
+  assert.strictEqual(response.isError, true);
+  assert.ok(response.content[0].text.indexOf("cannot spawn further") !== -1);
+});
+
+test("session spawn rejects an unknown vendor", function() {
+  assert.throws(function() {
+    spawnModule.validateVendor("unknown", { claude: {} }, null, yoke.getVendorInfo);
+  }, { message: "vendor is not available: unknown" });
+});
+
+test("session spawn rejects non-isolating vendor for isolated user", function() {
+  assert.strictEqual(yoke.getVendorInfo("kiro").osUserIsolation, false);
+  assert.throws(function() {
+    spawnModule.validateVendor("kiro", { kiro: {} }, "alice", yoke.getVendorInfo);
+  }, { message: "Kiro CLI is not available for OS-isolated users" });
+});

--- a/test/session-spawn.test.js
+++ b/test/session-spawn.test.js
@@ -4,6 +4,89 @@ var assert = require("node:assert");
 var spawnModule = require("../lib/project-session-spawn");
 var yoke = require("../lib/yoke");
 
+function createForkFixture(options) {
+  options = options || {};
+  var parent = Object.assign({
+    localId: 1,
+    ownerId: "owner-1",
+    sessionVisibility: "private",
+    vendor: "claude",
+    cliSessionId: "cli-parent",
+    history: [
+      { type: "user_message", text: "The plan is Project Pine." },
+      { type: "message_uuid", uuid: "uuid-user", messageType: "user" },
+      { type: "assistant_message", text: "I understand the plan." },
+      { type: "message_uuid", uuid: "uuid-assistant", messageType: "assistant" },
+    ],
+    messageUUIDs: [
+      { uuid: "uuid-user", type: "user", historyIndex: 1 },
+      { uuid: "uuid-assistant", type: "assistant", historyIndex: 3 },
+    ],
+  }, options.parent || {});
+  var sessions = new Map([[parent.localId, parent]]);
+  var nextId = 2;
+  var starts = [];
+  var forks = [];
+  var broadcasts = 0;
+  var forkCount = 0;
+  var sm = {
+    sessions: sessions,
+    defaultVendor: "claude",
+    capabilitiesByVendor: options.capabilitiesByVendor || { claude: { fork: true } },
+    createSessionRaw: function(sessionOptions) {
+      var session = Object.assign({
+        localId: nextId++,
+        history: [],
+        messageUUIDs: [],
+        sentToolResults: {},
+        isProcessing: false,
+        createdAt: Date.now(),
+      }, sessionOptions);
+      sessions.set(session.localId, session);
+      return session;
+    },
+    saveSessionFile: function() {},
+    appendToSessionFile: function() {},
+    broadcastSessionList: function() { broadcasts++; },
+  };
+  var sdk = {
+    forkSession: function(session, uuid) {
+      forkCount++;
+      forks.push({ session: session, uuid: uuid, count: forkCount });
+      if (options.forkSession) return options.forkSession(session, uuid, forkCount);
+      return Promise.resolve({ sessionId: "cli-fork-" + forkCount, useLocalHistory: true });
+    },
+    startQuery: function(session, prompt, images, linuxUser) {
+      starts.push({ session: session, prompt: prompt, linuxUser: linuxUser });
+      session.queryInstance = {};
+      return Promise.resolve();
+    },
+  };
+  var fakeAdapter = {
+    createToolServer: function(def) { return { name: def.name, tools: def.tools }; },
+  };
+  var adapters = options.adapters || { claude: fakeAdapter };
+  var attached = spawnModule.attachSessionSpawn({
+    cwd: process.cwd(),
+    sm: sm,
+    getSdk: function() { return sdk; },
+    isMate: false,
+    adapters: adapters,
+    getLinuxUserForSession: function() { return null; },
+    readCliSessionHistory: options.readCliSessionHistory,
+  });
+  var server = attached.createMcpServer(fakeAdapter, parent);
+  var spawnTool = server.tools.filter(function(tool) { return tool.name === "spawn_sessions"; })[0];
+  return {
+    parent: parent,
+    sessions: sessions,
+    starts: starts,
+    forks: forks,
+    get broadcasts() { return broadcasts; },
+    spawn: function(args) { return spawnTool.handler(args); },
+  };
+}
+
 test("session spawn parses a valid batch", function() {
   var batch = spawnModule.parseBatch(JSON.stringify([
     { title: " First ", prompt: " Do the first task " },
@@ -191,6 +274,116 @@ test("a bound child session is depth-guarded even while another session is viewe
   var response = await spawnTool.handler({ sessions: '[{"prompt":"x"}]' });
   assert.strictEqual(response.isError, true);
   assert.ok(response.content[0].text.indexOf("cannot spawn further") !== -1);
+});
+
+test("forkFromCurrent gives each child its own inherited history", async function() {
+  var fixture = createForkFixture();
+  var response = await fixture.spawn({
+    sessions: JSON.stringify([
+      { title: "Pine A", prompt: "Analyze area A" },
+      { title: "Pine B", prompt: "Analyze area B" },
+    ]),
+    forkFromCurrent: true,
+  });
+  var result = JSON.parse(response.content[0].text);
+  var first = fixture.sessions.get(result.spawned[0].localId);
+  var second = fixture.sessions.get(result.spawned[1].localId);
+
+  assert.strictEqual(first.cliSessionId, "cli-fork-1");
+  assert.strictEqual(second.cliSessionId, "cli-fork-2");
+  assert.notStrictEqual(first.history, fixture.parent.history);
+  assert.notStrictEqual(second.history, fixture.parent.history);
+  assert.deepStrictEqual(first.history.slice(0, -1), fixture.parent.history);
+  assert.deepStrictEqual(second.history.slice(0, -1), fixture.parent.history);
+  assert.deepStrictEqual(first.history[first.history.length - 1], { type: "user_message", text: "Analyze area A" });
+  assert.deepStrictEqual(second.history[second.history.length - 1], { type: "user_message", text: "Analyze area B" });
+  assert.deepStrictEqual(first.messageUUIDs, fixture.parent.messageUUIDs);
+  assert.deepStrictEqual(fixture.forks.map(function(call) { return call.uuid; }), ["uuid-assistant", "uuid-assistant"]);
+});
+
+test("forkFromCurrent restores Claude CLI history before the task prompt", async function() {
+  var cliHistory = [
+    { type: "user_message", text: "Inherited from CLI" },
+    { type: "message_uuid", uuid: "cli-uuid", messageType: "user" },
+  ];
+  var fixture = createForkFixture({
+    forkSession: function() {
+      return Promise.resolve({ sessionId: "cli-fork-1", useLocalHistory: false });
+    },
+    readCliSessionHistory: function(home, cwd, sessionId) {
+      assert.strictEqual(cwd, process.cwd());
+      assert.strictEqual(sessionId, "cli-fork-1");
+      return Promise.resolve(cliHistory);
+    },
+  });
+  var response = await fixture.spawn({
+    sessions: '[{"title":"CLI fork","prompt":"New task"}]',
+    forkFromCurrent: true,
+  });
+  var result = JSON.parse(response.content[0].text);
+  var child = fixture.sessions.get(result.spawned[0].localId);
+  assert.notStrictEqual(child.history, cliHistory);
+  assert.deepStrictEqual(child.history, cliHistory.concat([{ type: "user_message", text: "New task" }]));
+  assert.deepStrictEqual(child.messageUUIDs, [{ uuid: "cli-uuid", type: "user", historyIndex: 1 }]);
+});
+
+test("forkFromCurrent rejects a parent without a completed turn", async function() {
+  var fixture = createForkFixture({ parent: { cliSessionId: null } });
+  var response = await fixture.spawn({ sessions: '[{"prompt":"Task"}]', forkFromCurrent: true });
+  assert.strictEqual(response.isError, true);
+  assert.strictEqual(response.content[0].text, "Error: forkFromCurrent requires the calling session to have at least one completed turn");
+  assert.strictEqual(fixture.sessions.size, 1);
+  assert.strictEqual(fixture.forks.length, 0);
+});
+
+test("forkFromCurrent requires a fork-capable vendor", async function() {
+  var fixture = createForkFixture({ capabilitiesByVendor: { claude: { fork: false } } });
+  var response = await fixture.spawn({ sessions: '[{"prompt":"Task"}]', forkFromCurrent: true });
+  assert.strictEqual(response.isError, true);
+  assert.strictEqual(response.content[0].text, "Error: forkFromCurrent is not supported by vendor: claude");
+  assert.strictEqual(fixture.sessions.size, 1);
+  assert.strictEqual(fixture.forks.length, 0);
+});
+
+test("forkFromCurrent locks children to the parent vendor", async function() {
+  var fixture = createForkFixture({
+    capabilitiesByVendor: { claude: { fork: true }, codex: { fork: true } },
+    adapters: { claude: {}, codex: {} },
+  });
+  var response = await fixture.spawn({
+    sessions: '[{"prompt":"Task"}]',
+    vendor: "codex",
+    forkFromCurrent: true,
+  });
+  assert.strictEqual(response.isError, true);
+  assert.strictEqual(response.content[0].text, "Error: forkFromCurrent children must use the parent's vendor");
+  assert.strictEqual(fixture.sessions.size, 1);
+  assert.strictEqual(fixture.forks.length, 0);
+});
+
+test("forkFromCurrent reports a partial result and queues only successful forks", async function() {
+  var fixture = createForkFixture({
+    forkSession: function(session, uuid, count) {
+      if (count === 2) return Promise.reject(new Error("fork two failed"));
+      return Promise.resolve({ sessionId: "cli-fork-" + count, useLocalHistory: true });
+    },
+  });
+  var response = await fixture.spawn({
+    sessions: JSON.stringify([
+      { title: "One", prompt: "Task one" },
+      { title: "Two", prompt: "Task two" },
+      { title: "Three", prompt: "Task three" },
+    ]),
+    forkFromCurrent: true,
+  });
+  var result = JSON.parse(response.content[0].text);
+  assert.strictEqual(result.spawned.length, 1);
+  assert.deepStrictEqual(result.failed, { index: 1, error: "fork two failed" });
+  assert.strictEqual(result.running, 1);
+  assert.strictEqual(result.queued, 0);
+  assert.strictEqual(fixture.starts.length, 1);
+  assert.strictEqual(fixture.sessions.size, 2);
+  assert.strictEqual(fixture.broadcasts, 1);
 });
 
 test("session spawn rejects an unknown vendor", function() {


### PR DESCRIPTION
## Summary

Implements #358: one session can create N sibling sessions.

- **`clay-sessions` MCP server** with `spawn_sessions` (up to 10 titled children per call, each starting its own prompt, max 3 concurrent queries with a completion-driven queue) and `check_spawned_sessions` (running/done/error polling so the parent can collect results).
- **`forkFromCurrent`**: children are created from a CLI-native fork of the parent session, inheriting its full conversation context and receiving only a short task prompt — the workflow described in the issue thread.
- **Safety rails**: spawned children cannot spawn (depth guard), 20-children-per-parent cap, vendor validation through the YOKE registry (OS-isolation guard included), owner/visibility/Linux-user inheritance, and the tools are deliberately absent from every auto-approve list so the permission prompt always fires.
- **Session-bound tool servers**: `getLocalMcpServers`/`getMcpServers` now thread the querying session, and each query's `clay-sessions` instance closes over its caller — this keeps the depth guard sound when a child calls the tool and prevents cross-user misattribution.

Fork semantics verified against primary sources: Claude SDK `upToMessageId` omitted = full copy (`sdk.d.ts:708`); Codex `thread/fork` forks the whole thread (`codex.js:1567`). Known cosmetic limitation: codex fork children resume with full context but their Clay transcript shows only the task prompt (same as the existing UI fork on codex).

Closes #358.

## Test plan

- `npm test` 78/78 (18 spawn tests: batch parsing, caps, depth guard incl. the bound-child case, queue advancement, vendor guards, fork happy path/CLI-history path/error paths/partial failure)
- Live E2E: context planted in a parent, two `forkFromCurrent` children spawned via the permission card; both knew the parent's context without it appearing in their prompts; depth guard and permission prompt behaved as designed
- Static sweeps and client import check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)