### PR TITLE
feat(ui): worktrees as branches inside their project

### DIFF
--- a/docs/ongoing/worktree-switcher-handoff.md
+++ b/docs/ongoing/worktree-switcher-handoff.md
@@ -1,0 +1,233 @@
+# Handoff: worktrees as branches inside a project (stage 1: title-bar switcher)
+
+**Status:** proposed / ready to implement
+**Author:** handoff from Chad + Claude, 2026-08-16
+**Branch:** start from `main`
+**Decision (Chad, 2026-08-16):** worktrees should feel like something INSIDE
+one project, not sibling projects. Stage 1 keeps the per-worktree project
+context untouched and changes only the presentation: a branch switcher chip
+in the title bar replaces the worktree folder in the project strip.
+
+---
+
+## Mission
+
+Today a worktree is registered as a separate project (own slug
+`<parent>--<dir>`, own context) and rendered in the project icon strip as a
+collapsible folder under its parent. Clicking one navigates the whole app to
+"another project": different icon identity, different session list, no sense
+of "same repo, different branch".
+
+Stage 1 turns the presentation into a branch model:
+
+1. Worktrees disappear from the project icon strip entirely.
+2. The title bar gains a branch chip: `⎇ <branch> ▾`. Its dropdown lists
+   main + all worktrees of the current project family, switches between
+   them, and offers "New worktree".
+3. While a worktree is current, the title bar keeps the PARENT's name and
+   icon; only the chip changes. Switching reads as changing branches, not
+   leaving the project.
+
+Explicitly out of scope (stage 2, do not build): aggregating worktree
+sessions into the parent's session list, spawn-into-worktree, any change to
+project contexts, slugs, URLs, or the daemon registry.
+
+## Constraints
+
+- Root `CLAUDE.md` rules apply: `var`, no arrow functions, client modules
+  are ES modules, state in `store.js`, no `var _ctx` patterns, English
+  comments/commits, Angular commits, no commit/push/PR without Chad's
+  approval, and **no localStorage for user state** (this handoff deletes one
+  existing violation, see 3f).
+- Keep green: `npm test`, both syntax sweeps, `node scripts/check-client-imports.js`.
+
+---
+
+## Verified current state (all file:line checked 2026-08-16)
+
+| Fact | Where |
+|---|---|
+| Worktree slug = `parentSlug + "--" + dirName`; registered as a project whose display name is the branch, icon inherited from parent | `lib/daemon-projects.js:34-43` |
+| Client project objects already carry everything the chip needs: `isWorktree`, `parentSlug`, `branch`, `worktreeAccessible`, `isProcessing`, `unread`, `pendingPermissions`, `onlineUsers` | `lib/public/modules/app-projects.js:315-325` |
+| Project strip renders a collapsible parent+worktrees folder (chevron, per-family processing/pending aggregation) | `lib/public/modules/sidebar-projects.js:963-1330` (`groupProjects`, folder render, aggregation at `:1218` and `:1329`) |
+| Folder collapse state persisted in localStorage (`clay-wt-collapsed`) | `sidebar-projects.js:34-37, 956-960` |
+| Title bar: `#title-bar-project-dropdown` holds `#title-bar-project-icon` + `#title-bar-project-name` + chevron | `lib/public/index.html:207-211`; name updated from `app-projects.js:335` and `app-messages.js:85,299,308`; dropdown behavior in `sidebar-projects.js:290,790` |
+| Project switching entry point | `app-projects.js:409` `switchProject(slug)` |
+| "Add Worktree" context-menu item on parent projects; modal `showWorktreeModal(parentSlug, parentName)` fetches `/p/<slug>/api/branches`, sends `create_worktree`, handles `create_worktree_result` | `sidebar-projects.js:530,626-633,1040-1160` |
+| "Remove Worktree" context-menu item on worktree strip items; delete flow shows confirm, sends `delete_project`, toasts "Worktree removed" | `sidebar-projects.js:503-518`, `app-projects.js:480,561-598` |
+| Cmd-K project switcher lists worktrees and disables unreachable ones; command palette already skips worktrees | `project-switcher.js:260-310`, `command-palette.js:351` |
+
+No server changes are needed for stage 1. The `projects` payload (`info`
+message) already contains the family structure.
+
+---
+
+## Implementation
+
+### 3a. Family helper (client)
+
+In `app-projects.js` (or a small helper in `sidebar-projects.js`), derive
+from the cached projects list:
+
+```js
+// familyOf(slug): { parent, worktrees: [...] } where parent is the non-wt
+// project and worktrees are its children, using isWorktree/parentSlug.
+// For a worktree slug, resolve through parentSlug first.
+```
+
+`currentFamily()` = family of `store.currentSlug`. The chip and strip both
+render from this.
+
+### 3b. Project strip: remove the worktree folder
+
+In `sidebar-projects.js` strip rendering (`:1190-1330`):
+
+- Render parents only; drop the folder wrapper, chevron, and child rows.
+- KEEP the family aggregation: the parent icon's processing dot, unread,
+  and pending-permission badges must include its worktrees (the aggregation
+  loops at `:1218` and `:1329` already compute this; reattach them to the
+  single parent icon).
+- When the current project IS a worktree, mark the PARENT icon active in
+  the strip (`renderIconStrip` active-slug logic at `app-projects.js:328`
+  area: map a worktree currentSlug to its parentSlug for highlighting).
+
+### 3c. Title bar: branch chip
+
+`lib/public/index.html` next to `#title-bar-project-dropdown` (inside
+`.title-bar-sidebar`):
+
+```html
+<button id="branch-chip" class="hidden">
+  <i data-lucide="git-branch"></i>
+  <span id="branch-chip-label"></span>
+  <i data-lucide="chevron-down"></i>
+</button>
+<div id="branch-chip-menu" class="hidden"></div>
+```
+
+Behavior (new client module `lib/public/modules/branch-switcher.js`, wired
+from `app.js`; keep it under 200 lines):
+
+- Visibility: show the chip when `currentFamily().worktrees.length > 0`,
+  or when the current project is itself a worktree. Hide in DM/mate mode
+  (same gating the vendor toggle uses) and on the home hub.
+- Label: current branch. For the parent project the branch is not in the
+  payload; label it `main` only if cheap to know, otherwise use the repo's
+  actual default branch via the existing `/api/branches` route's
+  `headRef`... do NOT guess: `showWorktreeModal` already fetches
+  `/p/<slug>/api/branches` (`sidebar-projects.js:1085`) and the route
+  resolves `origin/HEAD` (`project-http.js:667-673`). Reuse that (cache per
+  slug). If the fetch fails, label the parent entry "default".
+- Dropdown rows: parent first, then worktrees sorted by name. Each row:
+  `⎇ branch`, processing dot / pending badge (data from the projects
+  payload), disabled state for `worktreeAccessible === false` with the same
+  tooltip the strip used (`project-switcher.js:260-263` has the wording).
+  Current row checkmarked.
+- Row click: `switchProject(slug)` — nothing else. The illusion work is 3d.
+- Footer row: `+ New worktree...` opens the existing
+  `showWorktreeModal(parentSlug, parentName)` (export it from
+  sidebar-projects.js if not already).
+- Per-row overflow action (or right-click, matching strip conventions):
+  `Remove worktree` for worktree rows, reusing the existing confirm +
+  `delete_project` flow from `app-projects.js:480`. This action currently
+  lives on the strip items that are being deleted, so it MUST move here or
+  worktree removal becomes unreachable from the UI.
+- Close on outside click like other popovers (see `session-ctx-menu`
+  document click pattern in `sidebar-sessions.js:492-495`).
+
+### 3d. Identity illusion while inside a worktree
+
+When `currentSlug` is a worktree:
+
+- `#title-bar-project-name` shows the PARENT project's name, not the
+  branch. The three writers of that element (`app-projects.js:335`,
+  `app-messages.js:85,299,308`) must route through one helper (put it in
+  app-projects.js) that resolves worktree -> parent name; the branch lives
+  in the chip. Same for `#title-bar-project-icon`.
+- Everything else (sessions, file browser, chat) keeps pointing at the
+  worktree project context exactly as today. No behavioral change.
+
+### 3e. Keyboard/switcher surfaces
+
+- `project-switcher.js`: keep worktrees listed (keyboard users need a path)
+  but label rows `parentName ⎇ branch` instead of the bare branch name.
+- `command-palette.js:351` already skips worktrees; leave it.
+
+### 3f. Delete the localStorage collapse state
+
+`sidebar-projects.js:34-37` and `:956-960` (`clay-wt-collapsed`) become
+dead with the folder UI; remove them. This also clears an existing
+violation of the no-localStorage rule. Do not migrate the stored value;
+it is presentation-only.
+
+### 3g. Mobile
+
+The mobile project sheet lists projects via `sidebar-mobile.js`. Stage 1
+scope: hide worktree entries from the mobile project list the same way as
+the strip, and add the family aggregation to the parent row. A mobile
+branch switcher is a follow-up; note it in the PR description rather than
+building it.
+
+---
+
+## Edge cases (handle explicitly)
+
+1. **Worktree removed while you are in it**: the existing delete flow
+   already handles navigation on `project_deleted` (`app-projects.js:561-598`,
+   which knows the `--` slug convention); verify it lands you on the parent
+   and the chip updates. Fix in place if it strands you.
+2. **Worktree becomes inaccessible** (parent moved): disabled dropdown row,
+   same as the switcher today.
+3. **No worktrees**: chip hidden entirely; "Add Worktree" stays available
+   in the project context menu, and the chip appears after the first
+   worktree registers (the daemon rescan interval, `daemon-projects.js:45-48`,
+   pushes an updated projects list; verify the chip appears without reload).
+4. **Multi-user**: worktree projects inherit parentOwnerId at registration
+   (`daemon-projects.js:41`); the dropdown must not offer families the user
+   cannot access — derive rows only from the projects payload the server
+   already filtered.
+5. **Deep links** (`/p/parent--dir`) keep working unchanged; entering via
+   URL must produce the same title-bar state as arriving via the chip.
+
+---
+
+## Tests / verification
+
+Client-heavy change, so automated coverage is the sweeps plus:
+
+- `node scripts/check-client-imports.js` (new module import graph).
+- If `familyOf`/label-resolution helpers are pure, put them in the new
+  module as exported functions and add `test/worktree-switcher.test.js`
+  exercising family derivation from a fixture projects array (parent with
+  2 wt, orphan wt whose parent is absent, inaccessible wt).
+
+Manual acceptance (record in this file's verification log):
+
+1. Project with 2 worktrees: strip shows ONE icon; chip shows the default
+   branch; dropdown lists 3 rows + New worktree.
+2. Switching via chip keeps the project name/icon in the title bar and
+   swaps sessions/file browser to the worktree; the strip highlight stays
+   on the parent.
+3. Processing dot on the parent icon lights when only a worktree session
+   is running.
+4. Create + remove a worktree from the chip; removal while inside it lands
+   on the parent.
+5. Cmd-K switcher rows read `parent ⎇ branch`; unreachable wt disabled.
+6. DM/mate mode and home hub: chip hidden.
+7. No `clay-wt-collapsed` reads/writes remain (`grep -rn "clay-wt-collapsed" lib/`).
+
+---
+
+## Verification log
+
+- 2026-08-16: `npm test` passed (82/82), including four new pure helper tests.
+- 2026-08-16: Both server/client syntax sweeps and
+  `node scripts/check-client-imports.js` passed (82 client modules).
+- 2026-08-16: Browser component harness with one parent and two worktrees
+  passed: one active parent strip icon, parent title identity, branch label,
+  aggregated processing/unread/pending state, three dropdown rows plus New
+  worktree, inaccessible-row disabling, and DM/mate/home visibility gates.
+- 2026-08-16: Keyboard switcher labels verified as `parent ⎇ branch`.
+- 2026-08-16: Full authenticated create/remove and session/file-context swaps
+  were not run because the local dev server required the user's Clay PIN; no
+  live project registry was mutated during verification.

--- a/lib/project-http.js
+++ b/lib/project-http.js
@@ -676,10 +676,13 @@ function attachHTTP(ctx) {
           defBr = hrRef.replace(/^origin\//, "");
         } catch (e) {}
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ branches: brList, defaultBranch: defBr }));
+        res.end(JSON.stringify({ branches: brList, defaultBranch: defBr, isGitRepo: true }));
       } catch (e) {
+        // git failed: not a repository (or git missing). The branch chip
+        // hides itself on isGitRepo:false; the fallback branch list keeps
+        // the worktree modal from crashing if it is somehow reached.
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ branches: ["main"], defaultBranch: "main" }));
+        res.end(JSON.stringify({ branches: ["main"], defaultBranch: "main", isGitRepo: false }));
       }
       return true;
     }

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -42,6 +42,7 @@ import { initProfile, getProfileLang } from './modules/profile.js';
 import { initUserSettings } from './modules/user-settings.js';
 import { initToolPalettes } from './modules/tool-palette.js';
 import { initProjectSwitcher } from './modules/project-switcher.js';
