### PR TITLE
perf(daemon): share periodic project sync loop

### DIFF
--- a/docs/guides/MODULE_MAP.md
+++ b/docs/guides/MODULE_MAP.md
@@ -66,6 +66,7 @@ Wires all modules, sets up session manager and SDK bridge, dispatches messages.
 | `users-auth.js` | Authentication, PIN hashing, auth tokens, multi-user mode, setup codes |
 | `users-permissions.js` | RBAC permissions, project/session access control |
 | `users-preferences.js` | DM favorites/hidden, auto-continue, chat layout, deleted builtin keys, mate onboarding |
+| `daemon-sync.js` | Shared 10-second daemon synchronization loop and non-overlapping task registry |
 | `daemon-projects.js` | Worktree tracking (scan, rescan, cleanup), removed project filtering |
 | `ws-schema.js` | WebSocket message type registry (328 message types, informational) |
 

--- a/lib/daemon-projects.js
+++ b/lib/daemon-projects.js
@@ -6,11 +6,15 @@
 
 var fs = require("fs");
 var { scanWorktrees, isWorktree } = require("./worktree");
+var { daemonSync } = require("./daemon-sync");
 
 // --- Worktree tracking state ---
 var worktreeRegistry = {}; // parentSlug -> [wtSlug, ...]
-var worktreeTimers = {};   // parentSlug -> intervalId
 var worktreeScanning = {}; // parentSlug -> boolean (mutex)
+
+function getWorktreeSyncKey(parentSlug) {
+  return "worktrees:" + parentSlug;
+}
 
 function isWorktreeSlug(slug) {
   return slug.indexOf("--") !== -1;
@@ -42,11 +46,9 @@ function scanAndRegisterWorktrees(relay, parentPath, parentSlug, parentIcon, par
     worktreeRegistry[parentSlug].push(wtSlug);
     console.log("[daemon] Registered worktree:", wtSlug, "->", wt.path, wt.accessible ? "(accessible)" : "(inaccessible)");
   }
-  if (!worktreeTimers[parentSlug]) {
-    worktreeTimers[parentSlug] = setInterval(function () {
-      rescanWorktrees(relay, parentPath, parentSlug, parentIcon, parentOwnerId);
-    }, 10000);
-  }
+  daemonSync.register(getWorktreeSyncKey(parentSlug), function () {
+    rescanWorktrees(relay, parentPath, parentSlug, parentIcon, parentOwnerId);
+  });
 }
 
 /**
@@ -114,10 +116,7 @@ function cleanupWorktreesForParent(relay, parentSlug) {
     console.log("[daemon] Cascade removed worktree:", wtSlugs[i]);
   }
   delete worktreeRegistry[parentSlug];
-  if (worktreeTimers[parentSlug]) {
-    clearInterval(worktreeTimers[parentSlug]);
-    delete worktreeTimers[parentSlug];
-  }
+  daemonSync.unregister(getWorktreeSyncKey(parentSlug));
 }
 
 /**

--- a/lib/daemon-sync.js
+++ b/lib/daemon-sync.js
@@ -1,0 +1,106 @@
+/**
+ * Shared daemon synchronization loop.
+ *
+ * Periodic daemon work registers here so every project shares one timer.
+ */
+
+function attachDaemonSync(ctx) {
+  var intervalMs = ctx.intervalMs || 10000;
+  var scheduleInterval = ctx.setInterval || setInterval;
+  var cancelInterval = ctx.clearInterval || clearInterval;
+  var onError = ctx.onError || function (key, err) {
+    console.error("[daemon] Sync task failed:", key, err);
+  };
+  var tasks = {};
+  var timer = null;
+
+  function finishTask(task) {
+    task.running = false;
+  }
+
+  function runTask(key, task) {
+    if (task.running) return;
+    task.running = true;
+    var result;
+    try {
+      result = task.run();
+    } catch (err) {
+      finishTask(task);
+      onError(key, err);
+      return;
+    }
+    if (result && typeof result.then === "function") {
+      Promise.resolve(result).then(function () {
+        finishTask(task);
+      }, function (err) {
+        finishTask(task);
+        onError(key, err);
+      });
+      return;
+    }
+    finishTask(task);
+  }
+
+  function tick() {
+    var keys = Object.keys(tasks);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      var task = tasks[key];
+      if (task) runTask(key, task);
+    }
+  }
+
+  function start() {
+    if (timer || Object.keys(tasks).length === 0) return;
+    timer = scheduleInterval(tick, intervalMs);
+    if (timer && typeof timer.unref === "function") timer.unref();
+  }
+
+  function register(key, run) {
+    var current = tasks[key];
+    if (current) {
+      current.run = run;
+    } else {
+      tasks[key] = { run: run, running: false };
+    }
+    start();
+  }
+
+  function unregister(key) {
+    delete tasks[key];
+    if (Object.keys(tasks).length === 0 && timer) {
+      cancelInterval(timer);
+      timer = null;
+    }
+  }
+
+  function stop() {
+    if (timer) cancelInterval(timer);
+    timer = null;
+    tasks = {};
+  }
+
+  function getTaskCount() {
+    return Object.keys(tasks).length;
+  }
+
+  function isRunning() {
+    return !!timer;
+  }
+
+  return {
+    register: register,
+    unregister: unregister,
+    tick: tick,
+    stop: stop,
+    getTaskCount: getTaskCount,
+    isRunning: isRunning,
+  };
+}
+
+var daemonSync = attachDaemonSync({});
+
+module.exports = {
+  attachDaemonSync: attachDaemonSync,
+  daemonSync: daemonSync,
+};

