### PR TITLE
feat(sidebar): per-session vendor badges

### DIFF
--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -105,7 +105,6 @@ function attachConnection(ctx) {
     }
 
     var loopState = _loop.loopState;
-    var loopRegistry = _loop.loopRegistry;
 
     // Resume loop if server restarted mid-execution (deferred so client gets initial state first)
     if (loopState._needsResume) {
@@ -179,32 +178,13 @@ function attachConnection(ctx) {
     if (_mcp) _mcp.sendConnectionState(ws);
     if (_notifications) _notifications.sendConnectionState(ws, sendTo);
 
-    // Session list (filtered for access control)
+    // Session list (filtered for access control). Uses the same mapper as
+    // broadcastSessionList: a hand-rolled copy here silently drifts and
+    // drops fields (the connect-time list was missing vendor/spawn/mode,
+    // so vendor badges showed Claude until the next broadcast).
     sendTo(ws, {
       type: "session_list",
-      sessions: allSessions.map(function (s) {
-        var loop = s.loop ? Object.assign({}, s.loop) : null;
-        if (loop && loop.loopId && loopRegistry) {
-          var rec = loopRegistry.getById(loop.loopId);
-          if (rec) {
-            if (rec.name) loop.name = rec.name;
-            if (rec.source) loop.source = rec.source;
-          }
-        }
-        return {
-          id: s.localId,
-          cliSessionId: s.cliSessionId || null,
-          title: s.title || "New Session",
-          active: s.localId === sm.activeSessionId,
-          isProcessing: s.isProcessing,
-          lastActivity: s.lastActivity || s.createdAt || 0,
-          loop: loop,
-          ownerId: s.ownerId || null,
-          sessionVisibility: s.sessionVisibility || "shared",
-          bookmarked: !!s.bookmarked,
-          favoriteOrder: typeof s.favoriteOrder === "number" ? s.favoriteOrder : null,
-        };
-      }),
+      sessions: allSessions.map(function (s) { return sm.mapSessionForClient(s); }),
     });
 
     // Restore active session for this client from server-side presence

--- a/lib/public/css/mobile-nav.css
+++ b/lib/public/css/mobile-nav.css
@@ -438,6 +438,22 @@
     object-fit: cover;
   }
 
+  /* No hover on touch: rest state stays dimmed, the active session shows color. */
+  .mobile-session-vendor-icon {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    border-radius: 3px;
+    object-fit: cover;
+    margin-right: 8px;
+    opacity: 0.5;
+    filter: grayscale(0.9) brightness(0.9);
+  }
+  .mobile-session-item.active .mobile-session-vendor-icon {
+    opacity: 1;
+    filter: none;
+  }
+
   /* --- Chat filter bar (horizontal scroll chips) --- */
   .mobile-chat-filter-bar {
     display: flex;

--- a/lib/public/css/sidebar.css
+++ b/lib/public/css/sidebar.css
@@ -835,6 +835,25 @@
   contain: size layout;
 }
 
+/* Vendor badge stays nearly monochrome at rest so a long session list does
+   not read as a row of logos; hover or the active session restores color. */
+.session-vendor-icon {
+  width: 13px;
+  height: 13px;
+  border-radius: 3px;
+  object-fit: cover;
+  vertical-align: -2px;
+  margin-right: 5px;
+  opacity: 0.45;
+  filter: grayscale(0.9) brightness(0.9);
+  transition: opacity 0.15s, filter 0.15s;
+}
+.session-item:hover .session-vendor-icon,
+.session-item.active .session-vendor-icon {
+  opacity: 1;
+  filter: none;
+}
+
 .session-item-text {
   flex: 1;
   overflow: hidden;

--- a/lib/public/modules/sidebar-mobile.js
+++ b/lib/public/modules/sidebar-mobile.js
@@ -383,6 +383,14 @@ function createMobileSessionItem(s) {
   var el = document.createElement("button");
   el.className = "mobile-session-item" + (s.active ? " active" : "");
 
+  // Vendor badge (legacy sessions without a vendor are Claude)
+  var mVendor = s.vendor || "claude";
+  var vendorIcon = document.createElement("img");
+  vendorIcon.className = "mobile-session-vendor-icon";
+  vendorIcon.src = VENDOR_AVATARS[mVendor] || VENDOR_AVATARS.claude;
+  vendorIcon.alt = "";
+  el.appendChild(vendorIcon);
+
   // Processing dot (left side, before title)
   if (s.isProcessing) {
     var dot = document.createElement("span");

--- a/lib/public/modules/sidebar-sessions.js
+++ b/lib/public/modules/sidebar-sessions.js
@@ -1148,6 +1148,11 @@ function renderSessionItem(s) {
   var textSpan = document.createElement("span");
   textSpan.className = "session-item-text";
   var textHtml = "";
+  // Which agent runtime this session ran on. Legacy sessions without a
+  // recorded vendor are Claude (pre-multi-vendor era).
+  var itemVendor = s.vendor || "claude";
+  textHtml += '<img class="session-vendor-icon" src="' + (VENDOR_AVATARS[itemVendor] || VENDOR_AVATARS.claude) +
+    '" alt="" title="' + escapeHtml(VENDOR_NAMES[itemVendor] || itemVendor) + '">';
   if (s.isProcessing) {
     textHtml += '<span class="session-processing"></span>';
   }

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1091,6 +1091,7 @@ function createSessionManager(opts) {
     searchSessions: searchSessions,
     searchSessionContent: searchSessionContent,
     setResolveLoopInfo: setResolveLoopInfo,
+    mapSessionForClient: mapSessionForClient,
     migrateSessionTitles: migrateSessionTitles,
     setSessionVisibility: function (localId, visibility) {
       var session = sessions.get(localId);


### PR DESCRIPTION
## Summary

- Every session row (desktop sidebar + mobile sheet) shows a small vendor avatar. At rest it is nearly monochrome and dimmed so a long list does not read as a row of logos; hover or the active session restores full color. Sessions without a recorded vendor render as Claude (pre-multi-vendor fallback).
- Fixes the bug the badge exposed: the connect-time `session_list` was a hand-rolled copy of the session mapping that had drifted from `mapSessionForClient` (missing `vendor`, `spawn`, `unread`, `mode`, runtime fields), so badges showed Claude for every session right after entering a project until the next broadcast. The connect path now uses the shared mapper.

## Test plan

- `npm test` 78/78, syntax sweeps and import check green
- Live: Kiro session keeps its badge immediately after switching away from and back to the project (previously required clicking another session first); hover shows the vendor name; unread badges now populate on first render too

🤖 Generated with [Claude Code](https://claude.com/claude-code)