### PR TITLE
fix(sessions): recover messages rejected by stale queries

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -972,7 +972,8 @@ function createSDKBridge(opts) {
       // Only clean up if the session still references OUR resources.
       // A rewind + new startQuery may have already replaced these with
       // a newer query — clobbering them would kill the new query.
-      if (session.queryInstance === myQueryInstance) {
+      var ownsRuntime = session.queryInstance === myQueryInstance;
+      if (ownsRuntime) {
         try {
           if (typeof session.queryInstance.close === "function") {
             session.queryInstance.close();
@@ -982,55 +983,57 @@ function createSDKBridge(opts) {
       }
       if (session.messageQueue === myMessageQueue) session.messageQueue = null;
       if (session.abortController === myAbortController) session.abortController = null;
-      session.taskStopRequested = false;
-      session.pendingPermissions = {};
-      // Preserve MCP-mode AskUserQuestion entries across turn boundaries.
-      // The MCP path is intentionally stateless: the tool returns immediately
-      // ("card posted, end your turn") and the user's answer is expected to
-      // arrive as a brand-new user_message on the *next* turn. That means the
-      // pending entry MUST survive this finally block. Without it, the
-      // ask_user_response handler can't find the toolId and silently drops
-      // the answer. canUseTool-mode entries (Claude's native path) still hold
-      // an open SDK permission callback that dies with the query, so those
-      // are correctly cleared here.
-      var keepAskUser = {};
-      for (var _tid in session.pendingAskUser) {
-        var _pending = session.pendingAskUser[_tid];
-        if (_pending && _pending.mode === "mcp") keepAskUser[_tid] = _pending;
-      }
-      session.pendingAskUser = keepAskUser;
-      session.pendingElicitations = {};
-
-      // Auto-continue on rate limit (scheduler sessions, or user setting)
-      // Mark session as done processing so the late rate_limit_event handler
-      // can detect the race condition and schedule auto-continue itself.
-      session.isProcessing = false;
-
-      var didScheduleAutoContinue = false;
-      var acEnabled = session.onQueryComplete || (typeof opts.getAutoContinueSetting === "function" && opts.getAutoContinueSetting(session));
-      if (session.rateLimitResetsAt && session.rateLimitResetsAt > Date.now()
-          && acEnabled && !session.destroying) {
-        var acResetsAt = session.rateLimitResetsAt;
-        session.rateLimitResetsAt = null;
-        session.rateLimitAutoContinuePending = true;
-        didScheduleAutoContinue = true;
-        console.log("[sdk-bridge] Rate limited, scheduling auto-continue via scheduleMessage for session " + session.localId);
-        if (typeof opts.scheduleMessage === "function") {
-          opts.scheduleMessage(session, "continue", acResetsAt);
+      if (ownsRuntime) {
+        session.taskStopRequested = false;
+        session.pendingPermissions = {};
+        // Preserve MCP-mode AskUserQuestion entries across turn boundaries.
+        // The MCP path is intentionally stateless: the tool returns immediately
+        // ("card posted, end your turn") and the user's answer is expected to
+        // arrive as a brand-new user_message on the *next* turn. That means the
+        // pending entry MUST survive this finally block. Without it, the
+        // ask_user_response handler can't find the toolId and silently drops
+        // the answer. canUseTool-mode entries (Claude's native path) still hold
+        // an open SDK permission callback that dies with the query, so those
+        // are correctly cleared here.
+        var keepAskUser = {};
+        for (var _tid in session.pendingAskUser) {
+          var _pending = session.pendingAskUser[_tid];
+          if (_pending && _pending.mode === "mcp") keepAskUser[_tid] = _pending;
         }
-      } else if (acEnabled && !session.destroying) {
-        // Log why auto-continue was not scheduled (for debugging)
-        console.log("[sdk-bridge] Query done, auto-continue enabled but not scheduled: rateLimitResetsAt=" +
-          session.rateLimitResetsAt + " (will rely on late rate_limit_event handler)");
-      }
+        session.pendingAskUser = keepAskUser;
+        session.pendingElicitations = {};
 
-      // Ralph Loop: notify completion so loop orchestrator can proceed
-      if (session.onQueryComplete && !didScheduleAutoContinue) {
-        console.log("[sdk-bridge] Calling onQueryComplete for session " + session.localId + " (title: " + (session.title || "?") + ")");
-        try {
-          session.onQueryComplete(session);
-        } catch (err) {
-          console.error("[sdk-bridge] onQueryComplete error:", err.message || err);
+        // Auto-continue on rate limit (scheduler sessions, or user setting)
+        // Mark session as done processing so the late rate_limit_event handler
+        // can detect the race condition and schedule auto-continue itself.
+        session.isProcessing = false;
+
+        var didScheduleAutoContinue = false;
+        var acEnabled = session.onQueryComplete || (typeof opts.getAutoContinueSetting === "function" && opts.getAutoContinueSetting(session));
+        if (session.rateLimitResetsAt && session.rateLimitResetsAt > Date.now()
+            && acEnabled && !session.destroying) {
+          var acResetsAt = session.rateLimitResetsAt;
+          session.rateLimitResetsAt = null;
+          session.rateLimitAutoContinuePending = true;
+          didScheduleAutoContinue = true;
+          console.log("[sdk-bridge] Rate limited, scheduling auto-continue via scheduleMessage for session " + session.localId);
+          if (typeof opts.scheduleMessage === "function") {
+            opts.scheduleMessage(session, "continue", acResetsAt);
+          }
+        } else if (acEnabled && !session.destroying) {
+          // Log why auto-continue was not scheduled (for debugging)
+          console.log("[sdk-bridge] Query done, auto-continue enabled but not scheduled: rateLimitResetsAt=" +
+            session.rateLimitResetsAt + " (will rely on late rate_limit_event handler)");
+        }
+
+        // Ralph Loop: notify completion so loop orchestrator can proceed
+        if (session.onQueryComplete && !didScheduleAutoContinue) {
+          console.log("[sdk-bridge] Calling onQueryComplete for session " + session.localId + " (title: " + (session.title || "?") + ")");
+          try {
+            session.onQueryComplete(session);
+          } catch (err) {
+            console.error("[sdk-bridge] onQueryComplete error:", err.message || err);
+          }
         }
       }
     }
@@ -1620,8 +1623,30 @@ function createSDKBridge(opts) {
     }
     // Route through QueryHandle (works for both in-process and worker paths)
     if (session.queryInstance && typeof session.queryInstance.pushMessage === "function") {
-      session.queryInstance.pushMessage(text, images);
-      return true;
+      var activeQuery = session.queryInstance;
+      var activeAbortController = session.abortController;
+      var activeMessageQueue = session.messageQueue;
+      var delivered = false;
+      try {
+        // Older third-party adapters returned undefined. Preserve compatibility
+        // while requiring built-in adapters to return false for a closed input.
+        delivered = activeQuery.pushMessage(text, images) !== false;
+      } catch (e) {
+        console.error("[sdk-bridge] QueryHandle rejected message for session " + session.localId + ":", e.message || e);
+      }
+      if (delivered) return true;
+
+      // The handle object can outlive its underlying input queue or worker.
+      // Retire it before the caller starts a resumed replacement query; the
+      // old stream's finally block compares object identity and cannot clobber
+      // the replacement resources.
+      try {
+        if (typeof activeQuery.close === "function") activeQuery.close();
+      } catch (e) {}
+      if (session.queryInstance === activeQuery) session.queryInstance = null;
+      if (session.abortController === activeAbortController) session.abortController = null;
+      if (session.messageQueue === activeMessageQueue) session.messageQueue = null;
+      return false;
     }
     if (session._queryStarting) {
       session.pendingPush = session.pendingPush || [];

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -53,7 +53,7 @@ function createMessageQueue() {
   var ended = false;
   return {
     push: function(msg) {
-      if (ended) return;
+      if (ended) return false;
       if (waiting) {
         var resolve = waiting;
         waiting = null;
@@ -61,6 +61,7 @@ function createMessageQueue() {
       } else {
         queue.push(msg);
       }
+      return true;
     },
     end: function() {
       ended = true;
@@ -346,6 +347,7 @@ function flattenEvent(raw) {
 // Wraps a raw SDK query object with the YOKE QueryHandle interface.
 // Events are flattened via flattenEvent before yielding.
 function createQueryHandle(rawQuery, messageQueue, abortController) {
+  var closed = false;
   var handle = {
     // Opaque adapter state (null for in-process queries)
     _adapterState: null,
@@ -356,14 +358,19 @@ function createQueryHandle(rawQuery, messageQueue, abortController) {
       return {
         next: function() {
           return rawIter.next().then(function(result) {
+            if (result.done) closed = true;
             if (result.done) return result;
             return { value: flattenEvent(result.value), done: false };
+          }, function(err) {
+            closed = true;
+            throw err;
           });
         },
       };
     },
 
     pushMessage: function(text, images) {
+      if (closed) return false;
       var content = [];
       if (images && images.length > 0) {
         for (var i = 0; i < images.length; i++) {
@@ -374,7 +381,7 @@ function createQueryHandle(rawQuery, messageQueue, abortController) {
         }
       }
       if (text) content.push({ type: "text", text: text });
-      messageQueue.push({ type: "user", message: { role: "user", content: content } });
+      return messageQueue.push({ type: "user", message: { role: "user", content: content } });
     },
 
     setModel: function(model) {
@@ -443,12 +450,14 @@ function createQueryHandle(rawQuery, messageQueue, abortController) {
     },
 
     abort: function() {
+      closed = true;
       if (abortController) {
         try { abortController.abort(); } catch (e) {}
       }
     },
 
     close: function() {
+      closed = true;
       try { messageQueue.end(); } catch (e) {}
       if (rawQuery && typeof rawQuery.close === "function") {
         try { rawQuery.close(); } catch (e) {}
@@ -457,6 +466,7 @@ function createQueryHandle(rawQuery, messageQueue, abortController) {
 
     // End the message queue without closing the raw query
     endInput: function() {
+      closed = true;
       try { messageQueue.end(); } catch (e) {}
     },
 
@@ -987,6 +997,7 @@ function createWorkerQueryHandle(worker, canUseTool, onElicitation, callMcpTool,
     },
 
     pushMessage: function(text, images) {
+      if (iterEnded || (worker.process && (worker.process.killed || worker.process.exitCode != null))) return false;
       var content = [];
       if (images && images.length > 0) {
         for (var i = 0; i < images.length; i++) {
@@ -998,7 +1009,12 @@ function createWorkerQueryHandle(worker, canUseTool, onElicitation, callMcpTool,
       }
       if (text) content.push({ type: "text", text: text });
       var userMsg = { type: "user", message: { role: "user", content: content } };
-      worker.send({ type: "push_message", content: userMsg });
+      try {
+        worker.send({ type: "push_message", content: userMsg });
+        return true;
+      } catch (e) {
+        return false;
+      }
     },
 
     setModel: function(model) {

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -738,7 +738,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
   var handlerEntry = null;
 
   function pushMessageToQueue(msg) {
-    if (messageQueueEnded) return;
+    if (messageQueueEnded) return false;
     if (messageWaiting) {
       var resolve = messageWaiting;
       messageWaiting = null;
@@ -746,6 +746,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
     } else {
       messageQueue.push(msg);
     }
+    return true;
   }
 
   function waitForMessage() {
@@ -1119,6 +1120,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
     },
 
     pushMessage: function(text, images) {
+      if (iteratorDone || state.done || messageQueueEnded) return false;
       var input;
       if (images && images.length > 0) {
         input = [];
@@ -1134,8 +1136,9 @@ function createCodexQueryHandle(appServer, queryOpts) {
       if (!state.loopStarted) {
         state.loopStarted = true;
         runQueryLoop(input);
+        return true;
       } else {
-        pushMessageToQueue(input);
+        return pushMessageToQueue(input);
       }
     },
 

--- a/lib/yoke/adapters/kiro.js
+++ b/lib/yoke/adapters/kiro.js
@@ -449,7 +449,7 @@ function createKiroQueryHandle(acp, queryOpts) {
   var messageQueueEnded = false;
 
   function pushMessageToQueue(msg) {
-    if (messageQueueEnded) return;
+    if (messageQueueEnded) return false;
     if (messageWaiting) {
       var resolve = messageWaiting;
       messageWaiting = null;
@@ -457,6 +457,7 @@ function createKiroQueryHandle(acp, queryOpts) {
     } else {
       messageQueue.push(msg);
     }
+    return true;
   }
   function waitForMessage() {
     if (messageQueue.length > 0) return Promise.resolve(messageQueue.shift());
@@ -737,6 +738,7 @@ function createKiroQueryHandle(acp, queryOpts) {
     },
 
     pushMessage: function(text, images) {
+      if (iteratorDone || state.done || messageQueueEnded) return false;
       var input = [];
       if (images && images.length > 0) {
         for (var i = 0; i < images.length; i++) {
@@ -752,8 +754,9 @@ function createKiroQueryHandle(acp, queryOpts) {
       if (!state.loopStarted) {
         state.loopStarted = true;
         runQueryLoop(payload);
+        return true;
       } else {
-        pushMessageToQueue(payload);
+        return pushMessageToQueue(payload);
       }
     },
 

--- a/lib/yoke/interface.js
+++ b/lib/yoke/interface.js
@@ -35,7 +35,7 @@ var TOOL_POLICIES = ["ask", "allow-all"];
  *
  * QueryHandle shape:
  *   [Symbol.asyncIterator]()  - yields SDK events (raw in Phase 3, normalized later)
- *   .pushMessage(text, images)
+ *   .pushMessage(text, images) - boolean; false when the handle cannot accept input
  *   .setModel(model)
  *   .setEffort(effort)
  *   .setToolPolicy(policy)    - "ask" | "allow-all"

--- a/test/sdk-bridge-delivery.test.js
+++ b/test/sdk-bridge-delivery.test.js
@@ -1,0 +1,73 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+var createSDKBridge = require("../lib/sdk-bridge").createSDKBridge;
+
+function createBridge() {
+  return createSDKBridge({
+    cwd: process.cwd(),
+    sessionManager: {},
+    adapter: {},
+    send: function () {},
+  });
+}
+
+test("pushMessage retires a query handle that rejects delivery", function() {
+  var bridge = createBridge();
+  var closeCount = 0;
+  var query = {
+    pushMessage: function() { return false; },
+    close: function() { closeCount++; },
+  };
+  var session = {
+    localId: 7,
+    queryInstance: query,
+    abortController: { signal: {} },
+    messageQueue: {},
+  };
+
+  assert.strictEqual(bridge.pushMessage(session, "hello"), false);
+  assert.strictEqual(closeCount, 1);
+  assert.strictEqual(session.queryInstance, null);
+  assert.strictEqual(session.abortController, null);
+  assert.strictEqual(session.messageQueue, null);
+});
+
+test("pushMessage retires a query handle that throws during delivery", function() {
+  var bridge = createBridge();
+  var query = {
+    pushMessage: function() { throw new Error("closed input"); },
+    close: function() {},
+  };
+  var session = { localId: 8, queryInstance: query };
+
+  assert.strictEqual(bridge.pushMessage(session, "hello"), false);
+  assert.strictEqual(session.queryInstance, null);
+});
+
+test("rejected delivery does not clear resources from a replacement query", function() {
+  var bridge = createBridge();
+  var replacementQuery = { pushMessage: function() { return true; } };
+  var replacementAbortController = { signal: {} };
+  var replacementMessageQueue = {};
+  var session = {
+    localId: 9,
+    abortController: { signal: {} },
+    messageQueue: {},
+  };
+  var originalQuery = {
+    pushMessage: function() {
+      session.queryInstance = replacementQuery;
+      session.abortController = replacementAbortController;
+      session.messageQueue = replacementMessageQueue;
+      return false;
+    },
+    close: function() {},
+  };
+  session.queryInstance = originalQuery;
+
+  assert.strictEqual(bridge.pushMessage(session, "hello"), false);
+  assert.strictEqual(session.queryInstance, replacementQuery);
+  assert.strictEqual(session.abortController, replacementAbortController);
+  assert.strictEqual(session.messageQueue, replacementMessageQueue);
+});

--- a/test/yoke-adapter-contract.test.js
+++ b/test/yoke-adapter-contract.test.js
@@ -45,6 +45,7 @@ for (var i = 0; i < fixtures.length; i++) {
       iface.validateAdapter(adapter);
       iface.validateQueryHandle(handle);
       handle.close();
+      assert.strictEqual(handle.pushMessage("closed handle probe"), false);
     });
 
     test(fixture.vendor + " protocol snapshot normalizes to stable YOKE events", function() {
@@ -56,3 +57,20 @@ for (var i = 0; i < fixtures.length; i++) {
     });
   })(fixtures[i]);
 }
+
+test("Claude query handles reject messages after their input queue closes", function() {
+  var claudeModule = require("../lib/yoke/adapters/claude");
+  var kit = claudeModule.contractTestKit;
+  var queue = kit.createMessageQueue();
+  var handle = kit.createQueryHandle({
+    [Symbol.asyncIterator]: function() {
+      return { next: function() { return new Promise(function() {}); } };
+    },
+    close: function() {},
+  }, queue, new AbortController());
+
+  assert.strictEqual(handle.pushMessage("first"), true);
+  handle.close();
+  assert.strictEqual(handle.pushMessage("must not be dropped silently"), false);
+  assert.strictEqual(queue.push({ type: "user" }), false);
+});


### PR DESCRIPTION
## What changed

- make query handles report whether they accepted a pushed message
- retire closed Claude, Codex, and Kiro query handles and resume through a fresh query
- guard query cleanup by resource identity so stale streams cannot clear replacement state
- add regression coverage for rejected delivery, thrown delivery errors, and replacement-query races

## Why

A query handle could outlive its underlying input queue or worker. Clay treated the presence of the handle as successful delivery even when the message was silently discarded, leaving the session apparently processing without a response.

## Impact

Messages sent across query teardown boundaries now fall back to a resumed query instead of disappearing.

## Validation

- focused delivery and adapter tests: 15 passed
- full suite: 171 passed, with one unrelated atomic file-watcher timing test passing when rerun in isolation (2 passed)
- `git diff --check`