+import { initBranchSwitcher } from './modules/branch-switcher.js';
 import { initAdmin, checkAdminAccess } from './modules/admin.js';
 import { initSessionSearch, toggleSearch, closeSearch, isSearchOpen, handleFindInSessionResults, onHistoryPrepended as onSessionSearchHistoryPrepended } from './modules/session-search.js';
 import { initTooltips, registerTooltip } from './modules/tooltip.js';
@@ -85,7 +86,6 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   var sendBtn = $("send-btn");
   function getStatusDot() {
     return document.querySelector("#icon-strip-projects .icon-strip-item.active .icon-strip-status") ||
-           document.querySelector("#icon-strip-projects .icon-strip-wt-item.active .icon-strip-status") ||
            document.querySelector("#icon-strip-users .icon-strip-mate.active .icon-strip-status");
   }
   var headerTitleEl = $("header-title");
@@ -270,6 +270,8 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     projectName: projectName,
     cwd: "",
     currentSlug: currentSlug,
+    projects: [],
+    homeHubVisible: false,
     currentProjectOwnerId: null,
     isOsUsers: false,
     skipPermsEnabled: false,
@@ -461,6 +463,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   // keydown listener registers later — capture-phase ordering doesn't
   // matter here but it keeps related bootstrap steps adjacent.
   initProjectSwitcher();
+  initBranchSwitcher();
 
   // --- Connect overlay (animated ASCII logo) ---
   var asciiLogoCanvas = $("ascii-logo-canvas");

--- a/lib/public/css/icon-strip.css
+++ b/lib/public/css/icon-strip.css
@@ -223,7 +223,6 @@
 
 /* Show dot only on active item or when processing */
 .icon-strip-item.active .icon-strip-status,
-.icon-strip-wt-item.active .icon-strip-status,
 .icon-strip-status.processing {
   opacity: 1;
 }
@@ -248,7 +247,6 @@
 
 /* Pending permission shake */
 .icon-strip-item.has-pending-perm,
-.icon-strip-wt-item.has-pending-perm,
 .icon-strip-mate.has-pending-perm {
   animation: permShake 2s ease-in-out infinite;
 }
@@ -1146,155 +1144,6 @@
   opacity: 1;
 }
 
-/* --- Worktree folder groups --- */
-.icon-strip-group {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  position: relative;
-}
-
-.icon-strip-group .folder-header {
-  position: relative;
-}
-
-.icon-strip-group-chevron {
-  position: absolute;
-  bottom: 2px;
-  right: 2px;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-dimmer);
-  pointer-events: auto;
-  cursor: pointer;
-  transition: transform 0.15s ease, background 0.15s, border-color 0.15s;
-  z-index: 2;
-  line-height: 1;
-}
-
-.icon-strip-group-chevron i,
-.icon-strip-group-chevron svg {
-  width: 10px;
-  height: 10px;
-}
-
-.icon-strip-group-chevron:hover {
-  background: var(--bg-hover, var(--bg-alt));
-  border-color: var(--text-dimmer);
-  color: var(--text-secondary);
-}
-
-.icon-strip-group.collapsed .icon-strip-group-chevron {
-  background: var(--border);
-}
-
-.icon-strip-group-items {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  overflow: hidden;
-  transition: max-height 0.2s ease;
-  max-height: 500px;
-  border-left: 2px solid var(--border);
-  margin-left: 0;
-  padding-left: 0;
-}
-
-.icon-strip-group.collapsed .icon-strip-group-items {
-  max-height: 0;
-}
-
-/* Worktree items (smaller than regular project icons) */
-.icon-strip-wt-item {
-  width: 48px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  position: relative;
-  text-decoration: none;
-  color: var(--text-secondary);
-  transition: background 0.15s;
-}
-
-.icon-strip-wt-item::before {
-  content: "";
-  position: absolute;
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
-  background: var(--bg-alt);
-  opacity: 0.7;
-  transition: opacity 0.15s, background 0.15s;
-}
-
-.icon-strip-wt-item:hover::before {
-  opacity: 1;
-}
-
-.icon-strip-wt-item.active::before {
-  background: var(--accent);
-  opacity: 1;
-}
-
-.icon-strip-wt-item.active {
-  color: #fff;
-}
-
-.icon-strip-wt-item .wt-branch-abbrev {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: -0.5px;
-  pointer-events: none;
-  position: relative;
-  z-index: 1;
-}
-
-/* Disabled/inaccessible worktree */
-.icon-strip-wt-item.wt-disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
-}
-
-.icon-strip-wt-item.wt-disabled::after {
-  content: "\1F6AB";
-  position: absolute;
-  font-size: 14px;
-  z-index: 3;
-  filter: grayscale(0.3);
-}
-
-/* Group add button */
-.icon-strip-group-add {
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
-  border: 1.5px dashed var(--border);
-  background: transparent;
-  color: var(--text-dimmer);
-  font-size: 16px;
-  font-weight: 400;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 2px 0 4px 0;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
-}
-
-.icon-strip-group-add:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-  background: rgba(var(--accent-rgb, 124, 58, 237), 0.08);
-}
-
 /* --- Worktree creation modal --- */
 .wt-modal-overlay {
   position: fixed;
@@ -1407,45 +1256,6 @@ select.wt-modal-input {
 .wt-modal-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-/* --- Mobile worktree folder --- */
-.mobile-project-folder {
-  display: flex;
-  flex-direction: column;
-}
-
-.mobile-project-item.wt-item {
-  padding-left: 28px;
-  opacity: 0.85;
-}
-
-.mobile-project-item.wt-disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
-}
-
-.mobile-folder-chevron {
-  font-size: 8px;
-  color: var(--text-dimmer);
-  margin-left: auto;
-  cursor: pointer;
-  transition: transform 0.15s ease;
-  padding: 4px;
-}
-
-.mobile-project-folder.collapsed .mobile-folder-chevron {
-  transform: rotate(-90deg);
-}
-
-.mobile-folder-items {
-  overflow: hidden;
-  transition: max-height 0.2s ease;
-  max-height: 500px;
-}
-
-.mobile-project-folder.collapsed .mobile-folder-items {
-  max-height: 0;
 }
 
 /* --- Per-project presence avatars --- */

--- a/lib/public/css/mobile-nav.css
+++ b/lib/public/css/mobile-nav.css
@@ -160,6 +160,10 @@
     background: rgba(var(--overlay-rgb), 0.06);
   }
 
