### PR TITLE
feat(notes): add cross-session task memory

### DIFF
--- a/docs/ongoing/sticky-notes-memory-handoff.md
+++ b/docs/ongoing/sticky-notes-memory-handoff.md
@@ -1,10 +1,16 @@
-# Sticky notes as agent-controllable long-term memory
+# Sticky notes as agent-controllable handoff memory
 
 **Goal (Chad, 2026-08-17):** sessions can read and write the project's
-sticky notes, turning the existing shared canvas into visible long-term
-memory. The user always sees what the agent remembers, can edit or
-delete it, and every vendor gets the same memory because injection is
-plain text.
+sticky notes, turning the existing shared canvas into visible handoff
+memory. People may use the board freely; Clay agents use it specifically
+for cross-session work memory: checklists and to-do lists, work goals,
+handoffs, unfinished work, durable decisions and constraints, and
+knowledge worth preserving beyond the current session. Notes are
+title-first, may contain detailed multi-paragraph context, and should
+let another worker continue without reconstructing the previous
+conversation. The user always sees what the agent remembers, can edit
+or delete it, and every vendor gets the same memory because injection
+is plain text.
 
 ## Why sticky notes beat a hidden memory file
 
@@ -44,13 +50,13 @@ plain text.
   the calling session; removing a user-created note (or another
   session's) keeps the permission prompt -- deleting someone else's
   memory is destructive.
-- Tool descriptions frame the memory contract AND the register (Chad,
-  2026-08-17: notes must never get verbose -- they are sticky notes):
-  "Shared project memory on the user's board. One note = one fact,
-  decision, or reminder, written like a real sticky note: a phrase or
-  at most two short sentences. Never paragraphs, lists of steps, or
-  logs. Update an existing note instead of adding a near-duplicate;
-  delete notes that stop being true."
+- Tool descriptions frame the memory contract as handoff-first. The
+  first line is a concise title; the remaining body may be long and
+  should preserve the goal, background, rationale, decisions, completed
+  work, current state, validation, next steps, blockers, and references
+  when those details prevent context loss. Quality is controlled by
+  prohibiting routine narration and duplicate notes, not by forcing
+  artificial brevity.
 
 ### 2. Injection (the recall half)
 
@@ -59,10 +65,11 @@ plain text.
   instructions.scanAndMerge / appendSystemPrompt from a726fbc):
   `"--- Project sticky notes (shared memory; manage via clay-notes
   tools) ---"` + `getActiveNotesText()`.
-- Caps: 2000 chars total, newest-first truncation with a note telling
-  the model to use list_notes for the rest. Zero notes -> inject
-  nothing. The injection block is intentionally small: sticky notes are
-  an index of durable facts, not a context dump.
+- Caps: 4000 chars total and 800 chars per note, newest-first truncation
+  with a marker telling the model to use list_notes for the full note.
+  The policy explicitly requires reading a relevant truncated handoff
+  before acting. Full board content remains available through
+  list_notes without truncation.
 - This makes recall automatic; the agent does not need to remember to
   look.
 
@@ -70,19 +77,23 @@ plain text.
 
 - Agent-created notes render a small vendor avatar badge (origin) in
   the note corner, mirroring the delegated-message pattern.
-- No other canvas changes; the whole point is reusing the existing
-  surface.
+- The first line renders as the note title. Checklist lines accept both
+  `[x]` / `[ ]` and `- [x]` / `- [ ]`; rendered boxes are keyboard- and
+  pointer-toggleable and persist back to Markdown.
+- The empty archive explains the value in user terms: notes survive the
+  current session and are useful for checklists, goals, handoffs, and
+  durable project knowledge. This is guidance, not a restriction on how
+  people use their board.
+- The rest of the canvas remains the existing shared surface.
 
 ## Rails
 
 - REVISED (Chad, 2026-08-17): no short hard cap -- the canvas has a
