### PR TITLE
fix(split): align pair arrow and deduplicate banners

### DIFF
--- a/lib/public/css/pane.css
+++ b/lib/public/css/pane.css
@@ -51,6 +51,7 @@ body.pane-mode #input-area {
 
 #split-host {
   display: none;
+  position: relative;
   flex: 1;
   min-width: 0;
   min-height: 0;

--- a/lib/public/modules/app-notifications.js
+++ b/lib/public/modules/app-notifications.js
@@ -56,6 +56,11 @@ export function initAppNotifications() {
   bellBtn = document.getElementById("notif-center-btn");
   badgeEl = document.getElementById("notif-center-badge");
 
+  // Split panes are secondary clients inside the parent shell. They keep
+  // notification state in sync, but the parent owns the single visible
+  // banner surface for the whole split view.
+  if (store.get('paneMode')) return;
+
   // Create banner container
   bannerContainer = document.createElement("div");
   bannerContainer.className = "notif-banner-container";

--- a/test/split-view.test.js
+++ b/test/split-view.test.js
@@ -77,3 +77,20 @@ test("split view promotes one sticky-note canvas above both panes", function () 
   assert.match(notesSource, /setPointerCapture\(pointerId\)/);
   assert.match(paneCss, /body\.sticky-note-interacting \.split-pane-frame\s*\{[^}]*pointer-events:\s*none/s);
 });
+
+test("split role arrow stays anchored to the pane divider", function () {
+  var paneCss = fs.readFileSync(path.join(__dirname, "../lib/public/css/pane.css"), "utf8");
+
+  assert.match(paneCss, /#split-host\s*\{[^}]*position:\s*relative/s);
+  assert.match(paneCss, /#split-host\.split-delegating::after\s*\{[^}]*left:\s*calc\(50% - 17px\)/s);
+});
+
+test("split pane clients leave notification banners to the parent shell", function () {
+  var notificationsSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-notifications.js"), "utf8");
+  var initStart = notificationsSource.indexOf("export function initAppNotifications()");
+  var initEnd = notificationsSource.indexOf("// ========================================================", initStart);
+  var initSource = notificationsSource.slice(initStart, initEnd);
+
+  assert.match(initSource, /if \(store\.get\('paneMode'\)\) return;/);
+  assert.ok(initSource.indexOf("paneMode") < initSource.indexOf('document.createElement("div")'));
+});


### PR DESCRIPTION
## What changed

- anchor the Driver/Worker direction arrow to the split host instead of the wider panel container
- let embedded pane clients synchronize notification state without creating banner surfaces
- add regression checks for divider positioning and parent-only banner ownership

## Why

The arrow used the positioned `#main-panels` ancestor, so opening the side terminal changed its visual center while the pane divider stayed inside the narrower split host. Split view also runs a parent client and two iframe clients; all three rendered the same notification banner.

## Impact

The pair arrow remains centered on the pane boundary when the terminal opens, and split-view notifications render once instead of three times.

## Validation

- split-view tests: 10 passed
- client import and syntax checks passed
- full suite: 173 passed; the unrelated file-watcher timing test passed 2/2 when rerun alone
- `git diff --check`