+  .mobile-project-item.has-pending-perm {
+    animation: permShake 2s ease-in-out infinite;
+  }
+
   .mobile-project-abbrev {
     width: 32px;
     height: 32px;

--- a/lib/public/css/title-bar.css
+++ b/lib/public/css/title-bar.css
@@ -272,6 +272,175 @@
   transform: rotate(180deg);
 }
 
+.branch-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 132px;
+  /* Optical alignment: the pill reads slightly high next to the 17px/800
+     project name, so nudge it down within the centered flex row. */
+  margin-top: 2px;
+  padding: 4px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-alt);
+  color: var(--text-secondary);
+  font: 600 11px/1.2 "Pretendard", system-ui, sans-serif;
+  cursor: pointer;
+  flex-shrink: 1;
+}
+
+.branch-chip.hidden,
+.branch-chip-menu.hidden {
+  display: none;
+}
+
+.branch-chip:hover,
+.branch-chip.open {
+  border-color: var(--text-dimmer);
+  color: var(--text);
+}
+
+.branch-chip > svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+#branch-chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-chip-chevron {
+  transition: transform 0.15s;
+}
+
+.branch-chip.open .branch-chip-chevron {
+  transform: rotate(180deg);
+}
+
+.branch-chip-menu {
+  position: fixed;
+  z-index: 10020;
+  width: 250px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.branch-chip-row {
+  display: flex;
+  align-items: center;
+  border-radius: 7px;
+}
+
+.branch-chip-row:hover {
+  background: var(--bg-alt);
+}
+
+.branch-chip-row-main,
+.branch-chip-row-action,
+.branch-chip-new {
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.branch-chip-row-main {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px;
+  text-align: left;
+}
+
+.branch-chip-row-main:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.branch-chip-row-main svg,
+.branch-chip-row-action svg,
+.branch-chip-new svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.branch-chip-row-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-chip-row.current .branch-chip-row-label {
+  color: var(--text);
+  font-weight: 700;
+}
+
+.branch-chip-row-main > .lucide-check {
+  margin-left: auto;
+  color: var(--accent);
+}
+
+.branch-chip-processing {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--success, #23a55a);
+  flex-shrink: 0;
+}
+
+.branch-chip-pending {
+  min-width: 17px;
+  padding: 1px 4px;
+  border-radius: 8px;
+  background: var(--danger, #e74c3c);
+  color: #fff;
+  font-size: 9px;
+  text-align: center;
+}
+
+.branch-chip-row-action {
+  display: flex;
+  padding: 7px;
+  opacity: 0;
+}
+
+.branch-chip-row:hover .branch-chip-row-action,
+.branch-chip-row-action:focus-visible {
+  opacity: 0.7;
+}
+
+.branch-chip-row-action:hover {
+  color: var(--danger, #e74c3c);
+  opacity: 1;
+}
+
+.branch-chip-new {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 5px;
+  padding: 9px 8px 7px;
+  border-top: 1px solid var(--border-subtle);
+  text-align: left;
+}
+
+.branch-chip-new:hover {
+  color: var(--text);
+}
+
 .project-rename-input {
   width: 100%;
   font-family: "Pretendard", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -210,6 +210,12 @@
           <span class="title-bar-project-name" id="title-bar-project-name"></span>
           <i data-lucide="chevron-down" class="title-bar-chevron"></i>
         </button>
+        <button id="branch-chip" class="branch-chip hidden" type="button" aria-label="Switch branch" aria-expanded="false" aria-haspopup="menu">
+          <i data-lucide="git-branch"></i>
+          <span id="branch-chip-label"></span>
+          <i data-lucide="chevron-down" class="branch-chip-chevron"></i>
+        </button>
+        <div id="branch-chip-menu" class="branch-chip-menu hidden"></div>
         <span id="sidebar-presence" class="sidebar-presence"></span>
         <button id="sidebar-toggle-btn" class="sidebar-collapse-btn" title="Collapse sidebar"><i data-lucide="panel-left-close"></i></button>
       </div>

--- a/lib/public/modules/app-favicon.js
+++ b/lib/public/modules/app-favicon.js
@@ -106,14 +106,6 @@ export function blinkIO() {
   var sessionDot = document.querySelector(".session-item.active .session-processing") ||
                    document.querySelector(".mate-session-item.active .session-processing");
   if (sessionDot) sessionDot.classList.add("io");
-  // If active project is a worktree, also blink the parent project dot
-  var activeWt = document.querySelector("#icon-strip-projects .icon-strip-wt-item.active");
-  var parentDot = null;
-  if (activeWt) {
-    var group = activeWt.closest(".icon-strip-group");
-    if (group) parentDot = group.querySelector(".folder-header .icon-strip-status");
-    if (parentDot) parentDot.classList.add("io");
-  }
   // Mobile chat chip dot + mobile session dot
   var mobileChipDot = null;
   var _s = store.snap();
@@ -132,7 +124,6 @@ export function blinkIO() {
     var sd = document.querySelector(".session-item.active .session-processing.io") ||
              document.querySelector(".mate-session-item.active .session-processing.io");
     if (sd) sd.classList.remove("io");
-    if (parentDot) parentDot.classList.remove("io");
     if (mobileChipDot) mobileChipDot.classList.remove("io");
     if (mobileSessionDot) mobileSessionDot.classList.remove("io");
   }, 80);
@@ -152,7 +143,7 @@ export function blinkSessionDot(sessionId) {
 export function updateCrossProjectBlink() {
   if (crossProjectBlinkTimer) { clearTimeout(crossProjectBlinkTimer); crossProjectBlinkTimer = null; }
   function doBlink() {
-    var dots = document.querySelectorAll("#icon-strip-projects .icon-strip-item:not(.active) .icon-strip-status.processing, #icon-strip-projects .icon-strip-wt-item:not(.active) .icon-strip-status.processing, #icon-strip-users .icon-strip-mate:not(.active) .icon-strip-status.processing");
+    var dots = document.querySelectorAll("#icon-strip-projects .icon-strip-item:not(.active) .icon-strip-status.processing, #icon-strip-users .icon-strip-mate:not(.active) .icon-strip-status.processing");
     // Also blink mobile chat chip dots (same icon-strip-status class inside chips)
     var mobileDots = document.querySelectorAll(".mobile-chat-chip .icon-strip-status.processing");
     var allDots = [];

--- a/lib/public/modules/app-home-hub.js
+++ b/lib/public/modules/app-home-hub.js
@@ -619,6 +619,7 @@ export function showHomeHub() {
   // anywhere via the persistent FAB (#clay-fab), not embedded here.
   if (store.get('dmMode')) exitDmMode();
   homeHubVisible = true;
+  store.set({ homeHubVisible: true });
   homeHub.classList.remove("hidden");
   // Show close button only if there's a project to return to
   if (hubCloseBtn) {
@@ -652,6 +653,7 @@ export function showHomeHub() {
 export function hideHomeHub() {
   if (!homeHubVisible) return;
   homeHubVisible = false;
+  store.set({ homeHubVisible: false });
   homeHub.classList.add("hidden");
   stopTipRotation();
   var mobileHome = document.getElementById("mobile-home-btn");

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -47,7 +47,7 @@ import { setStatus } from './app-connection.js';
 import { handleWhatsNewState, handleWhatsNewSeenResult, setKnownEntries as setWhatsNewKnownEntries } from './whats-new.js';
 import { closeArticle as closeWhatsNewArticle } from './whats-new-article.js';
 import { getModelEffortLevels, accumulateUsage, updateUsagePanel, accumulateContext, updateContextPanel, renderCtxPopover, updateStatusPanel } from './app-panels.js';
-import { updateProjectList, resetClientState, showUpdateAvailable, handleRemoveProjectCheckResult, handleRemoveProjectResult, handleBrowseDirResult, handleAddProjectResult, handleCloneProgress } from './app-projects.js';
+import { updateProjectList, updateTitleBarProjectIdentity, resetClientState, showUpdateAvailable, handleRemoveProjectCheckResult, handleRemoveProjectResult, handleBrowseDirResult, handleAddProjectResult, handleCloneProgress } from './app-projects.js';
 import { updateHistorySentinel, prependOlderHistory } from './app-header.js';
 import { hideHomeHub, handleHubSchedules } from './app-home-hub.js';
 import { openDm, enterDmMode, exitDmMode, handleMateCreatedInApp, updateMateIconStatus, appendDmMessage, showDmTypingIndicator, buildMateInterviewPrompt } from './app-dm.js';
@@ -82,8 +82,7 @@ export function processMessage(msg) {
         // Override title bar with mate name and re-apply color
         var _mdn = (store.get('dmTargetUser').displayName || "New Mate");
         if (headerTitleEl) headerTitleEl.textContent = _mdn;
-        var _tbpn = document.getElementById("title-bar-project-name");
-        if (_tbpn) _tbpn.textContent = _mdn;
+        updateTitleBarProjectIdentity(_mdn, null);
         var _mc2 = (store.get('dmTargetUser').profile && store.get('dmTargetUser').profile.avatarColor) || store.get('dmTargetUser').avatarColor || "#7c3aed";
         var _tbc2 = document.querySelector(".title-bar-content");
         if (_tbc2) { _tbc2.style.background = _mc2; _tbc2.classList.add("mate-dm-active"); }
@@ -296,8 +295,7 @@ export function processMessage(msg) {
         if (store.get('dmMode') && store.get('dmTargetUser') && store.get('dmTargetUser').isMate) {
           var _mateDN = store.get('dmTargetUser').displayName || "New Mate";
           headerTitleEl.textContent = _mateDN;
-          var tbProjectName = document.getElementById("title-bar-project-name");
-          if (tbProjectName) tbProjectName.textContent = _mateDN;
+          updateTitleBarProjectIdentity(_mateDN, null);
           // Re-apply mate title bar styling (may be lost during project switch)
           var _mc = (store.get('dmTargetUser').profile && store.get('dmTargetUser').profile.avatarColor) || store.get('dmTargetUser').avatarColor || "#7c3aed";
           var _tbc = document.querySelector(".title-bar-content");
@@ -305,8 +303,7 @@ export function processMessage(msg) {
           document.body.classList.add("mate-dm-active");
         } else {
           headerTitleEl.textContent = store.get('projectName');
-          var tbProjectName = document.getElementById("title-bar-project-name");
-          if (tbProjectName) tbProjectName.textContent = msg.title || store.get('projectName');
+          updateTitleBarProjectIdentity(msg.title || store.get('projectName'), null);
         }
         updatePageTitle();
         if (msg.version) {

--- a/lib/public/modules/app-projects.js
+++ b/lib/public/modules/app-projects.js
@@ -32,6 +32,7 @@ import { resetRateLimitState } from './app-rate-limit.js';
 import { closeSessionInfoPopover } from './app-header.js';
 import { resetDebateState } from './debate.js';
 import { removeDebateBottomBar } from './app-debate-ui.js';
+import { familyOf as deriveFamily, displayProject } from './worktree-family.js';
 
 // --- Module-owned state ---
 var cachedProjects = [];
@@ -201,6 +202,32 @@ export function setCachedProjectCount(v) { cachedProjectCount = v; }
 export function getCachedRemovedProjects() { return cachedRemovedProjects; }
 export function setCachedRemovedProjects(v) { cachedRemovedProjects = v; }
 
+export function familyOf(slug) { return deriveFamily(cachedProjects, slug); }
+export function currentFamily() { return familyOf(store.get('currentSlug')); }
+
+export function updateTitleBarProjectIdentity(fallbackName, fallbackIcon) {
+  if (store.get('dmMode') || store.get('mateProjectSlug')) {
+    var dmNameEl = document.getElementById("title-bar-project-name");
+    if (dmNameEl && fallbackName) dmNameEl.textContent = fallbackName;
+    return;
+  }
+  var identity = displayProject(cachedProjects, store.get('currentSlug'));
+  var name = identity ? (identity.title || identity.project || identity.slug) : fallbackName;
+  var icon = identity ? (identity.icon || null) : (fallbackIcon || null);
+  var nameEl = document.getElementById("title-bar-project-name");
+  if (nameEl && name) nameEl.textContent = name;
+  var iconEl = document.getElementById("title-bar-project-icon");
+  if (!iconEl) return;
+  if (icon) {
+    iconEl.textContent = icon;
+    parseEmojis(iconEl);
+    iconEl.classList.add("has-icon");
+  } else {
+    iconEl.textContent = "";
+    iconEl.classList.remove("has-icon");
+  }
+}
+
 // --- Functions ---
 
 export function updateProjectList(msg) {
@@ -215,6 +242,7 @@ export function updateProjectList(msg) {
       _lastProjectsJson = projectsJson;
     }
     cachedProjects = msg.projects;
+    store.set({ projects: cachedProjects });
   }
   if (msg.removedProjects) cachedRemovedProjects = msg.removedProjects;
   else if (msg.removedProjects === undefined) { /* keep cached */ }
@@ -326,31 +354,12 @@ export function renderProjectList() {
   });
   var st = store.snap();
   var iconStripActiveSlug = (st.mateProjectSlug && st.savedMainSlug) ? st.savedMainSlug : st.currentSlug;
+  var activeFamily = deriveFamily(cachedProjects, iconStripActiveSlug);
+  if (activeFamily.parent) iconStripActiveSlug = activeFamily.parent.slug;
   renderIconStrip(iconStripProjects, iconStripActiveSlug);
   // Update title bar project name and icon if it changed
   if (!st.mateProjectSlug) {
-    for (var pi = 0; pi < cachedProjects.length; pi++) {
-      if (cachedProjects[pi].slug === st.currentSlug) {
-        var updatedName = cachedProjects[pi].title || cachedProjects[pi].project;
-        var tbName = document.getElementById("title-bar-project-name");
-        if (tbName && updatedName) tbName.textContent = updatedName;
-        var tbIcon = document.getElementById("title-bar-project-icon");
-        if (tbIcon) {
-          var pIcon = cachedProjects[pi].icon || null;
-          if (pIcon) {
-            tbIcon.textContent = pIcon;
-            parseEmojis(tbIcon);
-            tbIcon.classList.add("has-icon");
-            try { localStorage.setItem("clay-project-icon-" + (st.currentSlug || "default"), pIcon); } catch (e) {}
-          } else {
-            tbIcon.textContent = "";
-            tbIcon.classList.remove("has-icon");
-            try { localStorage.removeItem("clay-project-icon-" + (st.currentSlug || "default")); } catch (e) {}
-          }
-        }
-        break;
-      }
-    }
+    updateTitleBarProjectIdentity(store.get('projectName'), null);
   }
   // Re-apply current socket status to the active icon's dot
   var dot = getStatusDot();
@@ -557,9 +566,13 @@ function showRemoveProjectTaskDialog(slug, name, taskCount) {
 export function handleRemoveProjectResult(msg) {
   if (msg.ok) {
     var currentSlug = store.get('currentSlug');
+    var removedProj = null;
+    for (var ri = 0; ri < cachedProjects.length; ri++) {
+      if (cachedProjects[ri].slug === msg.slug) { removedProj = cachedProjects[ri]; break; }
+    }
+    var isWorktree = removedProj ? !!removedProj.isWorktree : msg.slug.indexOf("--") !== -1;
     if (msg.slug === currentSlug) {
-      var isWorktree = msg.slug.indexOf("--") !== -1;
-      var parentSlug = isWorktree ? msg.slug.split("--")[0] : null;
+      var parentSlug = isWorktree ? ((removedProj && removedProj.parentSlug) || msg.slug.split("--")[0]) : null;
 
       showToast(isWorktree ? "Worktree removed" : "Project removed", "success");
 
@@ -570,10 +583,6 @@ export function handleRemoveProjectResult(msg) {
       store.set({ connected: false });
       document.getElementById("connect-overlay").classList.add("hidden");
       if (!isWorktree) {
-        var removedProj = null;
-        for (var ri = 0; ri < cachedProjects.length; ri++) {
-          if (cachedProjects[ri].slug === msg.slug) { removedProj = cachedProjects[ri]; break; }
-        }
         if (removedProj) {
           cachedRemovedProjects.push({
             path: removedProj.path || "",
@@ -585,7 +594,7 @@ export function handleRemoveProjectResult(msg) {
       }
       cachedProjects = cachedProjects.filter(function (p) { return p.slug !== msg.slug; });
       cachedProjectCount = cachedProjects.length;
-      store.set({ currentSlug: null });
+      store.set({ currentSlug: null, projects: cachedProjects });
       renderProjectList();
       resetClientState();
 
@@ -595,7 +604,11 @@ export function handleRemoveProjectResult(msg) {
         showHomeHub();
       }
     } else {
-      showToast(msg.slug.indexOf("--") !== -1 ? "Worktree removed" : "Project removed", "success");
+      showToast(isWorktree ? "Worktree removed" : "Project removed", "success");
+      cachedProjects = cachedProjects.filter(function (p) { return p.slug !== msg.slug; });
+      cachedProjectCount = cachedProjects.length;
+      store.set({ projects: cachedProjects });
+      renderProjectList();
     }
   } else {
     showToast(msg.error || "Failed to remove project", "error");

--- a/lib/public/modules/branch-switcher.js
+++ b/lib/public/modules/branch-switcher.js
@@ -1,0 +1,178 @@
+// Title-bar branch switcher for a project and its worktrees.
+
+import { store } from './store.js';
+import { iconHtml, refreshIcons } from './icons.js';
+import { escapeHtml } from './utils.js';
+import { familyOf } from './worktree-family.js';
+import { switchProject, confirmRemoveProject } from './app-projects.js';
+import { showWorktreeModal } from './sidebar-projects.js';
+
+var chip = null;
+var label = null;
+var menu = null;
+var menuOpen = false;
+var defaultBranches = {};
+// slug -> true/false once /api/branches answers; undefined while unknown.
+// Non-git projects hide the chip (no worktrees to manage there).
+var gitRepoBySlug = {};
+
+function projectName(project) {
+  return project ? (project.title || project.project || project.name || project.slug) : "";
+}
+
+function currentProject(projects) {
+  var slug = store.get('currentSlug');
+  for (var i = 0; i < projects.length; i++) {
+    if (projects[i].slug === slug) return projects[i];
+  }
+  return null;
+}
+
+function defaultBranch(parent) {
+  return defaultBranches[parent.slug] || "default";
+}
+
+function requestDefaultBranch(parent) {
+  if (!parent || Object.prototype.hasOwnProperty.call(defaultBranches, parent.slug)) return;
+  defaultBranches[parent.slug] = null;
+  fetch("/p/" + encodeURIComponent(parent.slug) + "/api/branches")
+    .then(function (response) { return response.json(); })
+    .then(function (data) {
+      defaultBranches[parent.slug] = data.defaultBranch || "default";
+      gitRepoBySlug[parent.slug] = data.isGitRepo !== false;
+      renderBranchSwitcher();
+    })
+    .catch(function () {
+      defaultBranches[parent.slug] = "default";
+      renderBranchSwitcher();
+    });
+}
+
+function closeMenu() {
+  menuOpen = false;
+  if (menu) menu.classList.add("hidden");
+  if (chip) {
+    chip.classList.remove("open");
+    chip.setAttribute("aria-expanded", "false");
+  }
+}
+
+function positionMenu() {
+  if (!chip || !menu || !menuOpen) return;
+  var rect = chip.getBoundingClientRect();
+  var left = Math.min(rect.left, window.innerWidth - menu.offsetWidth - 8);
+  var top = rect.bottom + 6;
+  if (top + menu.offsetHeight > window.innerHeight - 8) top = rect.top - menu.offsetHeight - 6;
+  menu.style.left = Math.max(8, left) + "px";
+  menu.style.top = Math.max(8, top) + "px";
+}
+
+function branchLabel(project, parent) {
+  return project.isWorktree ? (project.branch || projectName(project)) : defaultBranch(parent);
+}
+
+function appendProjectRow(container, project, parent, isCurrent) {
+  var row = document.createElement("div");
+  row.className = "branch-chip-row" + (isCurrent ? " current" : "");
+  var inaccessible = project.isWorktree && project.worktreeAccessible === false;
+  var main = document.createElement("button");
+  main.className = "branch-chip-row-main";
+  main.disabled = inaccessible;
+  if (inaccessible) main.title = "Outside project path";
+  main.innerHTML = iconHtml("git-branch") + '<span class="branch-chip-row-label">' +
+    escapeHtml(branchLabel(project, parent)) + "</span>";
+  if (project.isProcessing) {
+    var dot = document.createElement("span");
+    dot.className = "branch-chip-processing";
+    main.appendChild(dot);
+  }
+  if (project.pendingPermissions > 0) {
+    var badge = document.createElement("span");
+    badge.className = "branch-chip-pending";
+    badge.textContent = project.pendingPermissions > 99 ? "99+" : String(project.pendingPermissions);
+    main.appendChild(badge);
+  }
+  if (isCurrent) main.insertAdjacentHTML("beforeend", iconHtml("check"));
+  if (!inaccessible) {
+    main.addEventListener("click", function () { closeMenu(); switchProject(project.slug); });
+  }
+  row.appendChild(main);
+
+  if (project.isWorktree && (!store.get('permissions') || store.get('permissions').deleteProject !== false)) {
+    var remove = document.createElement("button");
+    remove.className = "branch-chip-row-action";
+    remove.title = "Remove worktree";
+    remove.innerHTML = iconHtml("trash-2");
+    remove.addEventListener("click", function (event) {
+      event.stopPropagation();
+      closeMenu();
+      confirmRemoveProject(project.slug, projectName(project));
+    });
+    row.appendChild(remove);
+  }
+  container.appendChild(row);
+}
+
+function renderMenu(family, current) {
+  menu.innerHTML = "";
+  if (family.parent) appendProjectRow(menu, family.parent, family.parent, current.slug === family.parent.slug);
+  for (var i = 0; i < family.worktrees.length; i++) {
+    appendProjectRow(menu, family.worktrees[i], family.parent || family.worktrees[i], current.slug === family.worktrees[i].slug);
+  }
+  if (family.parent) {
+    var footer = document.createElement("button");
+    footer.className = "branch-chip-new";
+    footer.innerHTML = iconHtml("plus") + " <span>New worktree...</span>";
+    footer.addEventListener("click", function () {
+      closeMenu();
+      showWorktreeModal(family.parent.slug, projectName(family.parent));
+    });
+    menu.appendChild(footer);
+  }
+  refreshIcons();
+  positionMenu();
+}
+
+export function renderBranchSwitcher() {
+  if (!chip) return;
+  var projects = store.get('projects') || [];
+  var current = currentProject(projects);
+  var family = current ? familyOf(projects, current.slug) : { parent: null, worktrees: [] };
+  // The chip is the project's worktree management surface, so it shows even
+  // with zero worktrees (the menu then offers the default branch and "New
+  // worktree"). Hidden where there is no project context to manage, and for
+  // non-git projects (optimistically visible until /api/branches answers).
+  var gateSlug = family.parent ? family.parent.slug : (current ? current.slug : null);
+  var hidden = !current || store.get('dmMode') || store.get('mateProjectSlug') ||
+    store.get('homeHubVisible') || (gateSlug && gitRepoBySlug[gateSlug] === false);
+  chip.classList.toggle("hidden", hidden);
+  if (hidden) { closeMenu(); return; }
+  if (family.parent) requestDefaultBranch(family.parent);
+  label.textContent = branchLabel(current, family.parent || current);
+  if (menuOpen) renderMenu(family, current);
+}
+
+export function initBranchSwitcher() {
+  chip = document.getElementById("branch-chip");
+  label = document.getElementById("branch-chip-label");
+  menu = document.getElementById("branch-chip-menu");
+  if (!chip || !label || !menu) return;
+  chip.addEventListener("click", function (event) {
+    event.stopPropagation();
+    menuOpen = !menuOpen;
+    chip.classList.toggle("open", menuOpen);
+    chip.setAttribute("aria-expanded", menuOpen ? "true" : "false");
+    menu.classList.toggle("hidden", !menuOpen);
+    renderBranchSwitcher();
+  });
+  document.addEventListener("click", function (event) {
+    if (menuOpen && !menu.contains(event.target) && !chip.contains(event.target)) closeMenu();
+  });
+  window.addEventListener("resize", positionMenu);
+  store.subscribe(function (state, prev) {
+    if (state.projects !== prev.projects || state.currentSlug !== prev.currentSlug ||
+        state.dmMode !== prev.dmMode || state.mateProjectSlug !== prev.mateProjectSlug ||
+        state.homeHubVisible !== prev.homeHubVisible) renderBranchSwitcher();
+  });
+  renderBranchSwitcher();
+}

--- a/lib/public/modules/dom-refs.js
+++ b/lib/public/modules/dom-refs.js
@@ -16,6 +16,5 @@ export function getSessionListEl() { return ref("session-list"); }
 
 export function getStatusDot() {
   return document.querySelector("#icon-strip-projects .icon-strip-item.active .icon-strip-status") ||
-         document.querySelector("#icon-strip-projects .icon-strip-wt-item.active .icon-strip-status") ||
          document.querySelector("#icon-strip-users .icon-strip-mate.active .icon-strip-status");
 }

--- a/lib/public/modules/project-switcher.js
+++ b/lib/public/modules/project-switcher.js
@@ -19,6 +19,7 @@ import { getCachedProjects, switchProject } from './app-projects.js';
 import { openDm } from './app-dm.js';
 import { mateAvatarUrl } from './avatar.js';
 import { parseEmojis } from './markdown.js';
+import { switcherProjectName } from './worktree-family.js';
 
 var _projectMru = [];   // project slugs, most recent first
 var _mateMru = [];      // mate ids (mate_XXX), most recent first
@@ -263,7 +264,7 @@ function buildProjectEntries() {
     var unreachable = p.isWorktree && p.worktreeAccessible === false;
     return {
       key: p.slug,
-      title: p.title || p.project || p.slug,
+      title: switcherProjectName(projects, p),
       icon: p.icon || null,
       fallbackIcon: 'folder',
       isCurrent: p.slug === store.get('currentSlug'),

--- a/lib/public/modules/sidebar-mobile.js
+++ b/lib/public/modules/sidebar-mobile.js
@@ -38,6 +38,7 @@ import { showHomeHub } from './app-home-hub.js';
 import { openTerminal } from './terminal.js';
 import { requestKnowledgeList } from './mate-knowledge.js';
 import { loadRootDirectory } from './filebrowser.js';
+import { aggregateFamily, familyOf, parentProjects } from './worktree-family.js';
 
 // --- Mobile state ---
 var mobileChatSheetOpen = false;
@@ -147,10 +148,22 @@ function closeMobileSheet() {
 }
 
 function renderSheetProjects(listEl) {
-  for (var i = 0; i < getCachedProjectList().length; i++) {
+  var projects = getCachedProjectList();
+  var parents = parentProjects(projects);
+  var activeFamily = familyOf(projects, getCachedCurrentSlug());
+  var activeSlug = activeFamily.parent ? activeFamily.parent.slug : getCachedCurrentSlug();
+
+  for (var i = 0; i < parents.length; i++) {
     (function (p) {
+      var family = familyOf(projects, p.slug);
+      var displayProject = aggregateFamily(p, family.worktrees);
+      var hasWorktreeUnread = family.worktrees.some(function (worktree) { return worktree.unread > 0; });
+      var hasWorktreePending = family.worktrees.some(function (worktree) { return worktree.pendingPermissions > 0; });
       var el = document.createElement("button");
-      el.className = "mobile-project-item" + (p.slug === getCachedCurrentSlug() ? " active" : "");
+      el.className = "mobile-project-item" + (p.slug === activeSlug ? " active" : "");
+      if ((displayProject.pendingPermissions > 0 && p.slug !== activeSlug) || hasWorktreePending) {
+        el.classList.add("has-pending-perm");
+      }
 
       var abbrev = document.createElement("span");
       abbrev.className = "mobile-project-abbrev";
@@ -167,16 +180,16 @@ function renderSheetProjects(listEl) {
       name.textContent = p.name;
       el.appendChild(name);
 
-      if (p.isProcessing) {
+      if (displayProject.isProcessing) {
         var dot = document.createElement("span");
         dot.className = "mobile-project-processing";
         el.appendChild(dot);
       }
 
-      if (p.unread > 0 && p.slug !== getCachedCurrentSlug()) {
+      if (displayProject.unread > 0 && (p.slug !== activeSlug || hasWorktreeUnread)) {
         var mBadge = document.createElement("span");
         mBadge.className = "mobile-project-unread";
-        mBadge.textContent = p.unread > 99 ? "99+" : String(p.unread);
+        mBadge.textContent = displayProject.unread > 99 ? "99+" : String(displayProject.unread);
         el.appendChild(mBadge);
       }
 
@@ -186,7 +199,7 @@ function renderSheetProjects(listEl) {
       });
 
       listEl.appendChild(el);
-    })(getCachedProjectList()[i]);
+    })(parents[i]);
   }
 }
 

--- a/lib/public/modules/sidebar-projects.js
+++ b/lib/public/modules/sidebar-projects.js
@@ -10,9 +10,10 @@ import { store } from './store.js';
 import { getWs } from './ws-ref.js';
 import { closeSidebar } from './sidebar.js';
 import { showIconTooltip, hideIconTooltip, closeUserCtxMenu, getCurrentDmUserId } from './sidebar-mates.js';
-import { switchProject, openAddProjectModal, getCachedProjects } from './app-projects.js';
+import { switchProject, openAddProjectModal } from './app-projects.js';
 import { showHomeHub } from './app-home-hub.js';
 import { getPendingTuiAttention } from './app-notifications.js';
+import { aggregateFamily } from './worktree-family.js';
 
 // --- Project state ---
 var cachedProjectList = [];
@@ -30,12 +31,6 @@ var emojiPickerEl = null;
 // --- Drag-and-drop state ---
 var draggedSlug = null;
 var draggedEl = null;
-
-// --- Worktree folder collapse state (persisted in localStorage) ---
-var wtCollapsed = {};
-try {
-  wtCollapsed = JSON.parse(localStorage.getItem("clay-wt-collapsed") || "{}");
-} catch (e) {}
 
 var EMOJI_CATEGORIES = [
   { id: "frequent", icon: "🕐", label: "Frequent", emojis: [
@@ -524,17 +519,8 @@ function showIconCtxMenu(anchorEl, slug, name) {
       }
     });
     menu.appendChild(removeWtItem);
-  } else {
-    var wtItem = document.createElement("button");
-    wtItem.className = "project-ctx-item";
-    wtItem.innerHTML = iconHtml("git-branch") + " <span>Add Worktree</span>";
-    wtItem.addEventListener("click", function (e) {
-      e.stopPropagation();
-      closeProjectCtxMenu();
-      showWorktreeModal(slug, name || slug);
-    });
-    menu.appendChild(wtItem);
   }
+  // Worktree creation lives in the title-bar branch chip, not here.
 
   document.body.appendChild(menu);
   projectCtxMenu = menu;
@@ -619,20 +605,7 @@ function showProjectCtxMenu(anchorEl, slug, name, icon, position) {
     }
   }
 
-  var sep2 = document.createElement("div");
-  sep2.className = "project-ctx-separator";
-  menu.appendChild(sep2);
-
-  // --- Add Worktree ---
-  var wtItem = document.createElement("button");
-  wtItem.className = "project-ctx-item";
-  wtItem.innerHTML = iconHtml("git-branch") + " <span>Add Worktree</span>";
-  wtItem.addEventListener("click", function (e) {
-    e.stopPropagation();
-    closeProjectCtxMenu();
-    showWorktreeModal(slug, name || slug);
-  });
-  menu.appendChild(wtItem);
+  // Worktree creation lives in the title-bar branch chip, not here.
 
   if (!store.get('permissions') || store.get('permissions').deleteProject !== false) {
     var sep3 = document.createElement("div");
@@ -953,13 +926,6 @@ function setupDragHandlers(el, slug) {
   });
 }
 
-// --- Worktree folder collapse ---
-
-function setWtCollapsed(slug, collapsed) {
-  wtCollapsed[slug] = collapsed;
-  try { localStorage.setItem("clay-wt-collapsed", JSON.stringify(wtCollapsed)); } catch (e) {}
-}
-
 function groupProjects(projects) {
   var parents = [];
   var wtByParent = {};
@@ -973,6 +939,21 @@ function groupProjects(projects) {
     }
   }
   return { parents: parents, wtByParent: wtByParent };
+}
+
+function aggregateProjectFamily(parent, worktrees) {
+  var aggregate = aggregateFamily(parent, worktrees);
+  aggregate.hasFamilyPendingAttention = getPendingTuiAttention(parent.slug) > 0;
+  aggregate.hasWorktreeUnread = false;
+  aggregate.hasWorktreePending = false;
+  for (var i = 0; i < worktrees.length; i++) {
+    if (getPendingTuiAttention(worktrees[i].slug) > 0) aggregate.hasFamilyPendingAttention = true;
+    if (worktrees[i].unread > 0) aggregate.hasWorktreeUnread = true;
+    if (worktrees[i].pendingPermissions > 0 || getPendingTuiAttention(worktrees[i].slug) > 0) {
+      aggregate.hasWorktreePending = true;
+    }
+  }
+  return aggregate;
 }
 
 // --- Icon item creation ---
@@ -1006,7 +987,7 @@ function createIconItem(p, currentSlug) {
 
   var projectBadge = document.createElement("span");
   projectBadge.className = "icon-strip-project-badge";
-  if (p.unread > 0 && !isActive) {
+  if (p.unread > 0 && (!isActive || p.hasWorktreeUnread)) {
     projectBadge.textContent = p.unread > 99 ? "99+" : String(p.unread);
     projectBadge.classList.add("has-unread");
   }
@@ -1016,7 +997,8 @@ function createIconItem(p, currentSlug) {
   // broadcast — they surface via tui_attention notifications. We shake the
   // same icon for either, so the user notices regardless of which engine
   // is asking.
-  if (!isActive && (p.pendingPermissions > 0 || getPendingTuiAttention(p.slug) > 0)) {
+  if ((!isActive && (p.pendingPermissions > 0 || p.hasFamilyPendingAttention || getPendingTuiAttention(p.slug) > 0)) ||
+      p.hasWorktreePending) {
     el.classList.add("has-pending-perm");
   }
 
@@ -1037,7 +1019,7 @@ function createIconItem(p, currentSlug) {
 
 // --- Worktree creation modal ---
 
-function showWorktreeModal(parentSlug, parentName) {
+export function showWorktreeModal(parentSlug, parentName) {
   var existing = document.getElementById("wt-modal-container");
   if (existing) existing.remove();
 
@@ -1192,164 +1174,17 @@ export function renderIconStrip(projects, currentSlug) {
   for (var i = 0; i < grouped.parents.length; i++) {
     var p = grouped.parents[i];
     var worktrees = grouped.wtByParent[p.slug] || [];
-    var hasWorktrees = worktrees.length > 0;
-
-    if (!hasWorktrees) {
-      var el = createIconItem(p, currentSlug);
-      (function (slug, name, elem) {
-        elem.addEventListener("contextmenu", function (e) {
-          e.preventDefault();
-          e.stopPropagation();
-          showIconCtxMenu(elem, slug, name);
-        });
-      })(p.slug, p.name || p.slug, el);
-      setupDragHandlers(el, p.slug);
-      container.appendChild(el);
-      continue;
-    }
-
-    // Folder group for parent + worktrees
-    var folder = document.createElement("div");
-    folder.className = "icon-strip-group";
-    folder.dataset.parentSlug = p.slug;
-    if (wtCollapsed[p.slug]) folder.classList.add("collapsed");
-
-    if (!p.isProcessing) {
-      for (var wpi = 0; wpi < worktrees.length; wpi++) {
-        if (worktrees[wpi].isProcessing) { p.isProcessing = true; break; }
-      }
-    }
-
-    var header = createIconItem(p, currentSlug);
-    header.classList.add("folder-header");
+    var familyProject = aggregateProjectFamily(p, worktrees);
+    var el = createIconItem(familyProject, currentSlug);
     (function (slug, name, elem) {
       elem.addEventListener("contextmenu", function (e) {
         e.preventDefault();
         e.stopPropagation();
         showIconCtxMenu(elem, slug, name);
       });
-    })(p.slug, p.name || p.slug, header);
-    setupDragHandlers(header, p.slug);
-
-    var chevron = document.createElement("span");
-    chevron.className = "icon-strip-group-chevron";
-    chevron.innerHTML = '<i data-lucide="git-branch"></i>';
-    (function (parentSlug, folderEl) {
-      chevron.addEventListener("click", function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        var nowCollapsed = folderEl.classList.toggle("collapsed");
-        setWtCollapsed(parentSlug, nowCollapsed);
-      });
-      chevron.addEventListener("contextmenu", function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-      });
-    })(p.slug, folder);
-    chevron.setAttribute("data-tip", "Toggle worktrees");
-    header.appendChild(chevron);
-    folder.appendChild(header);
-
-    var itemsContainer = document.createElement("div");
-    itemsContainer.className = "icon-strip-group-items";
-
-    for (var wi = 0; wi < worktrees.length; wi++) {
-      (function (wt) {
-        var wtEl = document.createElement("a");
-        var isWtActive = wt.slug === currentSlug && !currentDmUserId;
-        var isAccessible = wt.worktreeAccessible !== false;
-        wtEl.className = "icon-strip-wt-item" + (isWtActive ? " active" : "") + (!isAccessible ? " wt-disabled" : "");
-        wtEl.href = "/p/" + wt.slug + "/";
-        wtEl.dataset.slug = wt.slug;
-
-        if (wt.icon) {
-          var wtEmoji = document.createElement("span");
-          wtEmoji.className = "wt-branch-abbrev project-emoji";
-          wtEmoji.textContent = wt.icon;
-          parseEmojis(wtEmoji);
-          wtEl.appendChild(wtEmoji);
-        } else {
-          var abbrev = document.createElement("span");
-          abbrev.className = "wt-branch-abbrev";
-          abbrev.textContent = getProjectAbbrev(wt.name);
-          wtEl.appendChild(abbrev);
-        }
-
-        var wtStatus = document.createElement("span");
-        wtStatus.className = "icon-strip-status";
-        if (wt.isProcessing) wtStatus.classList.add("processing");
-        wtEl.appendChild(wtStatus);
-
-        var tooltipText = wt.name;
-        if (!isAccessible) {
-          tooltipText += " (outside project path, cannot be accessed)";
-        }
-        (function (text, elem) {
-          elem.addEventListener("mouseenter", function () { showIconTooltip(elem, text); });
-          elem.addEventListener("mouseleave", hideIconTooltip);
-        })(tooltipText, wtEl);
-
-        if (isAccessible) {
-          (function (slug) {
-            wtEl.addEventListener("click", function (e) {
-              e.preventDefault();
-              if (switchProject) switchProject(slug);
-            });
-          })(wt.slug);
-        } else {
-          wtEl.addEventListener("click", function (e) {
-            e.preventDefault();
-          });
-        }
-
-        if (isAccessible) {
-          (function (slug, name, elem) {
-            elem.addEventListener("contextmenu", function (e) {
-              e.preventDefault();
-              e.stopPropagation();
-              showIconCtxMenu(elem, slug, name);
-            });
-          })(wt.slug, wt.name, wtEl);
-        } else {
-          wtEl.addEventListener("contextmenu", function (e) {
-            e.preventDefault();
-            e.stopPropagation();
-          });
-        }
-
-        if (!isWtActive && (wt.pendingPermissions > 0 || getPendingTuiAttention(wt.slug) > 0)) {
-          wtEl.classList.add("has-pending-perm");
-        }
-
-        itemsContainer.appendChild(wtEl);
-      })(worktrees[wi]);
-    }
-
-    var hasWtPendingPerm = false;
-    for (var wpi2 = 0; wpi2 < worktrees.length; wpi2++) {
-      if (worktrees[wpi2].pendingPermissions > 0 || getPendingTuiAttention(worktrees[wpi2].slug) > 0) {
-        hasWtPendingPerm = true;
-        break;
-      }
-    }
-    if (hasWtPendingPerm) folder.classList.remove("collapsed");
-
-    var addBtn = document.createElement("button");
-    addBtn.className = "icon-strip-group-add";
-    addBtn.textContent = "+";
-    (function (parentSlug, parentName, btn) {
-      btn.addEventListener("click", function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        showWorktreeModal(parentSlug, parentName);
-      });
-      btn.addEventListener("mouseenter", function () { showIconTooltip(btn, "New worktree"); });
-      btn.addEventListener("mouseleave", hideIconTooltip);
-    })(p.slug, p.name, addBtn);
-    itemsContainer.appendChild(addBtn);
-
-    folder.appendChild(itemsContainer);
-    container.appendChild(folder);
+    })(p.slug, p.name || p.slug, el);
+    setupDragHandlers(el, p.slug);
+    container.appendChild(el);
   }
 
   // Update home icon active state
@@ -1377,50 +1212,17 @@ function renderProjectList(projects, currentSlug) {
   for (var i = 0; i < grouped.parents.length; i++) {
     var p = grouped.parents[i];
     var worktrees = grouped.wtByParent[p.slug] || [];
-
-    if (worktrees.length === 0) {
-      list.appendChild(createMobileProjectItem(p, currentSlug, false));
-      continue;
-    }
-
-    var folderDiv = document.createElement("div");
-    folderDiv.className = "mobile-project-folder";
-    if (wtCollapsed[p.slug]) folderDiv.classList.add("collapsed");
-
-    var headerEl = createMobileProjectItem(p, currentSlug, false);
-    var chevron = document.createElement("span");
-    chevron.className = "mobile-folder-chevron";
-    chevron.innerHTML = "&#9660;";
-    (function (parentSlug, fDiv) {
-      chevron.addEventListener("click", function (e) {
-        e.preventDefault();
-        e.stopPropagation();
-        var nowCollapsed = fDiv.classList.toggle("collapsed");
-        setWtCollapsed(parentSlug, nowCollapsed);
-      });
-    })(p.slug, folderDiv);
-    headerEl.appendChild(chevron);
-    folderDiv.appendChild(headerEl);
-
-    var wtList = document.createElement("div");
-    wtList.className = "mobile-folder-items";
-    for (var wi = 0; wi < worktrees.length; wi++) {
-      var isAccessible = worktrees[wi].worktreeAccessible !== false;
-      var wtItem = createMobileProjectItem(worktrees[wi], currentSlug, true);
-      if (!isAccessible) wtItem.classList.add("wt-disabled");
-      if (!isAccessible) {
-        wtItem.addEventListener("click", function (e) { e.preventDefault(); e.stopPropagation(); });
-      }
-      wtList.appendChild(wtItem);
-    }
-    folderDiv.appendChild(wtList);
-    list.appendChild(folderDiv);
+    list.appendChild(createMobileProjectItem(aggregateProjectFamily(p, worktrees), currentSlug));
   }
 }
 
-function createMobileProjectItem(p, currentSlug, isWorktree) {
+function createMobileProjectItem(p, currentSlug) {
   var el = document.createElement("button");
-  el.className = "mobile-project-item" + (p.slug === currentSlug ? " active" : "") + (isWorktree ? " wt-item" : "");
+  var isActive = p.slug === currentSlug;
+  el.className = "mobile-project-item" + (isActive ? " active" : "");
+  if ((!isActive && (p.pendingPermissions > 0 || p.hasFamilyPendingAttention)) || p.hasWorktreePending) {
+    el.classList.add("has-pending-perm");
+  }
 
   var abbrev = document.createElement("span");
   abbrev.className = "mobile-project-abbrev";
@@ -1443,6 +1245,13 @@ function createMobileProjectItem(p, currentSlug, isWorktree) {
     el.appendChild(dot);
   }
 
+  if (p.unread > 0 && (!isActive || p.hasWorktreeUnread)) {
+    var badge = document.createElement("span");
+    badge.className = "mobile-project-unread";
+    badge.textContent = p.unread > 99 ? "99+" : String(p.unread);
+    el.appendChild(badge);
+  }
+
   el.addEventListener("click", function () {
     if (switchProject) switchProject(p.slug);
     if (closeSidebar) closeSidebar();
@@ -1454,12 +1263,30 @@ function createMobileProjectItem(p, currentSlug, isWorktree) {
 export function getEmojiCategories() { return EMOJI_CATEGORIES; }
 
 export function updateProjectBadge(slug, count) {
-  var icon = document.querySelector('.icon-strip-item[data-slug="' + slug + '"]');
+  var targetSlug = slug;
+  for (var i = 0; i < cachedProjectList.length; i++) {
+    if (cachedProjectList[i].slug !== slug) continue;
+    cachedProjectList[i].unread = count;
+    if (cachedProjectList[i].isWorktree && cachedProjectList[i].parentSlug) {
+      targetSlug = cachedProjectList[i].parentSlug;
+    }
+    break;
+  }
+
+  var displayCount = count;
+  var grouped = groupProjects(cachedProjectList);
+  for (var pi = 0; pi < grouped.parents.length; pi++) {
+    if (grouped.parents[pi].slug !== targetSlug) continue;
+    displayCount = aggregateFamily(grouped.parents[pi], grouped.wtByParent[targetSlug] || []).unread;
+    break;
+  }
+
+  var icon = document.querySelector('.icon-strip-item[data-slug="' + targetSlug + '"]');
   if (!icon) return;
   var badge = icon.querySelector(".icon-strip-project-badge");
   if (!badge) return;
-  if (count > 0) {
-    badge.textContent = count > 99 ? "99+" : String(count);
+  if (displayCount > 0) {
+    badge.textContent = displayCount > 99 ? "99+" : String(displayCount);
     badge.classList.add("has-unread");
   } else {
     badge.textContent = "";

--- a/lib/public/modules/worktree-family.js
+++ b/lib/public/modules/worktree-family.js
@@ -1,0 +1,60 @@
+// Pure helpers for presenting worktree projects as branches of one family.
+
+function projectName(project) {
+  return project ? (project.title || project.project || project.name || project.slug) : "";
+}
+
+export function familyOf(projects, slug) {
+  var list = projects || [];
+  var current = null;
+  for (var i = 0; i < list.length; i++) {
+    if (list[i].slug === slug) { current = list[i]; break; }
+  }
+  if (!current) return { parent: null, worktrees: [] };
+
+  var parentSlug = current.isWorktree ? current.parentSlug : current.slug;
+  var parent = current.isWorktree ? null : current;
+  var worktrees = [];
+  for (var j = 0; j < list.length; j++) {
+    var project = list[j];
+    if (!parent && project.slug === parentSlug && !project.isWorktree) parent = project;
+    if (project.isWorktree && project.parentSlug === parentSlug) worktrees.push(project);
+  }
+  if (current.isWorktree && worktrees.indexOf(current) === -1) worktrees.push(current);
+  worktrees.sort(function (a, b) { return projectName(a).localeCompare(projectName(b)); });
+  return { parent: parent, worktrees: worktrees };
+}
+
+export function parentProjects(projects) {
+  return (projects || []).filter(function (project) { return !project.isWorktree; });
+}
+
+export function displayProject(projects, slug) {
+  var family = familyOf(projects, slug);
+  if (family.parent) return family.parent;
+  for (var i = 0; i < (projects || []).length; i++) {
+    if (projects[i].slug === slug) return projects[i];
+  }
+  return null;
+}
+
+export function aggregateFamily(parent, worktrees) {
+  var result = Object.assign({}, parent);
+  var children = worktrees || [];
+  result.isProcessing = !!result.isProcessing;
+  result.unread = result.unread || 0;
+  result.pendingPermissions = result.pendingPermissions || 0;
+  for (var i = 0; i < children.length; i++) {
+    result.isProcessing = result.isProcessing || !!children[i].isProcessing;
+    result.unread += children[i].unread || 0;
+    result.pendingPermissions += children[i].pendingPermissions || 0;
+  }
+  return result;
+}
+
+export function switcherProjectName(projects, project) {
+  if (!project || !project.isWorktree) return projectName(project);
+  var family = familyOf(projects, project.slug);
+  var parentName = family.parent ? projectName(family.parent) : (project.parentSlug || "Project");
+  return parentName + " \u2387 " + (project.branch || projectName(project));
+}

--- a/test/worktree-switcher.test.js
+++ b/test/worktree-switcher.test.js
@@ -1,0 +1,50 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var helperPromise = null;
+function loadHelpers() {
+  if (!helperPromise) {
+    var file = path.join(__dirname, "../lib/public/modules/worktree-family.js");
+    var source = fs.readFileSync(file, "utf8");
+    helperPromise = import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+  }
+  return helperPromise;
+}
+
+var projects = [
+  { slug: "clay", project: "Clay", unread: 1, pendingPermissions: 0 },
+  { slug: "clay--alpha", project: "alpha", isWorktree: true, parentSlug: "clay", branch: "feat/alpha", unread: 2, isProcessing: true },
+  { slug: "clay--beta", project: "beta", isWorktree: true, parentSlug: "clay", branch: "feat/beta", pendingPermissions: 1, worktreeAccessible: false },
+  { slug: "missing--orphan", project: "orphan", isWorktree: true, parentSlug: "missing", branch: "fix/orphan" },
+];
+
+test("familyOf resolves a parent from a worktree slug", async function() {
+  var helpers = await loadHelpers();
+  var family = helpers.familyOf(projects, "clay--alpha");
+  assert.strictEqual(family.parent.slug, "clay");
+  assert.deepStrictEqual(family.worktrees.map(function(p) { return p.slug; }), ["clay--alpha", "clay--beta"]);
+});
+
+test("familyOf preserves an orphan worktree without inventing a parent", async function() {
+  var helpers = await loadHelpers();
+  var family = helpers.familyOf(projects, "missing--orphan");
+  assert.strictEqual(family.parent, null);
+  assert.deepStrictEqual(family.worktrees.map(function(p) { return p.slug; }), ["missing--orphan"]);
+});
+
+test("family aggregation includes worktree activity and badges", async function() {
+  var helpers = await loadHelpers();
+  var family = helpers.familyOf(projects, "clay");
+  var aggregate = helpers.aggregateFamily(family.parent, family.worktrees);
+  assert.strictEqual(aggregate.isProcessing, true);
+  assert.strictEqual(aggregate.unread, 3);
+  assert.strictEqual(aggregate.pendingPermissions, 1);
+  assert.strictEqual(family.worktrees[1].worktreeAccessible, false);
+});
+
+test("switcher labels a worktree as parent and branch", async function() {
+  var helpers = await loadHelpers();
+  assert.strictEqual(helpers.switcherProjectName(projects, projects[1]), "Clay \u2387 feat/alpha");
+});


### PR DESCRIPTION
## Summary

Stage 1 of the worktree UX rework (spec: `docs/ongoing/worktree-switcher-handoff.md`): worktrees stop being sibling projects in the icon strip and become a **title-bar branch chip**.

- Strip shows one icon per parent project; processing/unread/pending/TUI-attention badges aggregate across the family; the parent stays highlighted while a worktree is current.
- The chip (`⎇ branch ▾`) lists the default branch + every worktree, switches, creates (`New worktree...`), and removes them. It shows even with zero worktrees, making it the single worktree-management surface; the context-menu "Add Worktree" entries are removed.
- Inside a worktree the title bar keeps the parent's name/icon; only the chip changes.
- `/api/branches` now reports `isGitRepo`; the chip hides on non-git projects.
- Cmd-K switcher labels worktrees as `parent ⎇ branch`; command palette continues to skip them.
- Deletes the `clay-wt-collapsed` localStorage state (no-localStorage rule violation).
- Fixes a mobile project-sheet bug: parents-only loop counter indexed the unfiltered list, rendering worktree rows and dropping trailing parents.

Under the hood nothing changes: worktrees remain separate project contexts with the same slugs and URLs. Stage 2 (aggregated session lists, spawn-into-worktree) is specced but out of scope.

## Test plan

- `npm test` 82/82 (4 new family-derivation tests), syntax sweeps, import check green
- Live: chip switch keeps project identity; create + remove worktree from the chip; removal while inside lands on the parent; processing dot on parent icon lights from a worktree session; chip hidden in DM/home hub and on non-git projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)