### PR TITLE
fix(pair): support driver tools across vendors

### DIFF
--- a/lib/project-http.js
+++ b/lib/project-http.js
@@ -698,7 +698,9 @@ function attachHTTP(ctx) {
           res.end('{"error":"MCP bridge not configured"}');
           return;
         }
-        var handler = getMcpBridgeHandler();
+        var sessionId = Number(body.sessionId);
+        if (!Number.isInteger(sessionId)) sessionId = null;
+        var handler = getMcpBridgeHandler(sessionId, body.pairOnly === true);
         if (!handler) {
           res.writeHead(500, { "Content-Type": "application/json" });
           res.end('{"error":"MCP bridge handler unavailable"}');

--- a/lib/project-session-pair.js
+++ b/lib/project-session-pair.js
@@ -299,7 +299,7 @@ function attachSessionPair(ctx) {
   function getSystemPrompt(session) {
     var group = store.groupForMember(session.localId);
     if (!group || !group.pair || group.pair.driverId !== session.localId) return "";
-    return "You are the Driver in a two-agent pair. Plan the work, delegate concrete bounded tasks with send_to_partner, inspect results with read_partner, then integrate and verify the final outcome. Do not delegate work that must be performed sequentially in this same session.";
+    return "You are the Driver in a two-agent pair. The tools send_to_partner and read_partner are provided directly to you. Use send_to_partner to delegate concrete bounded work to the Worker, use read_partner to inspect its progress or recent results, then integrate and verify the final outcome. Do not search the project for implementations of these tools, and do not delegate work that must be performed sequentially in this same session.";
   }
 
   return { getToolDefs: getToolDefs, handleMessage: handleMessage, getSystemPrompt: getSystemPrompt };

--- a/lib/project.js
+++ b/lib/project.js
@@ -419,11 +419,18 @@ function createProjectContext(opts) {
   sm.availableVendors = Object.keys(adapters);
   sm.defaultVendor = defaultVendor;
 
+  var sdk = null;
   var _splitGroups = attachSplitGroups({
     sm: sm,
     clients: clients,
     sendTo: sendTo,
     usersModule: usersModule,
+    onPairChanged: function (group) {
+      if (!sdk || !group || !Array.isArray(group.members)) return;
+      for (var i = 0; i < group.members.length; i++) {
+        sdk.refreshSessionRuntime(sm.sessions.get(group.members[i]));
+      }
+    },
   });
 
   var _projMode = typeof opts.onGetProjectDefaultMode === "function" ? opts.onGetProjectDefaultMode(slug) : null;
@@ -487,7 +494,6 @@ function createProjectContext(opts) {
 
   // The SDK bridge is created after local MCP servers. Session spawning uses
   // a getter so tool handlers see the initialized bridge when they run.
-  var sdk = null;
   var _sessionPair = attachSessionPair({
     sm: sm,
     isMate: isMate,
@@ -764,6 +770,7 @@ function createProjectContext(opts) {
       return false;
     },
     getSessionSystemPrompt: function (session) { return _sessionPair.getSystemPrompt(session); },
+    getSessionToolDefs: function (session) { return _sessionPair.getToolDefs(session); },
   });
 
   // --- Loop engine (delegated to project-loop.js) ---
@@ -1365,10 +1372,12 @@ function createProjectContext(opts) {
     FS_MAX_SIZE: FS_MAX_SIZE,
   });
 
-  // --- MCP bridge handler for Codex (Track 2) ---
+  // --- MCP bridge handler for Codex and session-bound Kiro tools ---
   // Provides list_tools and call_tool operations over HTTP for mcp-bridge-server.js.
-  // Excludes local MCP servers since Codex manages those natively via Track 1.
-  function getMcpBridgeHandler() {
+  // The normal Codex bridge excludes local MCP servers it manages natively;
+  // Kiro's pair-only bridge exposes only the tools bound to its Clay session.
+  function getMcpBridgeHandler(sessionId, pairOnly) {
+    var boundSession = Number.isInteger(sessionId) ? sm.sessions.get(sessionId) : null;
     // Build set of local MCP server names to exclude (Codex handles these natively)
     var localMcpNames = {};
     try {
@@ -1405,6 +1414,20 @@ function createProjectContext(opts) {
           }
         }
 
+        if (boundSession) {
+          var pairTools = _sessionPair.getToolDefs(boundSession);
+          for (var pti = 0; pti < pairTools.length; pti++) {
+            tools.push({
+              server: "clay-sessions",
+              name: pairTools[pti].name,
+              description: pairTools[pti].description || pairTools[pti].name,
+              inputSchema: pairTools[pti].inputSchema || { type: "object", properties: {} },
+            });
+          }
+        }
+
+        if (pairOnly) return Promise.resolve(tools);
+
         // In-app MCP servers (debate, browser, email).
         // Use getLocalMcpServers() so clay-browser is hidden unless the
         // Chrome extension is currently connected (see issue #325).
@@ -1430,6 +1453,15 @@ function createProjectContext(opts) {
         return Promise.resolve(tools);
       },
       callTool: function (serverName, toolName, args) {
+        if (boundSession && serverName === "clay-sessions") {
+          var pairTools = _sessionPair.getToolDefs(boundSession);
+          for (var pti = 0; pti < pairTools.length; pti++) {
+            if (pairTools[pti].name === toolName && typeof pairTools[pti].handler === "function") {
+              return Promise.resolve(pairTools[pti].handler(args || {}));
+            }
+          }
+        }
+        if (pairOnly) return Promise.reject(new Error("Pair tool not found: " + toolName));
         // Try in-app servers first (gated by extension connectivity for clay-browser).
         var localMcp = getLocalMcpServers();
         if (localMcp && localMcp[serverName]) {

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -124,9 +124,30 @@ function createSDKBridge(opts) {
   var clayPort = opts.clayPort || 2633;
   var clayTls = opts.clayTls || false;
   var clayAuthToken = opts.clayAuthToken || null;
+  var getSessionToolDefs = opts.getSessionToolDefs || function () { return []; };
   var onProcessingChanged = opts.onProcessingChanged || function () {};
   var _cachedFreshAuthState = null;
   var _cachedFreshAuthAt = 0;
+
+  function getKiroMcpServers(session) {
+    if (!session) return [];
+    var bridgeArgs = [
+      path.join(__dirname, "yoke", "mcp-bridge-server.js"),
+      "--port", String(clayPort),
+      "--slug", slug,
+      "--session", String(session.localId),
+      "--pair-only",
+    ];
+    if (clayTls) bridgeArgs.push("--tls");
+    var env = [];
+    if (clayAuthToken) env.push({ name: "CLAY_AUTH_TOKEN", value: clayAuthToken });
+    return [{
+      name: "clay-tools",
+      command: process.execPath,
+      args: bridgeArgs,
+      env: env,
+    }];
+  }
 
   function getFreshAuthState(force) {
     var now = Date.now();
@@ -766,6 +787,7 @@ function createSDKBridge(opts) {
     // not resources from a newer query that may have been created after an abort.
     var myQueryInstance = session.queryInstance;
     var myAbortController = session.abortController;
+    var myMessageQueue = session.messageQueue;
     console.log("[sdk-bridge] processQueryStream: starting for-await loop, vendor=" + (session.vendor || adapter.vendor));
     try {
       for await (var msg of myQueryInstance) {
@@ -926,7 +948,7 @@ function createSDKBridge(opts) {
         } catch (e) {}
         session.queryInstance = null;
       }
-      session.messageQueue = null;
+      if (session.messageQueue === myMessageQueue) session.messageQueue = null;
       if (session.abortController === myAbortController) session.abortController = null;
       session.taskStopRequested = false;
       session.pendingPermissions = {};
@@ -1373,6 +1395,7 @@ function createSDKBridge(opts) {
     var codexConfig = getCodexConfig(sm);
     var kiroConfig = getKiroConfig(sm);
     var mergedMcpServers = mergeMcpServers(getMcpServers(session), getRemoteMcpServers) || undefined;
+    var sessionToolDefs = getSessionToolDefs(session) || [];
 
     // Derive an explicit session title for fresh queries so the SDK records
     // it at session creation and skips its own auto-generation. This also
@@ -1416,6 +1439,15 @@ function createSDKBridge(opts) {
       title: initialTitle || undefined,
       toolServers: mergedMcpServers,
       toolServerDescriptors: extractMcpDescriptors(mergedMcpServers) || undefined,
+      dynamicTools: sessionToolDefs,
+      callDynamicTool: function (toolName, args) {
+        for (var dti = 0; dti < sessionToolDefs.length; dti++) {
+          if (sessionToolDefs[dti].name === toolName && typeof sessionToolDefs[dti].handler === "function") {
+            return sessionToolDefs[dti].handler(args || {});
+          }
+        }
+        return Promise.reject(new Error("Session tool not found: " + toolName));
+      },
       resumeSessionId: session.cliSessionId || undefined,
       abortController: linuxUser ? undefined : session.abortController,
       canUseTool: function(toolName, input, toolOpts) {
@@ -1444,10 +1476,10 @@ function createSDKBridge(opts) {
         KIRO: {
           engine: kiroConfig.engine,
           mode: kiroConfig.mode,
-          // Kiro reads its native ~/.kiro/settings/mcp.json. Clay-managed MCP
-          // servers are intentionally not forwarded until the ACP entry shape
-          // and duplicate-registration behavior are verified against CLI 3.x.
-          mcpServers: [],
+          // ACP accepts additional stdio MCP servers per session. The bridge is
+          // bound to this Clay session so partner calls cannot leak across
+          // concurrent Kiro sessions or users.
+          mcpServers: getKiroMcpServers(session),
         },
       },
     };
@@ -1543,6 +1575,17 @@ function createSDKBridge(opts) {
   // the processing indicator without ever answering until a second send.
   function pushMessage(session, text, images) {
     session.lastActivityAt = Date.now();
+    if (session._runtimeRefreshRequested && !session._queryStarting) {
+      session._runtimeRefreshRequested = false;
+      var staleQuery = session.queryInstance;
+      if (staleQuery && typeof staleQuery.close === "function") {
+        try { staleQuery.close(); } catch (e) {}
+      }
+      session.queryInstance = null;
+      session.abortController = null;
+      session.messageQueue = null;
+      return false;
+    }
     // Route through QueryHandle (works for both in-process and worker paths)
     if (session.queryInstance && typeof session.queryInstance.pushMessage === "function") {
       session.queryInstance.pushMessage(text, images);
@@ -1554,6 +1597,22 @@ function createSDKBridge(opts) {
       return true;
     }
     return false;
+  }
+
+  function refreshSessionRuntime(session) {
+    if (!session) return false;
+    session._runtimeRefreshRequested = true;
+    if (!session.isProcessing && !session._queryStarting) {
+      var staleQuery = session.queryInstance;
+      if (staleQuery && typeof staleQuery.close === "function") {
+        try { staleQuery.close(); } catch (e) {}
+      }
+      session.queryInstance = null;
+      session.abortController = null;
+      session.messageQueue = null;
+      session._runtimeRefreshRequested = false;
+    }
+    return true;
   }
 
   function permissionPushTitle(toolName, input) {
@@ -2010,6 +2069,7 @@ function createSDKBridge(opts) {
     forkSession: forkSessionUnified,
     startQuery: startQuery,
     pushMessage: pushMessage,
+    refreshSessionRuntime: refreshSessionRuntime,
     setModel: setModel,
     setEffort: setEffort,
     setPermissionMode: setPermissionMode,

--- a/lib/session-split-groups.js
+++ b/lib/session-split-groups.js
@@ -16,6 +16,7 @@ function createSplitGroupStore(opts) {
   var groupsFile = path.join(opts.sessionsDir, "split-groups.json");
   var usersModule = opts.usersModule;
   var broadcast = opts.broadcast || function () {};
+  var onPairChanged = opts.onPairChanged || function () {};
   var groups = [];
 
   // localIds are reassigned on every daemon restart (loadSessions renumbers
@@ -174,6 +175,7 @@ function createSplitGroupStore(opts) {
     groups.push(group);
     save();
     broadcast();
+    if (group.pair) onPairChanged(group);
     return { ok: true, group: group };
   }
 
@@ -203,6 +205,7 @@ function createSplitGroupStore(opts) {
       delete group.pairCliIds;
       save();
       broadcast();
+      onPairChanged(group);
       return { ok: true, group: group };
     }
     if (!Number.isInteger(msg.driverId) || group.members.indexOf(msg.driverId) === -1) {
@@ -212,6 +215,7 @@ function createSplitGroupStore(opts) {
     group.pair = { driverId: msg.driverId, workerId: workerId };
     save();
     broadcast();
+    onPairChanged(group);
     return { ok: true, group: group };
   }
 
@@ -264,6 +268,7 @@ function attachSplitGroups(ctx) {
     sessionsDir: ctx.sm.sessionsDir,
     usersModule: ctx.usersModule,
     broadcast: broadcast,
+    onPairChanged: ctx.onPairChanged,
   });
 
   function sendState(ws) {

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -515,6 +515,42 @@ function flattenEvent(notification, state) {
       return events;
     }
 
+    // Dynamic tools are supplied by Clay for a specific thread, such as the
+    // Driver's pair-session controls.
+    if (item.type === "dynamicToolCall" || item.type === "dynamic_tool_call") {
+      if (!state.toolBlocks[item.id]) {
+        state.blockCounter++;
+        state.toolBlocks[item.id] = "blk_" + state.blockCounter;
+        var dynamicBlockId = state.toolBlocks[item.id];
+        events.push({
+          yokeType: "tool_start",
+          blockId: dynamicBlockId,
+          toolId: item.id,
+          toolName: item.tool || "session_tool",
+        });
+        events.push({
+          yokeType: "tool_executing",
+          blockId: dynamicBlockId,
+          toolId: item.id,
+          toolName: item.tool || "session_tool",
+          input: item.arguments || {},
+        });
+      }
+      if (evtPhase === "completed") {
+        var dynamicText = Array.isArray(item.contentItems) ? item.contentItems.map(function (contentItem) {
+          return contentItem && contentItem.text ? contentItem.text : "";
+        }).join("\n") : "";
+        events.push({
+          yokeType: "tool_result",
+          toolId: item.id,
+          blockId: state.toolBlocks[item.id],
+          content: dynamicText,
+          isError: item.success === false || item.status === "failed",
+        });
+      }
+      return events;
+    }
+
     // Web search
     if (item.type === "webSearch" || item.type === "web_search") {
       if (!state.toolBlocks[item.id]) {
@@ -629,8 +665,10 @@ function createEventState(model) {
 
 function createCodexQueryHandle(appServer, queryOpts) {
   var abortController = queryOpts.abortController;
-  var systemPrompt = queryOpts.systemPrompt || queryOpts.appendSystemPrompt || "";
+  var promptParts = [queryOpts.systemPrompt, queryOpts.appendSystemPrompt].filter(function (part) { return !!part; });
+  var systemPrompt = promptParts.join("\n\n");
   var canUseTool = queryOpts.canUseTool || null;
+  var callDynamicTool = queryOpts.callDynamicTool || null;
   var onElicitation = queryOpts.onElicitation || null;
   var onFinished = queryOpts.onFinished || null;
 
@@ -764,6 +802,35 @@ function createCodexQueryHandle(appServer, queryOpts) {
       return;
     }
 
+    // Session-bound tools supplied at thread creation. Codex sends these as a
+    // server request and waits for the client to execute and answer it.
+    if (method === "item/tool/call") {
+      var dynamicParams = msg.params || {};
+      if (!callDynamicTool) {
+        appServer.respond(msg.id, {
+          contentItems: [{ type: "inputText", text: "Session tool handler is unavailable" }],
+          success: false,
+        });
+        return;
+      }
+      Promise.resolve(callDynamicTool(dynamicParams.tool, dynamicParams.arguments || {})).then(function (result) {
+        var content = result && Array.isArray(result.content) ? result.content : [];
+        var contentItems = content.map(function (item) {
+          return { type: "inputText", text: item && item.text ? item.text : JSON.stringify(item) };
+        });
+        if (contentItems.length === 0) {
+          contentItems.push({ type: "inputText", text: typeof result === "string" ? result : JSON.stringify(result) });
+        }
+        appServer.respond(msg.id, { contentItems: contentItems, success: !(result && result.isError) });
+      }).catch(function (err) {
+        appServer.respond(msg.id, {
+          contentItems: [{ type: "inputText", text: "Error: " + (err.message || String(err)) }],
+          success: false,
+        });
+      });
+      return;
+    }
+
     // MCP tool approval / elicitation (app-server uses mcpServer/elicitation/request)
     if (method === "item/tool/requestUserInput" || method === "mcpServer/elicitation/request") {
       var mcpParams = msg.params || {};
@@ -889,6 +956,16 @@ function createCodexQueryHandle(appServer, queryOpts) {
       }
       if (queryOpts.webSearchMode) {
         threadParams.webSearchMode = queryOpts.webSearchMode;
+      }
+      if (Array.isArray(queryOpts.dynamicTools) && queryOpts.dynamicTools.length > 0) {
+        threadParams.dynamicTools = queryOpts.dynamicTools.map(function (tool) {
+          return {
+            type: "function",
+            name: tool.name,
+            description: tool.description || tool.name,
+            inputSchema: tool.inputSchema || { type: "object", properties: {} },
+          };
+        });
       }
 
       var threadResult;
@@ -1479,6 +1556,9 @@ function createCodexAdapter(opts) {
         model: model,
         cwd: queryOpts.cwd || _cwd,
         systemPrompt: queryOpts.systemPrompt || "",
+        appendSystemPrompt: queryOpts.appendSystemPrompt || "",
+        dynamicTools: queryOpts.dynamicTools || [],
+        callDynamicTool: queryOpts.callDynamicTool || null,
         abortController: ac,
         canUseTool: queryOpts.canUseTool || null,
         onElicitation: queryOpts.onElicitation || null,

--- a/lib/yoke/adapters/kiro.js
+++ b/lib/yoke/adapters/kiro.js
@@ -397,7 +397,8 @@ function createEventState(opts) {
 
 function createKiroQueryHandle(acp, queryOpts) {
   var abortController = queryOpts.abortController;
-  var systemPrompt = queryOpts.systemPrompt || queryOpts.appendSystemPrompt || "";
+  var promptParts = [queryOpts.systemPrompt, queryOpts.appendSystemPrompt].filter(function (part) { return !!part; });
+  var systemPrompt = promptParts.join("\n\n");
   var canUseTool = queryOpts.canUseTool || null;
   var onFinished = queryOpts.onFinished || null;
 
@@ -1071,7 +1072,8 @@ function createKiroAdapter(opts) {
         contextWindow: _modelContextWindows[model] || null,
         mode: kiroOpts.mode || null,
         cwd: queryOpts.cwd || _cwd,
-        systemPrompt: (queryOpts.systemPrompt || "") + (skillIndex ? "\n\n" + skillIndex : ""),
+        systemPrompt: queryOpts.systemPrompt || "",
+        appendSystemPrompt: [queryOpts.appendSystemPrompt, skillIndex].filter(function (part) { return !!part; }).join("\n\n"),
         skills: sharedSkills,
         abortController: ac,
         canUseTool: queryOpts.canUseTool || null,

--- a/lib/yoke/mcp-bridge-server.js
+++ b/lib/yoke/mcp-bridge-server.js
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
-// mcp-bridge-server.js - Stdio MCP bridge for Codex
+// mcp-bridge-server.js - Stdio MCP bridge for Clay tools
 // --------------------------------------------------
-// Codex spawns this as a native MCP server via config.mcp_servers["clay-tools"].
+// Codex or Kiro spawns this as a native MCP server.
 // It implements the MCP protocol on stdio (JSON-RPC) and proxies tool
 // list/call requests to Clay's project-scoped HTTP endpoint
 // (/p/{slug}/api/mcp-bridge) when a slug is provided.
 //
-// Usage: node mcp-bridge-server.js --port 2633 --slug my-project
+// Usage: node mcp-bridge-server.js --port 2633 --slug my-project [--session 42] [--pair-only]
 //
 // Lifecycle:
-//   1. Codex spawns this process
-//   2. Codex sends MCP "initialize" request on stdin
+//   1. The vendor CLI spawns this process
+//   2. The vendor CLI sends MCP "initialize" request on stdin
 //   3. We respond, then fetch tool list from Clay
-//   4. Codex sends "tools/list" -> we return cached tools
-//   5. Codex sends "tools/call" -> we proxy to Clay and return result
-//   6. When stdin closes (Codex exits), we exit too
+//   4. The CLI sends "tools/list" -> we return cached tools
+//   5. The CLI sends "tools/call" -> we proxy to Clay and return result
+//   6. When stdin closes, we exit too
 
 var http = require("http");
 var https = require("https");
@@ -24,6 +24,8 @@ var args = process.argv.slice(2);
 var clayPort = 2633;
 var claySlug = "";
 var clayTls = false;
+var claySessionId = null;
+var pairOnly = false;
 
 for (var i = 0; i < args.length; i++) {
   if (args[i] === "--port" && args[i + 1]) {
@@ -32,8 +34,14 @@ for (var i = 0; i < args.length; i++) {
   } else if (args[i] === "--slug" && args[i + 1]) {
     claySlug = args[i + 1];
     i++;
+  } else if (args[i] === "--session" && args[i + 1]) {
+    claySessionId = parseInt(args[i + 1], 10);
+    if (!Number.isInteger(claySessionId)) claySessionId = null;
+    i++;
   } else if (args[i] === "--tls") {
     clayTls = true;
+  } else if (args[i] === "--pair-only") {
+    pairOnly = true;
   }
 }
 
@@ -111,7 +119,7 @@ function postJson(urlPath, body) {
 
 // --- Fetch tools from Clay ---
 function fetchTools() {
-  return postJson(CLAY_MCP_PATH, { action: "list_tools" }).then(function (resp) {
+  return postJson(CLAY_MCP_PATH, { action: "list_tools", sessionId: claySessionId, pairOnly: pairOnly }).then(function (resp) {
     if (resp.error) {
       log("Failed to fetch tools: " + resp.error);
       return [];
@@ -137,6 +145,8 @@ function callTool(serverName, toolName, args) {
     server: serverName,
     tool: toolName,
     args: args || {},
+    sessionId: claySessionId,
+    pairOnly: pairOnly,
   });
 }
 
@@ -190,8 +200,7 @@ function handleToolsList(id, params) {
     var mcpTools = _tools.map(function (t) {
       return {
         name: t.server + "__" + t.name,
-        description: "[REMOTE MCP: " + t.server + "] " + (t.description || t.name)
-          + " (This tool runs on a REMOTE machine connected via browser extension, NOT on the local server.)",
+        description: "[Clay: " + t.server + "] " + (t.description || t.name),
         inputSchema: t.inputSchema || { type: "object", properties: {} },
       };
     });
@@ -299,4 +308,4 @@ process.stdin.on("error", function () {
 process.on("SIGTERM", function () { process.exit(0); });
 process.on("SIGINT", function () { process.exit(0); });
 
-log("Started: port=" + clayPort + " slug=" + claySlug);
+log("Started: port=" + clayPort + " slug=" + claySlug + " session=" + (claySessionId === null ? "none" : claySessionId) + " pairOnly=" + pairOnly);

--- a/test/codex-dynamic-tools.test.js
+++ b/test/codex-dynamic-tools.test.js
@@ -1,0 +1,71 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var codexModule = require("../lib/yoke/adapters/codex");
+
+test("Codex registers and executes session-bound dynamic tools", async function () {
+  var calls = [];
+  var responses = [];
+  var handlerEntry = null;
+  var server = {
+    started: true,
+    addHandler: function (fn) {
+      handlerEntry = { threadId: null, fn: fn };
+      return handlerEntry;
+    },
+    removeHandler: function () {},
+    respond: function (id, result) { responses.push({ id: id, result: result }); },
+    send: function (method, params) {
+      calls.push({ method: method, params: params });
+      if (method === "thread/start") return Promise.resolve({ thread: { id: "thread-pair" } });
+      if (method === "turn/start") {
+        setImmediate(function () {
+          handlerEntry.fn({
+            id: 41,
+            method: "item/tool/call",
+            params: { threadId: "thread-pair", callId: "call-1", tool: "send_to_partner", arguments: { message: "Build it" } },
+          });
+          setImmediate(function () {
+            handlerEntry.fn({ method: "turn/completed", params: { threadId: "thread-pair" } });
+          });
+        });
+        return Promise.resolve({});
+      }
+      return Promise.resolve({});
+    },
+  };
+  var receivedArgs = null;
+  var handle = codexModule.contractTestKit.createQueryHandle(server, {
+    cwd: process.cwd(),
+    model: "gpt-test",
+    systemPrompt: "Base instructions",
+    appendSystemPrompt: "You are the Driver",
+    dynamicTools: [{
+      name: "send_to_partner",
+      description: "Delegate work",
+      inputSchema: { type: "object", properties: { message: { type: "string" } } },
+    }],
+    callDynamicTool: function (name, args) {
+      assert.strictEqual(name, "send_to_partner");
+      receivedArgs = args;
+      return Promise.resolve({ content: [{ type: "text", text: "Worker complete" }] });
+    },
+    abortController: new AbortController(),
+  });
+
+  handle.pushMessage("Implement the feature");
+  for await (var event of handle) {
+    if (event.yokeType === "result") break;
+  }
+  handle.close();
+
+  var startCall = calls.find(function (call) { return call.method === "thread/start"; });
+  assert.strictEqual(startCall.params.dynamicTools[0].name, "send_to_partner");
+  var turnCall = calls.find(function (call) { return call.method === "turn/start"; });
+  assert.match(turnCall.params.input[0].text, /Base instructions/);
+  assert.match(turnCall.params.input[0].text, /You are the Driver/);
+  assert.deepStrictEqual(receivedArgs, { message: "Build it" });
+  assert.deepStrictEqual(responses, [{
+    id: 41,
+    result: { contentItems: [{ type: "inputText", text: "Worker complete" }], success: true },
+  }]);
+});

--- a/test/kiro-adapter-query.test.js
+++ b/test/kiro-adapter-query.test.js
@@ -87,8 +87,10 @@ test("v3 resume suppresses replay and configures supervised model selection", as
   var handle = await adapter.createQuery({
     cwd: process.cwd(),
     model: "auto",
+    systemPrompt: "Base instructions",
+    appendSystemPrompt: "You are the Driver",
     resumeSessionId: "sess-existing",
-    adapterOptions: { KIRO: { mode: "vibe", mcpServers: [] } },
+    adapterOptions: { KIRO: { mode: "vibe", mcpServers: [{ name: "clay-tools", command: "/usr/bin/node", args: ["bridge.js"] }] } },
     canUseTool: function() { return Promise.resolve({ behavior: "deny" }); },
   });
   handle.pushMessage("hello");
@@ -116,4 +118,9 @@ test("v3 resume suppresses replay and configures supervised model selection", as
       && call.params.value === "auto";
   }));
   assert.ok(!calls.some(function(call) { return call.method === "session/set_model"; }));
+  var loadCall = calls.find(function(call) { return call.method === "session/load"; });
+  assert.strictEqual(loadCall.params.mcpServers[0].name, "clay-tools");
+  var promptCall = calls.find(function(call) { return call.method === "session/prompt"; });
+  assert.match(promptCall.params.prompt[0].text, /Base instructions/);
+  assert.match(promptCall.params.prompt[0].text, /You are the Driver/);
 });

--- a/test/split-groups.test.js
+++ b/test/split-groups.test.js
@@ -174,6 +174,21 @@ test("setPair clears roles with a null driverId", function (t) {
   assert.strictEqual(persisted[0].pair, undefined);
 });
 
+test("pair changes notify the runtime for both assignment and clearing", function (t) {
+  var f = fixture(t, false);
+  var changed = [];
+  var store = createSplitGroupStore({
+    sessions: f.sessions,
+    sessionsDir: f.dir,
+    usersModule: null,
+    onPairChanged: function (group) { changed.push(group.pair ? group.pair.driverId : null); },
+  });
+  var group = store.create(f.ws1, { members: [1, 2] }).group;
+  store.setPair(f.ws1, { id: group.id, driverId: 1 });
+  store.setPair(f.ws1, { id: group.id, driverId: null });
+  assert.deepStrictEqual(changed, [1, null]);
+});
+
 test("setPair rejects non-members, unknown groups, and non-owners", function (t) {
   var f = fixture(t, true);
   var group = f.store.create(f.ws1, { members: [1, 2] }).group;


### PR DESCRIPTION
## Summary

- expose pair-session Driver instructions to Claude, Codex, and Kiro
- register session-bound partner tools through Codex dynamic tools and a pair-only Kiro MCP bridge
- refresh vendor runtimes when Driver and Worker roles are assigned or cleared
- render Codex dynamic tool activity and add focused regression coverage

## Root cause

The pair role prompt and tools were created in the shared SDK bridge, but the Codex and Kiro adapters dropped the appended system prompt. Codex also had no session-bound dynamic tool registration, while Kiro received no Clay-managed MCP server configuration.

## Impact

Drivers can now call `send_to_partner` and `read_partner` regardless of whether the pair uses Claude, Codex, Kiro, or a cross-vendor combination. Existing split groups also pick up role changes on the next turn.

## Validation

- `npx --yes --package=node@22 node --test --test-force-exit test/*.test.js`
- 145 tests passed
