### PR TITLE
fix(split): align pane chrome with native sessions

### DIFF
--- a/lib/public/css/pane.css
+++ b/lib/public/css/pane.css
@@ -83,7 +83,7 @@ body.pane-mode #input-area {
   gap: 6px;
   padding: 0 5px 0 9px;
   border-bottom: 1px solid var(--border-subtle);
-  background: var(--sidebar-bg);
+  background: var(--bg);
   color: var(--text-secondary);
   flex-shrink: 0;
 }
@@ -194,7 +194,9 @@ button.split-pair-role:hover { filter: brightness(1.25); }
   display: none;
   align-items: center;
   gap: 6px;
-  margin: 0 12px;
+  width: 100%;
+  max-width: var(--content-width);
+  margin: 0 auto;
   padding: 4px 10px;
   border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
   border-bottom: 0;
@@ -205,6 +207,9 @@ button.split-pair-role:hover { filter: brightness(1.25); }
   line-height: 1.4;
 }
 .pane-delegation-notice.visible { display: flex; }
+.pane-delegation-notice.visible + #input-wrapper #input-row {
+  border-radius: 0 0 8px 8px;
+}
 .pane-delegation-notice::before {
   content: "";
   width: 6px;

--- a/lib/public/modules/split-pair-ui.js
+++ b/lib/public/modules/split-pair-ui.js
@@ -260,11 +260,12 @@ var workerNoticeEl = null;
 export function showWorkerDelegationNotice(driverTitle) {
   if (!store.get('paneMode')) return;
   var inputArea = document.getElementById("input-area");
-  if (!inputArea || !inputArea.parentNode) return;
+  var inputWrapper = document.getElementById("input-wrapper");
+  if (!inputArea || !inputWrapper) return;
   if (!workerNoticeEl) {
     workerNoticeEl = document.createElement("div");
     workerNoticeEl.className = "pane-delegation-notice";
-    inputArea.parentNode.insertBefore(workerNoticeEl, inputArea);
+    inputArea.insertBefore(workerNoticeEl, inputWrapper);
   }
   var who = driverTitle ? "“" + driverTitle + "”" : "the Driver";
   workerNoticeEl.textContent = "Following an instruction from " + who + " — messages you send now join the same turn.";

--- a/test/split-view.test.js
+++ b/test/split-view.test.js
@@ -85,6 +85,21 @@ test("split role arrow stays anchored to the pane divider", function () {
   assert.match(paneCss, /#split-host\.split-delegating::after\s*\{[^}]*left:\s*calc\(50% - 17px\)/s);
 });
 
+test("split pane headers match the native session header background", function () {
+  var paneCss = fs.readFileSync(path.join(__dirname, "../lib/public/css/pane.css"), "utf8");
+
+  assert.match(paneCss, /\.split-pane-header\s*\{[^}]*background:\s*var\(--bg\)/s);
+});
+
+test("worker delegation notice joins the composer without a gap", function () {
+  var pairSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/split-pair-ui.js"), "utf8");
+  var paneCss = fs.readFileSync(path.join(__dirname, "../lib/public/css/pane.css"), "utf8");
+
+  assert.match(pairSource, /inputArea\.insertBefore\(workerNoticeEl, inputWrapper\)/);
+  assert.match(paneCss, /\.pane-delegation-notice\s*\{[^}]*width:\s*100%[^}]*max-width:\s*var\(--content-width\)[^}]*margin:\s*0 auto/s);
+  assert.match(paneCss, /\.pane-delegation-notice\.visible \+ #input-wrapper #input-row\s*\{[^}]*border-radius:\s*0 0 8px 8px/s);
+});
+
 test("split pane clients leave notification banners to the parent shell", function () {
   var notificationsSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-notifications.js"), "utf8");
   var initStart = notificationsSource.indexOf("export function initAppNotifications()");


### PR DESCRIPTION
## Summary

- match split pane header backgrounds to regular session headers
- place the worker delegation banner inside the composer area
- align the banner and composer widths and remove the gap between them
- flatten the touching corners so the banner and composer render as one connected surface

## Root cause

Split pane headers explicitly used the sidebar background instead of the native session background. The worker delegation banner was also inserted outside the input area with different horizontal margins, leaving a visible gap and mismatched edges around the rounded composer.

## Impact

Split sessions now use the same header background as unsplit sessions. Delegation notices align cleanly with the chat composer in both width and corner treatment.

## Validation

- `node --check lib/public/modules/split-pair-ui.js`
- `node --test test/split-view.test.js`
- `git diff --check`

All 12 focused split-view tests pass. The full suite passed 179 of 180 tests; the unrelated file-watcher timing test passed when rerun in isolation.