-  collapse affordance, so long notes are fine on the BOARD. The real
-  enemy is rambling register, which the tool description polices, not
-  a length rejection. Keep only a generous abuse guard: write_note
-  rejects past 2000 chars.
-- Context cost is contained at INJECTION instead: each note contributes
-  at most ~240 chars (preview + "... (list_notes for the full note)"),
-  total block still capped at 2000 chars.
+  collapse affordance, so long handoff notes are encouraged when they
+  preserve worker context. Keep only a generous abuse guard:
+  write_note rejects past 20000 chars.
+- Context cost is contained at injection instead: each note contributes
+  at most 800 chars and the total note block stays capped at 4000 chars.
 - Note count cap (20 active) -- write_note errors past it, prompting
   consolidation/cleanup instead of unbounded growth.
 - remove_note ownership rule above.
@@ -97,24 +108,19 @@ spammed by it.
   empty board must still announce the capability, otherwise the agent
   never volunteers). Zero-note form: label + "(board is empty)" +
   policy text.
-- Policy text (goes inside the injected block, terse):
-  "Use the board proactively: when the user states a decision,
-  preference, correction, or durable project fact that future sessions
-  will need, record it with write_note WITHOUT being asked, and say so
-  in one short clause. The bar: a person skimming the board a week
-  from now must still find the note useful, and it must stand on its
-  own without this conversation. Never write announcement or narration
-  notes ('leaving a note', 'did X just now'), routine progress,
-  transient state, or anything the repo already records. Update or
-  remove your stale notes instead of adding near-duplicates. A task
-  should rarely add more than one or two notes."
-  (Revised 2026-08-17 per Chad: notes must be human-valuable memory,
-  never self-narration; writes run with no permission prompt.)
+- Policy text defines the board as shared cross-session work memory and
+  limits Clay-agent writes to checklists and to-dos, work goals,
+  handoffs, unfinished work, durable decisions and constraints, and
+  knowledge worth preserving beyond the current session. It requires a
+  title on the first line, welcomes detailed bodies, and tells the next
+  worker to call list_notes before acting on a relevant truncated
+  preview. Transcripts, routine progress narration, self-announcements,
+  and duplicate notes remain forbidden. Human use remains unrestricted.
 - Noticeability: on an agent write, the server broadcasts
   `note_written {id, byTitle, vendor, preview}` (register in
   ws-schema); non-pane clients toast "<title> left a note: <preview>"
   and pulse the note on the canvas. User's own edits never toast.
-- Abuse ceiling stays structural: 20 active notes, 2000-char guard,
+- Abuse ceiling stays structural: 20 active notes, 20000-char guard,
   ownership rule.
 
 ## Out of scope (v1)

--- a/lib/mates-prompts.js
+++ b/lib/mates-prompts.js
@@ -45,8 +45,9 @@ var STICKY_NOTES_SECTION =
   "\n\n" + STICKY_NOTES_MARKER + "\n" +
   "## Sticky Notes\n\n" +
   "**This section is managed by the system and cannot be removed.**\n\n" +
-  "Your `knowledge/sticky-notes.md` file contains sticky notes left by the user. " +
-  "Read this file when starting a conversation for important context. " +
+  "Your `knowledge/sticky-notes.md` file is shared project memory that persists across sessions. " +
+  "It may contain checklists, to-do items, work goals, handoffs, unfinished work, durable decisions and constraints, or project knowledge that future sessions should remember. " +
+  "Read this file when starting a conversation and use relevant notes to recover the current context and next actions. " +
   "These notes are read-only. You cannot create, update, or delete them.\n";
 
 var PROJECT_REGISTRY_MARKER = "<!-- PROJECT_REGISTRY_MANAGED_BY_SYSTEM -->";

--- a/lib/project-session-notes.js
+++ b/lib/project-session-notes.js
@@ -1,12 +1,12 @@
 var sessionNotesMcp = require("./session-notes-mcp-server");
 
-var MAX_NOTE_TEXT_CHARS = 2000;
+var MAX_NOTE_TEXT_CHARS = 20000;
 var MAX_ACTIVE_NOTES = 20;