--- a/test/daemon-sync.test.js
+++ b/test/daemon-sync.test.js
@@ -1,0 +1,114 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("fs");
+var path = require("path");
+var { attachDaemonSync } = require("../lib/daemon-sync");
+
+function createHarness() {
+  var scheduled = [];
+  var cancelled = [];
+  var errors = [];
+  var sync = attachDaemonSync({
+    intervalMs: 10000,
+    setInterval: function (run, intervalMs) {
+      var handle = { run: run, intervalMs: intervalMs };
+      scheduled.push(handle);
+      return handle;
+    },
+    clearInterval: function (handle) {
+      cancelled.push(handle);
+    },
+    onError: function (key, err) {
+      errors.push({ key: key, err: err });
+    },
+  });
+  return {
+    sync: sync,
+    scheduled: scheduled,
+    cancelled: cancelled,
+    errors: errors,
+  };
+}
+
+test("daemon sync shares one interval across all registered tasks", function () {
+  var harness = createHarness();
+  var calls = [];
+
+  harness.sync.register("worktrees:one", function () { calls.push("one"); });
+  harness.sync.register("worktrees:two", function () { calls.push("two"); });
+
+  assert.equal(harness.scheduled.length, 1);
+  assert.equal(harness.scheduled[0].intervalMs, 10000);
+  assert.equal(harness.sync.getTaskCount(), 2);
+
+  harness.scheduled[0].run();
+  assert.deepEqual(calls, ["one", "two"]);
+
+  harness.sync.unregister("worktrees:one");
+  assert.equal(harness.cancelled.length, 0);
+  harness.sync.unregister("worktrees:two");
+  assert.equal(harness.cancelled.length, 1);
+  assert.equal(harness.sync.isRunning(), false);
+});
+
+test("daemon sync replaces a task without creating another interval", function () {
+  var harness = createHarness();
+  var value = "";
+
+  harness.sync.register("worktrees:one", function () { value = "old"; });
+  harness.sync.register("worktrees:one", function () { value = "new"; });
+  harness.sync.tick();
+
+  assert.equal(harness.scheduled.length, 1);
+  assert.equal(harness.sync.getTaskCount(), 1);
+  assert.equal(value, "new");
+});
+
+test("daemon sync does not overlap an unfinished asynchronous task", async function () {
+  var harness = createHarness();
+  var resolveTask;
+  var calls = 0;
+  var pending = new Promise(function (resolve) { resolveTask = resolve; });
+
+  harness.sync.register("issues:one", function () {
+    calls++;
+    return pending;
+  });
+
+  harness.sync.tick();
+  harness.sync.tick();
+  assert.equal(calls, 1);
+
+  resolveTask();
+  await pending;
+  await Promise.resolve();
+  harness.sync.tick();
+  assert.equal(calls, 2);
+});
+
+test("daemon sync reports a rejection and runs the task again later", async function () {
+  var harness = createHarness();
+  var calls = 0;
+
+  harness.sync.register("issues:one", function () {
+    calls++;
+    return Promise.reject(new Error("network failed"));
+  });
+
+  harness.sync.tick();
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(harness.errors.length, 1);
+  assert.equal(harness.errors[0].key, "issues:one");
+
+  harness.sync.tick();
+  assert.equal(calls, 2);
+});
+
+test("daemon project scans use the shared sync loop", function () {
+  var source = fs.readFileSync(path.join(__dirname, "../lib/daemon-projects.js"), "utf8");
+
+  assert.match(source, /daemonSync\.register\(getWorktreeSyncKey\(parentSlug\)/);
+  assert.match(source, /daemonSync\.unregister\(getWorktreeSyncKey\(parentSlug\)/);
+  assert.doesNotMatch(source, /setInterval|worktreeTimers/);
+});


### PR DESCRIPTION
## Summary

- replace per-project worktree polling timers with one daemon-wide 10-second synchronization loop
- register and unregister worktree scans through the shared scheduler
- prevent unfinished asynchronous synchronization tasks from overlapping with the next interval
- document the new daemon synchronization module

## Root cause

Each parent project with worktrees created its own 10-second interval. Adding issue synchronization independently would multiply pollers further as the project count increased.

## Impact

The daemon now maintains one periodic timer regardless of project count. Future issue synchronization can use the same registry, and slow asynchronous tasks cannot pile up across intervals.

## Validation

- `node --check lib/daemon-sync.js`
- `node --check lib/daemon-projects.js`
- `node --test test/daemon-sync.test.js test/project-file-watch.test.js`
- `git diff --check`

The full 179-test suite passed 178 tests; the existing file-watcher isolation test timed out only under the full parallel suite and passed in isolated and focused reruns.