-var MAX_PROMPT_CHARS = 2000;
-var MAX_NOTE_PROMPT_CHARS = 240;
-var NOTES_LABEL = "--- Project sticky notes (shared memory; manage via clay-notes tools) ---";
+var MAX_PROMPT_CHARS = 4000;
+var MAX_NOTE_PROMPT_CHARS = 800;
+var NOTES_LABEL = "--- Project sticky notes (cross-session work memory; manage via clay-notes tools) ---";
 var NOTES_HINT = "- More notes are available; call list_notes for the rest.";
-var PROACTIVE_POLICY = "Use the board proactively: when the user states a decision, preference, correction, or durable project fact that future sessions will need, record it with write_note WITHOUT being asked, and say so in one short clause. The bar: a person skimming the board a week from now must still find the note useful, and it must stand on its own without this conversation. Never write announcement or narration notes ('leaving a note', 'did X just now'), routine progress, transient state, or anything the repo already records. Update or remove your stale notes instead of adding near-duplicates. A task should rarely add more than one or two notes.";
+var PROACTIVE_POLICY = "The board persists across sessions and is shared with the user and every Clay agent working on this project. People may use it freely. As a Clay agent, use it specifically as cross-session work memory: checklists and to-do lists, work goals, handoffs, unfinished work, durable decisions and constraints, and knowledge that should remain available after this session ends. Create or update a note proactively when the user asks for a handoff, establishes something future sessions must remember, or when preserving the current goal and next actions would make continuation easier. Put a concise plain-text title on the first line. Add a detailed body with the relevant background, rationale, decisions, completed work, current state, validation, next steps, blockers, and references. If an injected preview is relevant or truncated, call list_notes and read the full note before acting. Do not use notes as a transcript, routine progress log, or self-announcement. Keep one coherent topic per note and consolidate or remove stale notes instead of creating duplicates.";
 var NOTE_COLORS = ["yellow", "blue", "green", "pink", "orange", "purple"];
 
 function toolResult(value) {
@@ -128,7 +128,7 @@ function attachSessionNotes(ctx) {
   function writeNote(args, caller) {
     if (!caller) return toolError("write_note requires a session-bound tool server");
     var rawText = typeof args.text === "string" ? args.text : "";
-    if (rawText.length > MAX_NOTE_TEXT_CHARS) return toolError("text exceeds 2000 characters");
+    if (rawText.length > MAX_NOTE_TEXT_CHARS) return toolError("text exceeds " + MAX_NOTE_TEXT_CHARS + " characters");
     var text = rawText.trim();
     if (!text) return toolError("text is required");
     var notes = nm.list() || [];

--- a/lib/public/css/sticky-notes.css
+++ b/lib/public/css/sticky-notes.css
@@ -335,13 +335,35 @@
 }
 
 .sticky-note-rendered .sn-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
   font-size: 12px;
   margin-right: 4px;
   opacity: 0.6;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 3px;
+  transition: opacity 0.15s, background 0.15s, transform 0.15s;
+}
+
+.sticky-note-rendered .sn-check:hover,
+.sticky-note-rendered .sn-check:focus-visible {
+  opacity: 1;
+  background: rgba(0,0,0,0.07);
+  outline: none;
+  transform: scale(1.08);
 }
 
 .sticky-note-rendered .sn-check.checked {
   opacity: 0.9;
+}
+
+.dark-theme .sticky-note-rendered .sn-check:hover,
+.dark-theme .sticky-note-rendered .sn-check:focus-visible {
+  background: rgba(255,255,255,0.1);
 }
 
 /* --- Resize handle (bottom-right corner) --- */
@@ -649,9 +671,12 @@
   font-weight: 400 !important;
   color: var(--text-dimmer) !important;
   margin-top: 6px !important;
+  max-width: 520px;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 4px;
+  line-height: 1.55;
 }
 
 .notes-archive-empty-sub .lucide {

--- a/lib/public/modules/sticky-note-markdown.js
+++ b/lib/public/modules/sticky-note-markdown.js
@@ -1,0 +1,89 @@
+// Markdown helpers for sticky-note titles, handoff bodies, and checklists.
+
+export function getTitle(text) {
+  if (!text) return "";
+  var idx = text.indexOf("\n");
+  return idx === -1 ? text : text.substring(0, idx);
+}
+
+function formatInline(text) {
+  var escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped
+    .replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener">$1</a>')
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>")
+    .replace(/`([^`]+)`/g, "<code>$1</code>")
+    .replace(/~~(.+?)~~/g, "<del>$1</del>")
+    .replace(/^(?:-\s*)?\[[xX]\]/gm, '<span class="sn-check checked" role="checkbox" aria-checked="true" tabindex="0" contenteditable="false">✓</span>')
+    .replace(/^(?:-\s*)?\[ \]/gm, '<span class="sn-check" role="checkbox" aria-checked="false" tabindex="0" contenteditable="false">☐</span>')
+    .replace(/\n/g, "<br>");
+}
+
+export function renderMiniMarkdown(text) {
+  if (!text) return "";
+  var lines = text.split("\n");
+  var title = lines[0];
+  var body = lines.slice(1).join("\n");
+  var html = '<div class="sn-title">' + formatInline(title) + "</div>";
+  if (body.trim()) html += formatInline(body);
+  return html;
+}
+
+function childrenToMarkdown(element) {
+  var result = "";
+  for (var i = 0; i < element.childNodes.length; i++) {
+    result += nodeToMarkdown(element.childNodes[i]);
+  }
+  return result;
+}
+
+function nodeToMarkdown(node) {
+  if (node.nodeType === 3) return node.textContent;
+  if (node.nodeType !== 1) return "";
+
+  var tag = node.tagName;
+  var inner = childrenToMarkdown(node);
+  switch (tag) {
+    case "STRONG": case "B": return "**" + inner + "**";
+    case "EM": case "I": return "*" + inner + "*";
+    case "DEL": case "S": case "STRIKE": return "~~" + inner + "~~";
+    case "CODE": return "`" + inner + "`";
+    case "BR": return "\n";
+    case "DIV":
+      if (node.classList.contains("sn-title")) return inner;
+      if (node.classList.contains("sn-placeholder")) return "";
+      return "\n" + inner;
+    case "P": return "\n" + inner;
+    case "A": return node.getAttribute("href") || inner;
+    case "SPAN":
+      if (node.classList.contains("sn-check")) {
+        return node.classList.contains("checked") ? "- [x]" : "- [ ]";
+      }
+      if (node.classList.contains("sn-placeholder")) return "";
+      return inner;
+    default: return inner;
+  }
+}
+
+export function extractMarkdown(rendered) {
+  var titleEl = rendered.querySelector(".sn-title");
+  if (titleEl) {
+    var titleMarkdown = childrenToMarkdown(titleEl);
+    var rest = "";
+    var afterTitle = false;
+    for (var i = 0; i < rendered.childNodes.length; i++) {
+      var child = rendered.childNodes[i];
+      if (child === titleEl) {
+        afterTitle = true;
+        continue;
+      }
+      if (afterTitle) rest += nodeToMarkdown(child);
+    }
+    if (rest && rest.charAt(0) === "\n") rest = rest.substring(1);
+    return titleMarkdown + (rest ? "\n" + rest : "");
+  }
+  return childrenToMarkdown(rendered).replace(/^\n+/, "");
+}

--- a/lib/public/modules/sticky-notes.js
+++ b/lib/public/modules/sticky-notes.js
@@ -1,5 +1,6 @@
 import { refreshIcons, iconHtml } from './icons.js';
 import { VENDOR_AVATARS } from './app-rendering.js';
+import { extractMarkdown, getTitle, renderMiniMarkdown } from './sticky-note-markdown.js';
 
 var ctx;
 var notes = new Map();  // id -> { data, el }
@@ -136,104 +137,9 @@ function debouncedTextUpdate(id, text) {
   }, 500);
 }
 
-// --- Simple markdown ---
-
-function getTitle(text) {
-  if (!text) return "";
-  var idx = text.indexOf("\n");
-  return idx === -1 ? text : text.substring(0, idx);
-}
-
-function renderMiniMarkdown(text) {
-  if (!text) return "";
-  var lines = text.split("\n");
-  var title = lines[0];
-  var body = lines.slice(1).join("\n");
-
-  function fmt(s) {
-    var escaped = s
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
-    return escaped
-      .replace(/(https?:\/\/[^\s<]+)/g, '<a href="$1" target="_blank" rel="noopener">$1</a>')
-      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>")
-      .replace(/`([^`]+)`/g, "<code>$1</code>")
-      .replace(/~~(.+?)~~/g, "<del>$1</del>")
-      .replace(/^- \[x\]/gm, '<span class="sn-check checked">✓</span>')
-      .replace(/^- \[ \]/gm, '<span class="sn-check">☐</span>')
-      .replace(/\n/g, "<br>");
-  }
-
-  var html = '<div class="sn-title">' + fmt(title) + '</div>';
-  if (body.trim()) {
-    html += fmt(body);
-  }
-  return html;
-}
-
 function syncTitle(noteEl, text) {
   var spacer = noteEl.querySelector(".sticky-note-spacer");
   if (spacer) spacer.textContent = getTitle(text) || "Untitled";
-}
-
-// --- HTML-to-Markdown reverse conversion (for contenteditable) ---
-
-function nodeToMd(node) {
-  if (node.nodeType === 3) return node.textContent;
-  if (node.nodeType !== 1) return "";
-
-  var tag = node.tagName;
-  var inner = childrenToMd(node);
-
-  switch (tag) {
-    case "STRONG": case "B": return "**" + inner + "**";
-    case "EM": case "I": return "*" + inner + "*";
-    case "DEL": case "S": case "STRIKE": return "~~" + inner + "~~";
-    case "CODE": return "`" + inner + "`";
-    case "BR": return "\n";
-    case "DIV":
-      if (node.classList.contains("sn-title")) return inner;
-      if (node.classList.contains("sn-placeholder")) return "";
-      // Browser-generated div from Enter key = new line
-      return "\n" + inner;
-    case "P": return "\n" + inner;
-    case "A": return node.getAttribute("href") || inner;
-    case "SPAN":
-      if (node.classList.contains("sn-check")) {
-        return node.classList.contains("checked") ? "- [x]" : "- [ ]";
-      }
-      if (node.classList.contains("sn-placeholder")) return "";
-      return inner;
-    default: return inner;
-  }
-}
-
-function childrenToMd(el) {
-  var result = "";
-  for (var i = 0; i < el.childNodes.length; i++) {
-    result += nodeToMd(el.childNodes[i]);
-  }
-  return result;
-}
-
-function extractMdFromRendered(rendered) {
-  var titleEl = rendered.querySelector(".sn-title");
-  if (titleEl) {
-    var titleMd = childrenToMd(titleEl);
-    var rest = "";
-    var afterTitle = false;
-    for (var i = 0; i < rendered.childNodes.length; i++) {
-      var child = rendered.childNodes[i];
-      if (child === titleEl) { afterTitle = true; continue; }
-      if (afterTitle) rest += nodeToMd(child);
-    }
-    if (rest && rest.charAt(0) === "\n") rest = rest.substring(1);
-    return titleMd + (rest ? "\n" + rest : "");
-  }
-  var md = childrenToMd(rendered);
-  return md.replace(/^\n+/, "");
 }
 
 // --- Note rendering ---
@@ -613,13 +519,29 @@ function setupTextEdit(textarea, rendered, noteId, mdBtn) {
   var noteEl = textarea.closest(".sticky-note");
   var mdMode = false;
 
+  function saveRenderedMarkdown() {
+    var markdown = extractMarkdown(rendered);
+    textarea.value = markdown;
+    debouncedTextUpdate(noteId, markdown);
+    syncTitle(noteEl, markdown);
+    rendered.classList.toggle("is-empty", !markdown.trim());
+  }
+
+  function toggleChecklistItem(check) {
+    var checked = !check.classList.contains("checked");
+    check.classList.toggle("checked", checked);
+    check.textContent = checked ? "✓" : "☐";
+    check.setAttribute("aria-checked", checked ? "true" : "false");
+    saveRenderedMarkdown();
+  }
+
   // MD button: toggle between contenteditable rendered view and raw textarea
   mdBtn.addEventListener("click", function (e) {
     e.stopPropagation();
     mdMode = !mdMode;
     if (mdMode) {
       // Switch to raw markdown editing
-      var md = extractMdFromRendered(rendered);
+      var md = extractMarkdown(rendered);
       textarea.value = md;
       textarea.style.display = "";
       rendered.style.display = "none";
@@ -646,11 +568,15 @@ function setupTextEdit(textarea, rendered, noteId, mdBtn) {
 
   // Sync contenteditable changes to textarea (data store) and save
   rendered.addEventListener("input", function () {
-    var md = extractMdFromRendered(rendered);
-    textarea.value = md;
-    debouncedTextUpdate(noteId, md);
-    syncTitle(noteEl, md);
-    rendered.classList.toggle("is-empty", !md.trim());
+    saveRenderedMarkdown();
+  });
+
+  rendered.addEventListener("click", function (e) {
+    var check = e.target.closest && e.target.closest(".sn-check");
+    if (!check || !rendered.contains(check)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    toggleChecklistItem(check);
   });
 
   // On blur, re-render to normalize HTML structure
@@ -658,7 +584,7 @@ function setupTextEdit(textarea, rendered, noteId, mdBtn) {
     // Don't re-render if clicking format toolbar (it prevents default, but just in case)
     if (e.relatedTarget && e.relatedTarget.closest && e.relatedTarget.closest(".sn-format-toolbar")) return;
     closeFormatToolbar();
-    var md = extractMdFromRendered(rendered);
+    var md = extractMarkdown(rendered);
     textarea.value = md;
     if (md.trim()) {
       rendered.innerHTML = renderMiniMarkdown(md);
@@ -696,6 +622,12 @@ function setupTextEdit(textarea, rendered, noteId, mdBtn) {
 
   // Insert <br> on Enter instead of <div>
   rendered.addEventListener("keydown", function (e) {
+    if (e.target.classList && e.target.classList.contains("sn-check") &&
+        (e.key === "Enter" || e.key === " ")) {
+      e.preventDefault();
+      toggleChecklistItem(e.target);
+      return;
+    }
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       document.execCommand("insertLineBreak");
@@ -979,7 +911,7 @@ function renderArchiveCards() {
   if (notes.size === 0) {
     var empty = document.createElement("div");
     empty.className = "notes-archive-empty";
-    empty.innerHTML = iconHtml("sticky-note") + "<p>No sticky notes yet</p><p class=\"notes-archive-empty-sub\">Create one with the " + iconHtml("sticky-note") + " button in the title bar</p>";
+    empty.innerHTML = iconHtml("sticky-note") + "<p>Keep what matters across sessions</p><p class=\"notes-archive-empty-sub\">Use sticky notes for checklists, goals, handoffs, and durable project knowledge. You and every Clay agent can find them in future sessions.</p><p class=\"notes-archive-empty-sub\">Create one with the " + iconHtml("sticky-note") + " button in the title bar</p>";
     grid.appendChild(empty);
     refreshIcons();
     return;

--- a/lib/session-notes-mcp-server.js
+++ b/lib/session-notes-mcp-server.js
@@ -2,7 +2,7 @@
 
 var buildShape = require("./session-spawn-mcp-server").buildShape;
 
-var MEMORY_CONTRACT = "Shared project memory on the user's board. One note = one fact, decision, or reminder, written like a real sticky note: a phrase or at most two short sentences. It must be worth a human's attention a week later and stand on its own without the current conversation. Never paragraphs, lists of steps, logs, or announcement notes about your own activity. Update an existing note instead of adding a near-duplicate; delete notes that stop being true.";
+var MEMORY_CONTRACT = "Shared project memory that persists across sessions and is visible to the user and other Clay agents. People may use the board freely. As a Clay agent, use notes specifically for actionable or durable work memory: checklists and to-do lists, work goals, handoffs, unfinished work, durable decisions and constraints, and knowledge that should still be available after the current session ends. Every note starts with a concise plain-text title on the first line. Add a detailed body whenever another worker would otherwise need to reconstruct the context. Keep one coherent topic per note, update an existing note instead of adding a near-duplicate, and delete notes that stop being true. Do not use notes as a transcript, a routine progress log, or an announcement of your own activity.";
 
 function getToolDefs(handlers) {
   return [
@@ -14,10 +14,10 @@ function getToolDefs(handlers) {
     },
     {
       name: "write_note",
-      description: MEMORY_CONTRACT + " Create a new note, or update an existing note by id. Long board notes are allowed, with a 2000-character abuse guard.",
+      description: MEMORY_CONTRACT + " Create a new note, or update an existing note by id. Long task and handoff notes are allowed, with a generous 20000-character abuse guard.",
       inputSchema: buildShape({
         id: { type: "string", description: "Existing note id to update. Omit to create a note." },
-        text: { type: "string", description: "Sticky-note text. Keep the register concise even though the board permits up to 2000 characters." },
+        text: { type: "string", description: "Sticky-note text. Put the title on the first line, followed by the detailed handoff body. The board permits up to 20000 characters." },
         color: { type: "string", enum: ["yellow", "blue", "green", "pink", "orange", "purple"], description: "Optional sticky-note color." },
       }, ["text"]),
       handler: function (args) { return handlers.write(args || {}); },

--- a/test/session-notes.test.js
+++ b/test/session-notes.test.js
@@ -134,12 +134,26 @@ test("manual note-manager edits do not broadcast note_written", function () {
   assert.deepStrictEqual(f.written, []);
 });
 
-test("write_note rejects text past the 2000-character abuse guard", async function () {
+test("write_note allows detailed handoffs up to the generous abuse guard", async function () {
   var f = createFixture();
-  var result = await toolsFor(f).write_note.handler({ text: "x".repeat(2001) });
+  var tools = toolsFor(f);
+  var acceptedText = "Detailed handoff\n" + "x".repeat(notesModule.MAX_NOTE_TEXT_CHARS - 17);
+  var accepted = await tools.write_note.handler({ text: acceptedText });
+  assert.strictEqual(accepted.isError, undefined);
+
+  var result = await tools.write_note.handler({ text: "x".repeat(notesModule.MAX_NOTE_TEXT_CHARS + 1) });
   assert.strictEqual(result.isError, true);
-  assert.match(result.content[0].text, /text exceeds 2000 characters/);
-  assert.strictEqual(f.notes.length, 0);
+  assert.match(result.content[0].text, new RegExp("text exceeds " + notesModule.MAX_NOTE_TEXT_CHARS + " characters"));
+  assert.strictEqual(f.notes.length, 1);
+});
+
+test("write_note contract requires a titled detailed handoff format", function () {
+  var tool = toolsFor(createFixture()).write_note;
+  assert.match(tool.description, /title on the first line/i);
+  assert.match(tool.description, /checklists and to-do lists/i);
+  assert.match(tool.description, /knowledge that should still be available after the current session ends/i);
+  assert.match(tool.description, /People may use the board freely/i);
+  assert.match(tool.description, /20000-character abuse guard/i);
 });
 
 test("write_note caps new active notes at twenty but still permits updates", async function () {
@@ -183,25 +197,26 @@ test("sticky-note prompt announces an empty board and proactive policy", functio
   var prompt = notesModule.buildNotesPrompt([{ text: "Use port 2633", color: "yellow", updatedAt: 1 }]);
   assert.ok(prompt.startsWith(notesModule.NOTES_LABEL + "\n"));
   assert.match(prompt, /Use port 2633/);
-  assert.match(prompt, /Use the board proactively:/);
+  assert.match(prompt, /persists across sessions/);
+  assert.match(prompt, /checklists and to-do lists/);
   assert.ok(prompt.endsWith(notesModule.PROACTIVE_POLICY));
 });
 
-test("sticky-note prompt is capped at 2000 characters with newest notes first", function () {
+test("sticky-note prompt stays bounded with newest notes first", function () {
   var notes = [];
-  for (var i = 0; i < 30; i++) {
+  for (var i = 0; i < 60; i++) {
     notes.push({ text: "note-" + i + " " + "x".repeat(100), color: "blue", updatedAt: i });
   }
   var prompt = notesModule.buildNotesPrompt(notes);
   var notesPortion = prompt.slice(0, prompt.length - notesModule.PROACTIVE_POLICY.length - 1);
-  assert.ok(notesPortion.length <= 2000);
-  assert.ok(prompt.indexOf("note-29") < prompt.indexOf("note-28"));
+  assert.ok(notesPortion.length <= notesModule.MAX_PROMPT_CHARS);
+  assert.ok(prompt.indexOf("note-59") < prompt.indexOf("note-58"));
   assert.match(prompt, /call list_notes for the rest/);
   assert.ok(prompt.endsWith(notesModule.PROACTIVE_POLICY));
   assert.strictEqual(prompt.indexOf("note-0"), -1);
 });
 
-test("long notes use a 240-character injection preview while list_notes returns full text", async function () {
+test("long notes use a bounded injection preview while list_notes returns full text", async function () {
   var longText = "Long durable context " + "x".repeat(900);
   var f = createFixture();
   var tools = toolsFor(f);

--- a/test/sticky-note-markdown.test.js
+++ b/test/sticky-note-markdown.test.js
@@ -1,0 +1,55 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+
+async function loadMarkdownModule() {
+  var source = fs.readFileSync(path.join(__dirname, "../lib/public/modules/sticky-note-markdown.js"), "utf8");
+  return import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+}
+
+function classList(names) {
+  return {
+    contains: function (name) { return names.indexOf(name) !== -1; },
+  };
+}
+
+function textNode(text) {
+  return { nodeType: 3, textContent: text };
+}
+
+function element(tagName, classes, children) {
+  return {
+    nodeType: 1,
+    tagName: tagName,
+    classList: classList(classes || []),
+    childNodes: children || [],
+    getAttribute: function () { return null; },
+  };
+}
+
+test("sticky-note markdown renders bare and bulleted checklist markers", async function () {
+  var markdown = await loadMarkdownModule();
+  var html = markdown.renderMiniMarkdown("Handoff\n[x] Done\n[ ] Next\n- [X] Also done\n- [ ] Later");
+  assert.strictEqual((html.match(/role=\"checkbox\"/g) || []).length, 4);
+  assert.strictEqual((html.match(/aria-checked=\"true\"/g) || []).length, 2);
+  assert.strictEqual((html.match(/aria-checked=\"false\"/g) || []).length, 2);
+});
+
+test("sticky-note checklist state serializes back to markdown", async function () {
+  var markdown = await loadMarkdownModule();
+  var title = element("DIV", ["sn-title"], [textNode("Handoff")]);
+  var checked = element("SPAN", ["sn-check", "checked"], [textNode("✓")]);
+  var unchecked = element("SPAN", ["sn-check"], [textNode("☐")]);
+  var rendered = element("DIV", [], [
+    title,
+    element("BR"),
+    checked,
+    textNode(" Done"),
+    element("BR"),
+    unchecked,
+    textNode(" Next"),
+  ]);
+  rendered.querySelector = function () { return title; };
+  assert.strictEqual(markdown.extractMarkdown(rendered), "Handoff\n- [x] Done\n- [ ] Next");
+});


### PR DESCRIPTION
## Summary

- define sticky notes as shared cross-session work memory for Clay agents while keeping human use unrestricted
- support detailed title-first handoffs with a larger storage guard and bounded prompt previews
- render `[x]` and `[ ]` checklist items as accessible, interactive controls that persist to Markdown
- explain the cross-session value in the empty notes view and update Mate guidance

## Why

The previous agent guidance treated sticky notes as very short reminders. That made them too shallow for handoffs and did not communicate their main advantage: goals, next actions, and durable project knowledge remain available to other Clay agents in future sessions.

## User impact

Users can now use sticky notes as practical checklists and long-form handoff memory. Checkbox items can be toggled with a pointer or keyboard, and the empty state explains that notes survive across sessions.

## Validation

- `npm test` — 156 tests passed
- `git diff --check`
- `node --check` on the changed JavaScript modules
