### PR TITLE
feat(pair): add Fable worker delegation flow

### DIFF
--- a/docs/guides/MODULE_MAP.md
+++ b/docs/guides/MODULE_MAP.md
@@ -49,6 +49,7 @@ Wires all modules, sets up session manager and SDK bridge, dispatches messages.
 | `project-image.js` | `hydrateImageRefs`, `saveImageFile`, image directory setup |
 | `project-file-watch.js` | File and directory fs.watch wrappers |
 | `project-session-spawn.js` | Agent-driven sibling session creation, safety policy, and concurrency queue |
+| `project-worker-proposal.js` | Fable-triggered inline Worker suggestions, approval routing, and execution handoff |
 | `session-spawn-mcp-server.js` | SDK-free `clay-sessions` MCP tool definitions for spawning and checking sessions |
 | `project-session-document.js` + `session-document-mcp-server.js` | Session-bound `clay-documents` MCP signal that snapshots and presents explicit Markdown editing work |
 | `sdk-bridge.js` | SDK bridge coordinator: createSDKBridge factory, worker lifecycle, query stream, tool permissions, mention sessions |
@@ -141,6 +142,7 @@ Bootstraps UI, initializes store, wires remaining Tier 3 modules. All business l
 | `app-rendering.js` | Message rendering, streaming, scroll management, pre-thinking dots, suggestion chips, system messages |
 | `app-projects.js` | Project list, switching, add/remove project modals, update available pill, topbar presence |
 | `app-panels.js` | Config chip (model/mode/effort/thinking/beta), usage panel, status panel, context panel, context popover |
+| `worker-proposal.js` | Inline Worker recommendation card with model/reasoning selection and lifecycle states |
 | `app-loop-ui.js` | Ralph Loop UI: bars, banners, preview modal, execution modal |
 | `app-loop-wizard.js` | Ralph Loop wizard: step navigation, mode/authorship selection, data collection |
 | `app-notifications.js` | Notification center panel, badge, rendering, click-to-navigate |

--- a/lib/project-session-pair.js
+++ b/lib/project-session-pair.js
@@ -1,4 +1,5 @@
 var pairMcp = require("./session-pair-mcp-server");
+var { attachWorkerProposal } = require("./project-worker-proposal");
 var yoke = require("./yoke");
 
 var MAX_RESPONSE_CHARS = 30000;
@@ -57,6 +58,7 @@ function recentTurns(session, count) {
 function attachSessionPair(ctx) {
   var sm = ctx.sm;
   var store = ctx.splitStore;
+  var workerProposal;
 
   function groupAndPartner(caller) {
     if (!caller) throw new Error("partner tools require a session-bound tool server");
@@ -91,6 +93,63 @@ function attachSessionPair(ctx) {
     broadcastDelegation(group, caller, partner, false);
   }
 
+  function resumeDriverWithResult(caller, partner, token) {
+    if (!token.detached || token.delivered || caller.destroying) return false;
+    token.delivered = true;
+    var failure = token.failure || null;
+    var response = token.response || "";
+    var text = "A Worker task delegated through send_to_partner has finished.\n\n" +
+      "Original task:\n" + token.message + "\n\n" +
+      (failure ? "Worker error:\n" + failure : "Worker result:\n" + (response || "(No text response was recorded.)")) +
+      "\n\nReview the result, verify it as needed, and continue the task.";
+    sm.sendAndRecord(caller, {
+      type: "user_message",
+      text: text,
+      _internal: true,
+      partnerResult: true,
+      partnerSessionId: partner.localId,
+    });
+    caller.lastActivity = Date.now();
+    var sdk = ctx.getSdk();
+    if (!sdk) {
+      sm.sendAndRecord(caller, { type: "error", text: "Could not resume the Driver: SDK bridge is not ready" });
+      return false;
+    }
+    if (!caller.isProcessing) {
+      caller.isProcessing = true;
+      caller.sentToolResults = {};
+      ctx.onProcessingChanged();
+      sm.sendToSession(caller, { type: "status", status: "processing" });
+    }
+    if (!sdk.pushMessage(caller, text)) {
+      caller._queryStartTs = Date.now();
+      Promise.resolve(sdk.startQuery(caller, text, undefined, ctx.getLinuxUserForSession(caller))).catch(function (err) {
+        caller.isProcessing = false;
+        sm.sendAndRecord(caller, { type: "error", text: err.message || String(err) });
+        ctx.onProcessingChanged();
+      });
+    }
+    sm.broadcastSessionList();
+    return true;
+  }
+
+  function handleTurnDone(partner) {
+    var token = partner && partner._pairDelegation;
+    if (!token) return false;
+    var group = store.groupForMember(partner.localId);
+    if (!group || group.id !== token.groupId || group.members.indexOf(token.from) === -1) return false;
+    var caller = sm.sessions.get(token.from);
+    if (!caller || caller.ownerId !== partner.ownerId) return false;
+    if (group.pair && (group.pair.driverId !== caller.localId || group.pair.workerId !== partner.localId)) {
+      finishDelegation(group, caller, partner, token);
+      return false;
+    }
+    token.response = responseText(partner.history || [], token.startIndex);
+    token.failure = errorSince(partner.history || [], token.startIndex);
+    finishDelegation(group, caller, partner, token);
+    return resumeDriverWithResult(caller, partner, token);
+  }
+
   function waitForPartner(group, caller, partner, token, timeoutSeconds) {
     return new Promise(function (resolve, reject) {
       var deadline = Date.now() + timeoutSeconds * 1000;
@@ -115,8 +174,9 @@ function attachSessionPair(ctx) {
         }
         if (Date.now() >= deadline) {
           clearInterval(timer);
+          token.detached = true;
           monitorPartner(group, caller, partner, token);
-          resolve({ status: "running", response: responseText(partner.history || [], token.startIndex), hint: "Use read_partner to check again." });
+          resolve({ status: "running", response: responseText(partner.history || [], token.startIndex), hint: "The completed result will be pushed back automatically. Use read_partner only for an interim status check." });
         }
       }, 500);
     });
@@ -127,7 +187,8 @@ function attachSessionPair(ctx) {
       var currentGroup = store.groupForMember(caller.localId);
       if (!currentGroup || currentGroup.id !== group.id || (!partner.isProcessing && !partner._queryStarting)) {
         clearInterval(timer);
-        finishDelegation(group, caller, partner, token);
+        if (currentGroup && currentGroup.id === group.id) handleTurnDone(partner);
+        else finishDelegation(group, caller, partner, token);
       }
     }, 500);
   }
@@ -143,7 +204,7 @@ function attachSessionPair(ctx) {
       timeout = Math.max(1, Math.min(900, timeout));
       var partner = resolved.partner;
       if (partner._pairDelegation) throw new Error("the partner is already handling a delegated task");
-      var token = { from: caller.localId, groupId: resolved.group.id, startIndex: partner.history.length };
+      var token = { from: caller.localId, groupId: resolved.group.id, startIndex: partner.history.length, message: message };
       partner._pairDelegation = token;
       partner._delegatedBy = caller.localId;
       sm.sendAndRecord(partner, {
@@ -173,8 +234,9 @@ function attachSessionPair(ctx) {
       }
       sm.broadcastSessionList();
       if (!wait) {
+        token.detached = true;
         monitorPartner(resolved.group, caller, partner, token);
-        return toolResult({ status: "running", partnerId: partner.localId, hint: "Use read_partner to check progress." });
+        return toolResult({ status: "running", partnerId: partner.localId, hint: "The completed result will be pushed back automatically. Use read_partner only for an interim status check." });
       }
       return toolResult(await waitForPartner(resolved.group, caller, partner, token, timeout));
     } catch (e) {
@@ -223,10 +285,11 @@ function attachSessionPair(ctx) {
     // pair worker at query start never sees the tools.
     var group = store.groupForMember(boundSession.localId);
     if (group && group.pair && group.pair.driverId !== boundSession.localId) return [];
-    return pairMcp.getToolDefs({
+    var tools = pairMcp.getToolDefs({
       send: function (args) { return sendToPartner(args, boundSession); },
       read: function (args) { return readPartner(args, boundSession); },
     });
+    return tools.concat(workerProposal.getToolDefs(boundSession));
   }
 
   function validateVendor(vendor) {
@@ -235,49 +298,69 @@ function attachSessionPair(ctx) {
     return vendor;
   }
 
+  function createPairRecord(ws, msg) {
+    if (ctx.isMate) throw new Error("Pair sessions are only available in projects");
+    var driverSpec = msg.driver || {};
+    var workerSpec = msg.worker || {};
+    var workerVendor = validateVendor(workerSpec.vendor || sm.lastVendor || "codex");
+    var ownerId = ws._clayUser && ctx.usersModule.isMultiUser() ? ws._clayUser.id : null;
+    var driver;
+    var groupName;
+    if (Number.isInteger(driverSpec.sessionId)) {
+      // "Add Worker" on an existing session: the current session becomes
+      // the Driver with its full conversation context intact.
+      driver = sm.sessions.get(driverSpec.sessionId);
+      if (!driver) throw new Error("driver session not found");
+      if ((driver.ownerId || null) !== ownerId) throw new Error("driver session access denied");
+      if (store.groupForMember(driver.localId)) throw new Error("this session is already in a split group");
+      groupName = undefined; // auto name from member titles
+    } else {
+      var driverVendor = validateVendor(driverSpec.vendor || "claude");
+      var driverEffort = yoke.clampEffort(driverVendor, driverSpec.effort || (sm.currentEffortByVendor && sm.currentEffortByVendor[driverVendor]) || sm.currentEffort || "medium") || null;
+      driver = sm.createSessionRaw({ ownerId: ownerId, vendor: driverVendor, model: driverSpec.model || null, effort: driverEffort });
+      driver.title = "Driver · " + ((yoke.getVendorInfo(driverVendor) || {}).displayName || driverVendor);
+      if (driverSpec.effort) driver.loopSettings = { effort: driverSpec.effort };
+      groupName = "Agent pair";
+    }
+    var workerEffort = yoke.clampEffort(workerVendor, workerSpec.effort || (sm.currentEffortByVendor && sm.currentEffortByVendor[workerVendor]) || sm.currentEffort || "medium") || null;
+    var worker = sm.createSessionRaw({ ownerId: ownerId, vendor: workerVendor, model: workerSpec.model || null, effort: workerEffort });
+    worker.title = "Worker · " + ((yoke.getVendorInfo(workerVendor) || {}).displayName || workerVendor);
+    if (workerSpec.effort) worker.loopSettings = { effort: workerSpec.effort };
+    var result = store.create(ws, {
+      members: [driver.localId, worker.localId],
+      pair: { driverId: driver.localId, workerId: worker.localId },
+      name: groupName,
+    });
+    if (!result.ok) throw new Error(result.error);
+    sm.broadcastSessionList();
+    return { driver: driver, worker: worker, group: result.group };
+  }
+
   function createPair(ws, msg) {
     try {
-      if (ctx.isMate) throw new Error("Pair sessions are only available in projects");
-      var driverSpec = msg.driver || {};
-      var workerSpec = msg.worker || {};
-      var workerVendor = validateVendor(workerSpec.vendor || sm.lastVendor || "codex");
-      var ownerId = ws._clayUser && ctx.usersModule.isMultiUser() ? ws._clayUser.id : null;
-      var driver;
-      var groupName;
-      if (Number.isInteger(driverSpec.sessionId)) {
-        // "Add Worker" on an existing session: the current session becomes
-        // the Driver with its full conversation context intact.
-        driver = sm.sessions.get(driverSpec.sessionId);
-        if (!driver) throw new Error("driver session not found");
-        if ((driver.ownerId || null) !== ownerId) throw new Error("driver session access denied");
-        if (store.groupForMember(driver.localId)) throw new Error("this session is already in a split group");
-        groupName = undefined; // auto name from member titles
-      } else {
-        var driverVendor = validateVendor(driverSpec.vendor || "claude");
-        var driverEffort = yoke.clampEffort(driverVendor, driverSpec.effort || (sm.currentEffortByVendor && sm.currentEffortByVendor[driverVendor]) || sm.currentEffort || "medium") || null;
-        driver = sm.createSessionRaw({ ownerId: ownerId, vendor: driverVendor, model: driverSpec.model || null, effort: driverEffort });
-        driver.title = "Driver · " + ((yoke.getVendorInfo(driverVendor) || {}).displayName || driverVendor);
-        if (driverSpec.effort) driver.loopSettings = { effort: driverSpec.effort };
-        groupName = "Agent pair";
-      }
-      var workerEffort = yoke.clampEffort(workerVendor, workerSpec.effort || (sm.currentEffortByVendor && sm.currentEffortByVendor[workerVendor]) || sm.currentEffort || "medium") || null;
-      var worker = sm.createSessionRaw({ ownerId: ownerId, vendor: workerVendor, model: workerSpec.model || null, effort: workerEffort });
-      worker.title = "Worker · " + ((yoke.getVendorInfo(workerVendor) || {}).displayName || workerVendor);
-      if (workerSpec.effort) worker.loopSettings = { effort: workerSpec.effort };
-      var result = store.create(ws, {
-        members: [driver.localId, worker.localId],
-        pair: { driverId: driver.localId, workerId: worker.localId },
-        name: groupName,
-      });
-      if (!result.ok) throw new Error(result.error);
-      sm.broadcastSessionList();
-      ctx.sendTo(ws, { type: "pair_session_created", ok: true, group: result.group });
+      var created = createPairRecord(ws, msg);
+      ctx.sendTo(ws, { type: "pair_session_created", ok: true, group: created.group });
     } catch (e) {
       ctx.sendTo(ws, { type: "pair_session_created", ok: false, error: e.message || String(e) });
     }
   }
 
+  workerProposal = attachWorkerProposal({
+    sm: sm,
+    isMate: ctx.isMate,
+    splitStore: store,
+    getSdk: ctx.getSdk,
+    sendTo: ctx.sendTo,
+    usersModule: ctx.usersModule,
+    getLinuxUserForSession: ctx.getLinuxUserForSession,
+    onProcessingChanged: ctx.onProcessingChanged,
+    adapters: ctx.adapters,
+    createPairRecord: createPairRecord,
+    sendToPartner: sendToPartner,
+  });
+
   function handleMessage(ws, msg) {
+    if (workerProposal.handleMessage(ws, msg)) return true;
     if (msg.type === "pair_session_options") {
       if (ctx.isMate) return false;
       ctx.sendTo(ws, {
@@ -298,11 +381,14 @@ function attachSessionPair(ctx) {
 
   function getSystemPrompt(session) {
     var group = store.groupForMember(session.localId);
-    if (!group || !group.pair || group.pair.driverId !== session.localId) return "";
-    return "You are the Driver in a two-agent pair. The tools send_to_partner and read_partner are provided directly to you. Use send_to_partner to delegate concrete bounded work to the Worker, use read_partner to inspect its progress or recent results, then integrate and verify the final outcome. Do not search the project for implementations of these tools, and do not delegate work that must be performed sequentially in this same session.";
+    var pairPrompt = "";
+    if (group && group.pair && group.pair.driverId === session.localId) {
+      pairPrompt = "You are the Driver in a two-agent pair. The tools send_to_partner and read_partner are provided directly to you. Use send_to_partner to delegate concrete bounded work to the Worker. If a non-waiting delegation finishes later, Clay pushes the result back and resumes you automatically; use read_partner only when you need an interim status check. Integrate and verify the final outcome. Do not search the project for implementations of these tools, and do not delegate work that must be performed sequentially in this same session.";
+    }
+    return [pairPrompt, workerProposal.getSystemPrompt(session)].filter(Boolean).join("\n\n");
   }
 
-  return { getToolDefs: getToolDefs, handleMessage: handleMessage, getSystemPrompt: getSystemPrompt };
+  return { getToolDefs: getToolDefs, handleMessage: handleMessage, handleTurnDone: handleTurnDone, getSystemPrompt: getSystemPrompt };
 }
 
 module.exports = {

--- a/lib/project-worker-proposal.js
+++ b/lib/project-worker-proposal.js
@@ -1,0 +1,317 @@
+var crypto = require("crypto");
+var yoke = require("./yoke");
+var buildShape = require("./session-spawn-mcp-server").buildShape;
+
+var MAX_SUMMARY_CHARS = 600;
+var MAX_PLAN_CHARS = 6000;
+var MAX_TASK_CHARS = 30000;
+
+function modelValue(entry) {
+  if (typeof entry === "string") return entry;
+  return entry && (entry.value || entry.id) || "";
+}
+
+function modelLabel(entry) {
+  if (typeof entry === "string") return entry;
+  return entry && (entry.displayName || entry.name || entry.value || entry.id) || "";
+}
+
+function isFableSession(session, modelsByVendor, fallbackModel) {
+  if (!session || (session.vendor || "claude") !== "claude") return false;
+  var effectiveModel = session.model || fallbackModel || "";
+  var selected = String(effectiveModel).toLowerCase();
+  if (selected.indexOf("fable") !== -1) return true;
+  var models = (modelsByVendor && modelsByVendor.claude) || [];
+  for (var i = 0; i < models.length; i++) {
+    if (modelValue(models[i]) !== effectiveModel) continue;
+    if (modelLabel(models[i]).toLowerCase().indexOf("fable") !== -1) return true;
+  }
+  return false;
+}
+
+function toolResult(value) {
+  return Promise.resolve({ content: [{ type: "text", text: JSON.stringify(value) }] });
+}
+
+function attachWorkerProposal(ctx) {
+  var sm = ctx.sm;
+  var store = ctx.splitStore;
+
+  function isEligible(session) {
+    if (ctx.isMate || !session || session.mode === "tui") return false;
+    if (store.groupForMember(session.localId)) return false;
+    return isFableSession(session, sm.modelsByVendor, sm.currentModel);
+  }
+
+  function safeModelsByVendor(installed) {
+    var result = {};
+    for (var i = 0; i < installed.length; i++) {
+      var vendor = installed[i];
+      var source = (sm.modelsByVendor && sm.modelsByVendor[vendor]) || [];
+      result[vendor] = source.map(function (entry) {
+        if (typeof entry === "string") return entry;
+        return {
+          value: modelValue(entry),
+          displayName: modelLabel(entry),
+          supportedEffortLevels: entry.supportedEffortLevels || null,
+        };
+      });
+    }
+    return result;
+  }
+
+  function proposalOptions() {
+    var installed = (sm.installedVendors || []).slice();
+    var capabilities = {};
+    for (var i = 0; i < installed.length; i++) {
+      var source = (sm.capabilitiesByVendor && sm.capabilitiesByVendor[installed[i]]) || {};
+      var vendorInfo = yoke.getVendorInfo(installed[i]) || {};
+      var supportsEffort = Array.isArray(vendorInfo.effortLevels) && vendorInfo.effortLevels.length > 0;
+      capabilities[installed[i]] = { effort: source.effort === undefined ? supportsEffort : source.effort !== false };
+    }
+    return {
+      installedVendors: installed,
+      modelsByVendor: safeModelsByVendor(installed),
+      capabilitiesByVendor: capabilities,
+    };
+  }
+
+  async function ensureModelCatalogs() {
+    var installed = sm.installedVendors || [];
+    sm.modelsByVendor = sm.modelsByVendor || {};
+    for (var i = 0; i < installed.length; i++) {
+      var vendor = installed[i];
+      if (sm.modelsByVendor[vendor] && sm.modelsByVendor[vendor].length > 0) continue;
+      var adapter = ctx.adapters && ctx.adapters[vendor];
+      if (!adapter || typeof adapter.supportedModels !== "function") continue;
+      try { sm.modelsByVendor[vendor] = await adapter.supportedModels(); }
+      catch (err) { console.warn("[worker-proposal] Could not load " + vendor + " models:", err.message || err); }
+    }
+  }
+
+  function modelIsAvailable(options, vendor, model) {
+    if (!model) return true;
+    var models = options.modelsByVendor[vendor] || [];
+    for (var i = 0; i < models.length; i++) {
+      if (modelValue(models[i]) === model) return true;
+    }
+    return models.length === 0;
+  }
+
+  function chooseRecommendation(args, session, options) {
+    var installed = options.installedVendors;
+    var vendor = args.recommendedVendor;
+    if (installed.indexOf(vendor) === -1) {
+      if (installed.indexOf("codex") !== -1) vendor = "codex";
+      else {
+        vendor = installed[0] || session.vendor || "claude";
+        for (var i = 0; i < installed.length; i++) {
+          if (installed[i] !== session.vendor) { vendor = installed[i]; break; }
+        }
+      }
+    }
+    var models = options.modelsByVendor[vendor] || [];
+    var model = modelIsAvailable(options, vendor, args.recommendedModel) ? (args.recommendedModel || "") : "";
+    var currentModel = session.model || sm.currentModel || "";
+    if (vendor === session.vendor && model === currentModel) model = "";
+    if (!model && models.length > 0) {
+      for (var j = 0; j < models.length; j++) {
+        if (vendor === session.vendor && modelValue(models[j]) === currentModel) continue;
+        if (modelLabel(models[j]).toLowerCase().indexOf("fable") !== -1) continue;
+        model = modelValue(models[j]);
+        break;
+      }
+    }
+    if (!model && models.length > 0 && vendor !== session.vendor) model = modelValue(models[0]);
+    var effort = yoke.clampEffort(vendor, args.recommendedEffort || "medium") || "";
+    return { vendor: vendor, model: model, effort: effort };
+  }
+
+  function findProposal(session, proposalId) {
+    var history = (session && session.history) || [];
+    for (var i = history.length - 1; i >= 0; i--) {
+      if (history[i] && history[i].type === "worker_proposal" && history[i].proposalId === proposalId) return history[i];
+    }
+    return null;
+  }
+
+  function hasPendingProposal(session) {
+    var history = (session && session.history) || [];
+    for (var i = history.length - 1; i >= 0; i--) {
+      var item = history[i];
+      if (!item || item.type !== "worker_proposal") continue;
+      return item.status === "pending" || item.status === "starting" || item.status === "running";
+    }
+    return false;
+  }
+
+  function updateProposal(session, proposal, patch) {
+    Object.assign(proposal, patch, { updatedAt: Date.now() });
+    sm.saveSessionFile(session);
+    sm.sendToSession(session, Object.assign({
+      type: "worker_proposal_update",
+      proposalId: proposal.proposalId,
+    }, patch));
+  }
+
+  async function propose(args, session) {
+    if (!isEligible(session)) return toolResult({ error: "Worker suggestions are only available in an unpaired Fable session." });
+    if (hasPendingProposal(session)) return toolResult({ error: "A Worker suggestion is already awaiting a decision." });
+    var summary = typeof args.summary === "string" ? args.summary.trim() : "";
+    var plan = typeof args.plan === "string" ? args.plan.trim() : "";
+    var task = typeof args.message === "string" ? args.message.trim() : "";
+    if (!summary || !plan || !task) return toolResult({ error: "summary, plan, and message are required." });
+    if (task.length > MAX_TASK_CHARS) return toolResult({ error: "The Worker task is too long." });
+    await ensureModelCatalogs();
+    var options = proposalOptions();
+    if (options.installedVendors.length === 0) return toolResult({ error: "No coding agent is installed for a Worker session." });
+    var recommendation = chooseRecommendation(args, session, options);
+    var proposal = {
+      type: "worker_proposal",
+      proposalId: "worker_" + crypto.randomUUID(),
+      summary: summary.slice(0, MAX_SUMMARY_CHARS),
+      plan: plan.slice(0, MAX_PLAN_CHARS),
+      message: task,
+      status: "pending",
+      recommendedVendor: recommendation.vendor,
+      recommendedModel: recommendation.model,
+      recommendedEffort: recommendation.effort,
+      options: options,
+    };
+    sm.sendAndRecord(session, proposal);
+    return toolResult({
+      status: "posted",
+      proposalId: proposal.proposalId,
+      instruction: "The Worker suggestion is visible in the chat. End this turn now and wait for the user's decision.",
+    });
+  }
+
+  function resumeDriver(session, text) {
+    var sdk = ctx.getSdk();
+    if (!sdk) return Promise.reject(new Error("SDK bridge is not ready"));
+    var message = { type: "user_message", text: text, _internal: true };
+    sm.sendAndRecord(session, message);
+    session.sentToolResults = {};
+    if (!session.isProcessing) {
+      session.isProcessing = true;
+      ctx.onProcessingChanged();
+      sm.sendToSession(session, { type: "status", status: "processing" });
+    }
+    if (sdk.pushMessage(session, text)) return Promise.resolve();
+    return Promise.resolve(sdk.startQuery(session, text, undefined, ctx.getLinuxUserForSession(session)));
+  }
+
+  function parsePartnerResult(result) {
+    if (!result || result.isError || !result.content || !result.content[0]) {
+      return { status: "error", error: "Worker execution failed." };
+    }
+    try { return JSON.parse(result.content[0].text); }
+    catch (e) { return { status: "error", error: result.content[0].text || "Worker execution failed." }; }
+  }
+
+  async function runWorker(session, proposal) {
+    var result = parsePartnerResult(await ctx.sendToPartner({ message: proposal.message, wait: true, timeoutSeconds: 900 }, session));
+    var status = result.status === "complete" ? "completed" : result.status;
+    updateProposal(session, proposal, {
+      status: status || "error",
+      resultPreview: result.response ? result.response.slice(0, 1200) : "",
+      error: result.error || null,
+    });
+    var followup;
+    if (result.status === "complete") {
+      followup = "[Worker execution completed]\nReview the Worker's result, verify the implementation, and integrate any remaining changes.\n\n" + (result.response || "The Worker completed without a text summary.");
+    } else if (result.status === "running") {
+      followup = "[Worker execution is still running]\nUse read_partner to inspect progress before completing the task.";
+    } else {
+      followup = "[Worker execution failed]\nInspect the failure and decide whether to fix it here or delegate a narrower follow-up.\n\n" + (result.error || result.response || "Unknown Worker error.");
+    }
+    await resumeDriver(session, followup);
+  }
+
+  function sessionForResponse(ws) {
+    var session = sm.sessions.get(ws._clayActiveSession);
+    if (!session) throw new Error("active Driver session not found");
+    if (ctx.usersModule.isMultiUser()) {
+      var userId = ws._clayUser && ws._clayUser.id;
+      if (!userId || session.ownerId !== userId) throw new Error("Driver session access denied");
+    }
+    return session;
+  }
+
+  async function respondToProposal(ws, msg) {
+    var session = sessionForResponse(ws);
+    var proposal = findProposal(session, msg.proposalId);
+    if (!proposal) throw new Error("Worker suggestion not found");
+    if (proposal.status !== "pending") throw new Error("Worker suggestion has already been resolved");
+    if (!msg.accepted) {
+      updateProposal(session, proposal, { status: "declined" });
+      await resumeDriver(session, "[Worker suggestion declined]\nContinue this task in the current session using the plan you already prepared.");
+      return { ok: true, status: "declined" };
+    }
+    var options = proposal.options || proposalOptions();
+    var vendor = msg.vendor || proposal.recommendedVendor;
+    var model = msg.model || "";
+    if (options.installedVendors.indexOf(vendor) === -1) throw new Error("Selected Worker vendor is not installed");
+    if (!modelIsAvailable(options, vendor, model)) throw new Error("Selected Worker model is unavailable");
+    var effort = yoke.clampEffort(vendor, msg.effort || proposal.recommendedEffort || "medium") || "";
+    updateProposal(session, proposal, { status: "starting", selectedVendor: vendor, selectedModel: model, selectedEffort: effort });
+    try {
+      var created = ctx.createPairRecord(ws, {
+        driver: { sessionId: session.localId },
+        worker: { vendor: vendor, model: model, effort: effort },
+      });
+      updateProposal(session, proposal, { status: "running", groupId: created.group.id, workerId: created.worker.localId });
+      ctx.sendTo(ws, { type: "pair_session_created", ok: true, group: created.group });
+      runWorker(session, proposal).catch(function (err) {
+        updateProposal(session, proposal, { status: "error", error: err.message || String(err) });
+        resumeDriver(session, "[Worker execution failed]\n" + (err.message || String(err))).catch(function () {});
+      });
+      return { ok: true, status: "running", group: created.group };
+    } catch (err) {
+      updateProposal(session, proposal, { status: "pending", error: err.message || String(err) });
+      return { ok: false, status: "pending", error: err.message || String(err) };
+    }
+  }
+
+  function handleMessage(ws, msg) {
+    if (msg.type !== "worker_proposal_response") return false;
+    respondToProposal(ws, msg).catch(function (err) {
+      ctx.sendTo(ws, { type: "worker_proposal_update", proposalId: msg.proposalId, status: "pending", error: err.message || String(err) });
+    });
+    return true;
+  }
+
+  function getToolDefs(session) {
+    if (!isEligible(session)) return [];
+    return [{
+      name: "propose_worker",
+      description: "After making a concise plan for an implementation-heavy task, suggest that the user run the execution with another model in a visible Worker session. Use this only before substantial execution begins, never for small edits, explanations, or tasks the user asked you to keep in this session.",
+      inputSchema: buildShape({
+        summary: { type: "string", description: "One short sentence explaining why a Worker is useful for this task." },
+        plan: { type: "string", description: "A concise numbered implementation plan to show in the approval card." },
+        message: { type: "string", description: "Complete execution instructions for the Worker, including scope, constraints, validation, and expected result." },
+        recommendedVendor: { type: "string", description: "Optional installed vendor id for the Worker." },
+        recommendedModel: { type: "string", description: "Optional exact Worker model id. Omit when uncertain." },
+        recommendedEffort: { type: "string", description: "Optional reasoning effort: minimal, low, medium, high, xhigh, or max." },
+      }, ["summary", "plan", "message"]),
+      handler: function (args) { return propose(args || {}, session); },
+    }];
+  }
+
+  function getSystemPrompt(session) {
+    if (!isEligible(session)) return "";
+    return "You can introduce Clay's Driver/Worker workflow with propose_worker. For an implementation-heavy task that is likely to consume substantial execution time, first reason about the work and form a concise plan. Before editing files or running substantial execution, call propose_worker once with that plan and a complete Worker instruction, recommending another suitable execution model. Use it conservatively: do not suggest a Worker for questions, investigations, tiny fixes, or when the user explicitly wants you to execute here. After posting a proposal, end the turn and wait. If accepted, the Worker runs visibly and its result returns to you for review.";
+  }
+
+  return {
+    getToolDefs: getToolDefs,
+    getSystemPrompt: getSystemPrompt,
+    handleMessage: handleMessage,
+    respondToProposal: respondToProposal,
+  };
+}
+
+module.exports = {
+  attachWorkerProposal: attachWorkerProposal,
+  isFableSession: isFableSession,
+};

--- a/lib/project.js
+++ b/lib/project.js
@@ -541,6 +541,7 @@ function createProjectContext(opts) {
     usersModule: usersModule,
     getLinuxUserForSession: getLinuxUserForSession,
     onProcessingChanged: onProcessingChanged,
+    adapters: adapters,
   });
   var _sessionSpawn = attachSessionSpawn({
     cwd: cwd,
@@ -817,9 +818,10 @@ function createProjectContext(opts) {
     clayTls: serverTls,
     clayAuthToken: serverAuthToken,
     onProcessingChanged: onProcessingChanged,
-    onTurnDone: isMate ? function (session, preview) {
-      digestDmTurn(session, preview);
-    } : null,
+    onTurnDone: function (session, preview) {
+      if (isMate) digestDmTurn(session, preview);
+      else _sessionPair.handleTurnDone(session);
+    },
     scheduleMessage: function (session, text, resetsAt) {
       scheduleMessage(session, text, resetsAt);
     },

--- a/lib/public/css/worker-proposal.css
+++ b/lib/public/css/worker-proposal.css
@@ -1,0 +1,127 @@
+/* Inline approval surface for Fable's Driver/Worker recommendation. */
+
+.worker-proposal-card {
+  width: min(var(--content-width), calc(100% - 40px));
+  margin: 16px auto;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--accent2) 30%, var(--border));
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--accent2) 10%, transparent), transparent 42%),
+    var(--bg-alt);
+  box-shadow: 0 12px 32px rgba(var(--shadow-rgb), 0.12);
+}
+
+.worker-proposal-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.worker-proposal-mark {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--accent2) 14%, var(--bg));
+  color: var(--accent2);
+}
+
+.worker-proposal-mark .lucide { width: 17px; height: 17px; }
+.worker-proposal-heading { min-width: 0; display: grid; gap: 1px; }
+.worker-proposal-heading strong { color: var(--text); font-size: 14px; line-height: 1.25; }
+.worker-proposal-kicker { color: var(--accent2); font-size: 8px; font-weight: 800; letter-spacing: 0.14em; }
+
+.worker-proposal-status {
+  margin-left: auto;
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent2) 10%, transparent);
+  color: var(--accent2);
+  font-size: 9px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.worker-proposal-summary {
+  margin: 12px 0 10px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.worker-proposal-plan {
+  display: grid;
+  gap: 5px;
+  margin: 0 0 14px;
+  padding: 10px 12px 10px 32px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.worker-proposal-plan li::marker { color: var(--accent2); font-weight: 700; }
+
+.worker-proposal-config {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.8fr) minmax(160px, 1.2fr) minmax(190px, auto);
+  gap: 9px;
+  align-items: end;
+}
+
+.worker-proposal-field { min-width: 0; display: grid; gap: 5px; }
+.worker-proposal-field > span { color: var(--text-dimmer); font-size: 9px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.worker-proposal-vendor-control { position: relative; display: flex; align-items: center; }
+.worker-proposal-vendor-control img { position: absolute; left: 9px; width: 15px; height: 15px; border-radius: 4px; pointer-events: none; z-index: 1; }
+.worker-proposal-vendor-control .worker-proposal-select { padding-left: 30px; }
+
+.worker-proposal-select {
+  width: 100%;
+  height: 34px;
+  min-width: 0;
+  padding: 0 28px 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--input-bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 11px;
+  outline: none;
+}
+
+.worker-proposal-select:focus { border-color: var(--accent2); }
+.worker-proposal-effort-buttons { display: flex; height: 34px; padding: 3px; border: 1px solid var(--border); border-radius: 9px; background: var(--input-bg); }
+.worker-proposal-effort-btn { flex: 1; min-width: 38px; border: 0; border-radius: 6px; background: transparent; color: var(--text-dimmer); font: inherit; font-size: 9px; font-weight: 650; cursor: pointer; }
+.worker-proposal-effort-btn:hover { color: var(--text); }
+.worker-proposal-effort-btn.active { background: color-mix(in srgb, var(--accent2) 18%, var(--bg)); color: var(--accent2); }
+
+.worker-proposal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; }
+.worker-proposal-action { min-height: 34px; padding: 0 13px; border-radius: 9px; font: inherit; font-size: 11px; font-weight: 700; cursor: pointer; }
+.worker-proposal-action.secondary { border: 1px solid var(--border); background: transparent; color: var(--text-muted); }
+.worker-proposal-action.primary { display: inline-flex; align-items: center; gap: 6px; border: 1px solid color-mix(in srgb, var(--accent2) 55%, var(--border)); background: color-mix(in srgb, var(--accent2) 16%, var(--bg)); color: var(--accent2); }
+.worker-proposal-action.primary .lucide { width: 13px; height: 13px; }
+.worker-proposal-action:not(:disabled):hover { filter: brightness(1.12); }
+.worker-proposal-action:disabled, .worker-proposal-select:disabled, .worker-proposal-effort-btn:disabled { cursor: default; opacity: 0.58; }
+
+.worker-proposal-error, .worker-proposal-result { margin-top: 10px; padding: 8px 10px; border-radius: 8px; font-size: 10px; line-height: 1.45; }
+.worker-proposal-error { color: var(--error); background: var(--error-8); }
+.worker-proposal-result { max-height: 96px; overflow: hidden; color: var(--text-muted); background: color-mix(in srgb, var(--success) 7%, transparent); white-space: pre-wrap; }
+.worker-proposal-card[data-status="starting"] .worker-proposal-status,
+.worker-proposal-card[data-status="running"] .worker-proposal-status { animation: worker-proposal-pulse 1.6s ease-in-out infinite; }
+.worker-proposal-card[data-status="completed"] { border-color: color-mix(in srgb, var(--success) 35%, var(--border)); }
+.worker-proposal-card[data-status="completed"] .worker-proposal-status { color: var(--success); background: var(--success-8); }
+.worker-proposal-card[data-status="declined"] .worker-proposal-status { color: var(--text-muted); background: rgba(var(--overlay-rgb), 0.04); }
+
+@keyframes worker-proposal-pulse { 50% { opacity: 0.55; } }
+
+@media (max-width: 720px) {
+  .worker-proposal-card { width: calc(100% - 24px); padding: 14px; }
+  .worker-proposal-config { grid-template-columns: 1fr 1fr; }
+  .worker-proposal-effort { grid-column: 1 / -1; }
+  .worker-proposal-status { display: none; }
+}

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -21,6 +21,7 @@ import { handlePaletteSessionSwitch, setPaletteVersion } from './command-palette
 import { handleFindInSessionResults } from './session-search.js';
 import { syncPaneTitles, maybeRestoreSplitGroup, openGroup } from './split-view.js';
 import { showPairDialog, handlePairCreated, handleSplitDelegation, showWorkerDelegationNotice, hideWorkerDelegationNotice } from './split-pair-ui.js';
+import { renderWorkerProposal, updateWorkerProposal } from './worker-proposal.js';
 import { handleInputSync, autoResize, builtinCommands, setScheduleBtnDisabled } from './input.js';
 import { startThinking, appendThinking, stopThinking, resetThinkingGroup, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, closeToolGroup, removeToolFromGroup, resetToolState, getTools, getPlanContent, setPlanContent, renderPlanBanner, renderPlanCard, getTodoTools, handleTodoWrite, handleTaskCreate, handleTaskUpdate, applyDeadSessionTodoCompaction, isPlanFilePath, enableMainInput, addTurnMeta, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, initSubagentStop, updateSubagentProgress, updateSubagentTaskStatus, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionCancelled, markPermissionResolved, renderElicitationRequest, markElicitationResolved, renderUserDialogRequest, markUserDialogResolved, updateThinkingTokens } from './tools.js';
 import { showDoneNotification, playDoneSound, isNotifAlertEnabled, isNotifSoundEnabled } from './notifications.js';
@@ -587,6 +588,14 @@ export function processMessage(msg) {
         if (createdPairGroup) openGroup(createdPairGroup);
         break;
 
+      case "worker_proposal":
+        renderWorkerProposal(msg);
+        break;
+
+      case "worker_proposal_update":
+        updateWorkerProposal(msg);
+        break;
+
       case "split_delegation":
         handleSplitDelegation(msg);
         syncPaneTitles();
@@ -932,7 +941,7 @@ export function processMessage(msg) {
           }
           renderPlanBanner("exit");
           getTools()[msg.id] = { el: null, name: msg.name, input: null, done: true, hidden: true };
-        } else if (msg.name === "propose_debate" || (msg.name && msg.name.indexOf("propose_debate") !== -1)) {
+        } else if (msg.name === "propose_debate" || (msg.name && msg.name.indexOf("propose_debate") !== -1) || (msg.name && msg.name.indexOf("propose_worker") !== -1)) {
           getTools()[msg.id] = { el: null, name: msg.name, input: null, done: true, hidden: true };
         } else if (msg.name === "ask_user_questions") {
           getTools()[msg.id] = { el: null, name: msg.name, input: null, done: true, hidden: true };

--- a/lib/public/modules/worker-proposal.js
+++ b/lib/public/modules/worker-proposal.js
@@ -1,0 +1,239 @@
+import { getWs } from './ws-ref.js';
+import { addToMessages, scrollToBottom, VENDOR_AVATARS, VENDOR_NAMES } from './app-rendering.js';
+import { effortLevelsFor, effortDisplayName } from './app-panels.js';
+import { iconHtml, refreshIcons } from './icons.js';
+
+function optionValue(entry) {
+  if (typeof entry === "string") return entry;
+  return entry && (entry.value || entry.id) || "";
+}
+
+function optionLabel(entry) {
+  if (typeof entry === "string") return entry;
+  return entry && (entry.displayName || entry.name || entry.value || entry.id) || "";
+}
+
+function findCard(proposalId) {
+  var cards = document.querySelectorAll(".worker-proposal-card");
+  for (var i = 0; i < cards.length; i++) {
+    if (cards[i].dataset.proposalId === proposalId) return cards[i];
+  }
+  return null;
+}
+
+function planSteps(plan) {
+  return String(plan || "").split("\n").map(function (line) {
+    return line.trim().replace(/^\s*(?:\d+[.)]|[-*])\s*/, "");
+  }).filter(Boolean).slice(0, 8);
+}
+
+function buildVendorSelect(msg) {
+  var select = document.createElement("select");
+  select.className = "worker-proposal-select worker-proposal-vendor";
+  var installed = (msg.options && msg.options.installedVendors) || [];
+  for (var i = 0; i < installed.length; i++) {
+    var option = document.createElement("option");
+    option.value = installed[i];
+    option.textContent = VENDOR_NAMES[installed[i]] || installed[i];
+    select.appendChild(option);
+  }
+  if (installed.indexOf(msg.recommendedVendor) !== -1) select.value = msg.recommendedVendor;
+  return select;
+}
+
+function fillModels(select, vendor, msg, preferred) {
+  var models = (msg.options && msg.options.modelsByVendor && msg.options.modelsByVendor[vendor]) || [];
+  select.innerHTML = "";
+  var automatic = document.createElement("option");
+  automatic.value = "";
+  automatic.textContent = "Automatic";
+  select.appendChild(automatic);
+  for (var i = 0; i < models.length; i++) {
+    var option = document.createElement("option");
+    option.value = optionValue(models[i]);
+    option.textContent = optionLabel(models[i]);
+    select.appendChild(option);
+  }
+  select.value = preferred || "";
+  if (select.value !== (preferred || "")) select.value = "";
+}
+
+function fillEffort(card, vendor, model, msg, preferred) {
+  var wrap = card.querySelector(".worker-proposal-effort");
+  var buttons = card.querySelector(".worker-proposal-effort-buttons");
+  var capabilities = (msg.options && msg.options.capabilitiesByVendor && msg.options.capabilitiesByVendor[vendor]) || {};
+  if (capabilities.effort === false) {
+    wrap.classList.add("hidden");
+    buttons.innerHTML = "";
+    return;
+  }
+  wrap.classList.remove("hidden");
+  var models = (msg.options && msg.options.modelsByVendor && msg.options.modelsByVendor[vendor]) || [];
+  var levels = effortLevelsFor(vendor, models, model);
+  buttons.innerHTML = "";
+  var selected = levels.indexOf(preferred) !== -1 ? preferred : (levels.indexOf("medium") !== -1 ? "medium" : levels[0]);
+  for (var i = 0; i < levels.length; i++) {
+    var button = document.createElement("button");
+    button.type = "button";
+    button.className = "worker-proposal-effort-btn" + (levels[i] === selected ? " active" : "");
+    button.dataset.effort = levels[i];
+    button.textContent = effortDisplayName(levels[i]);
+    button.addEventListener("click", function () {
+      buttons.querySelectorAll("button").forEach(function (item) { item.classList.remove("active"); });
+      this.classList.add("active");
+    });
+    buttons.appendChild(button);
+  }
+}
+
+function setControlsDisabled(card, disabled) {
+  var controls = card.querySelectorAll("select, .worker-proposal-effort-btn, .worker-proposal-action");
+  for (var i = 0; i < controls.length; i++) controls[i].disabled = disabled;
+}
+
+function statusLabel(status) {
+  if (status === "starting") return "Starting Worker";
+  if (status === "running") return "Worker running";
+  if (status === "completed") return "Completed";
+  if (status === "declined") return "Continuing here";
+  if (status === "error") return "Needs attention";
+  return "Suggested by Fable";
+}
+
+function applyState(card, msg) {
+  var status = msg.status || "pending";
+  card.dataset.status = status;
+  var badge = card.querySelector(".worker-proposal-status");
+  if (badge) badge.textContent = statusLabel(status);
+  var error = card.querySelector(".worker-proposal-error");
+  if (error) {
+    error.textContent = msg.error || "";
+    error.classList.toggle("hidden", !msg.error);
+  }
+  var preview = card.querySelector(".worker-proposal-result");
+  if (preview && msg.resultPreview) {
+    preview.textContent = msg.resultPreview;
+    preview.classList.remove("hidden");
+  }
+  setControlsDisabled(card, status !== "pending");
+}
+
+function sendDecision(card, accepted) {
+  var ws = getWs();
+  if (!ws || ws.readyState !== 1 || card.dataset.status !== "pending") return;
+  var vendor = card.querySelector(".worker-proposal-vendor");
+  var model = card.querySelector(".worker-proposal-model");
+  var effort = card.querySelector(".worker-proposal-effort-btn.active");
+  applyState(card, { status: accepted ? "starting" : "declined" });
+  ws.send(JSON.stringify({
+    type: "worker_proposal_response",
+    proposalId: card.dataset.proposalId,
+    accepted: accepted,
+    vendor: vendor ? vendor.value : "",
+    model: model ? model.value : "",
+    effort: effort ? effort.dataset.effort : "",
+  }));
+}
+
+export function renderWorkerProposal(msg) {
+  var existing = findCard(msg.proposalId);
+  if (existing) {
+    applyState(existing, msg);
+    return;
+  }
+  var card = document.createElement("section");
+  card.className = "worker-proposal-card";
+  card.dataset.proposalId = msg.proposalId;
+  card.dataset.status = msg.status || "pending";
+
+  var header = document.createElement("div");
+  header.className = "worker-proposal-header";
+  header.innerHTML = '<div class="worker-proposal-mark">' + iconHtml("git-branch") + '</div><div class="worker-proposal-heading"><span class="worker-proposal-kicker">DRIVER / WORKER</span><strong>Let a Worker handle the execution</strong></div><span class="worker-proposal-status"></span>';
+  card.appendChild(header);
+
+  var summary = document.createElement("p");
+  summary.className = "worker-proposal-summary";
+  summary.textContent = msg.summary || "This task can be planned here and executed in a visible Worker session.";
+  card.appendChild(summary);
+
+  var steps = planSteps(msg.plan);
+  if (steps.length > 0) {
+    var plan = document.createElement("ol");
+    plan.className = "worker-proposal-plan";
+    for (var i = 0; i < steps.length; i++) {
+      var item = document.createElement("li");
+      item.textContent = steps[i];
+      plan.appendChild(item);
+    }
+    card.appendChild(plan);
+  }
+
+  var config = document.createElement("div");
+  config.className = "worker-proposal-config";
+  var vendorField = document.createElement("label");
+  vendorField.className = "worker-proposal-field worker-proposal-vendor-field";
+  vendorField.innerHTML = '<span>Worker</span><span class="worker-proposal-vendor-control"><img alt=""></span>';
+  var vendorSelect = buildVendorSelect(msg);
+  vendorField.querySelector(".worker-proposal-vendor-control").appendChild(vendorSelect);
+  config.appendChild(vendorField);
+  var modelField = document.createElement("label");
+  modelField.className = "worker-proposal-field";
+  modelField.innerHTML = "<span>Model</span>";
+  var modelSelect = document.createElement("select");
+  modelSelect.className = "worker-proposal-select worker-proposal-model";
+  modelField.appendChild(modelSelect);
+  config.appendChild(modelField);
+  var effortField = document.createElement("div");
+  effortField.className = "worker-proposal-field worker-proposal-effort";
+  effortField.innerHTML = '<span>Reasoning</span><div class="worker-proposal-effort-buttons"></div>';
+  config.appendChild(effortField);
+  card.appendChild(config);
+
+  function syncVendor(preferredModel, preferredEffort) {
+    var vendor = vendorSelect.value;
+    var avatar = vendorField.querySelector("img");
+    avatar.src = VENDOR_AVATARS[vendor] || VENDOR_AVATARS.claude;
+    fillModels(modelSelect, vendor, msg, preferredModel);
+    fillEffort(card, vendor, modelSelect.value, msg, preferredEffort);
+  }
+  vendorSelect.addEventListener("change", function () { syncVendor("", "medium"); });
+  modelSelect.addEventListener("change", function () {
+    var active = card.querySelector(".worker-proposal-effort-btn.active");
+    fillEffort(card, vendorSelect.value, modelSelect.value, msg, active ? active.dataset.effort : "medium");
+  });
+  syncVendor(msg.recommendedModel || "", msg.recommendedEffort || "medium");
+
+  var error = document.createElement("div");
+  error.className = "worker-proposal-error hidden";
+  card.appendChild(error);
+  var result = document.createElement("div");
+  result.className = "worker-proposal-result hidden";
+  card.appendChild(result);
+
+  var actions = document.createElement("div");
+  actions.className = "worker-proposal-actions";
+  var decline = document.createElement("button");
+  decline.type = "button";
+  decline.className = "worker-proposal-action secondary";
+  decline.textContent = "Continue here";
+  decline.addEventListener("click", function () { sendDecision(card, false); });
+  var accept = document.createElement("button");
+  accept.type = "button";
+  accept.className = "worker-proposal-action primary";
+  accept.innerHTML = iconHtml("panel-right-open") + "<span>Run with Worker</span>";
+  accept.addEventListener("click", function () { sendDecision(card, true); });
+  actions.appendChild(decline);
+  actions.appendChild(accept);
+  card.appendChild(actions);
+
+  addToMessages(card);
+  applyState(card, msg);
+  refreshIcons();
+  scrollToBottom();
+}
+
+export function updateWorkerProposal(msg) {
+  var card = findCard(msg.proposalId);
+  if (!card) return;
+  applyState(card, msg);
+}

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -2,6 +2,7 @@
 @import url("css/icon-strip.css");
 @import url("css/title-bar.css");
 @import url("css/pane.css");
+@import url("css/worker-proposal.css");
 @import url("css/sidebar.css");
 @import url("css/overlays.css");
 @import url("css/menus.css");

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -559,7 +559,7 @@ function createSDKBridge(opts) {
     // split partner, and a prompt on every delegation hop defeats the
     // driver/worker workflow. spawn_sessions is NOT here: it creates new
     // sessions and keeps its prompt.
-    var pairPartnerTools = { send_to_partner: true, read_partner: true };
+    var pairPartnerTools = { send_to_partner: true, read_partner: true, propose_worker: true };
     if (toolName.indexOf("mcp__clay-sessions__") === 0) {
       var sessionsToolName = toolName.substring(toolName.lastIndexOf("__") + 2);
       if (pairPartnerTools[sessionsToolName]) {

--- a/lib/session-pair-mcp-server.js
+++ b/lib/session-pair-mcp-server.js
@@ -6,7 +6,7 @@ function getToolDefs(handlers) {
   return [
     {
       name: "send_to_partner",
-      description: "Delegate one concrete task to the other session in this split. The partner works visibly in its own pane. A delegated turn cannot delegate back, so keep orchestration one hop deep.",
+      description: "Delegate one concrete task to the other session in this split. The partner works visibly in its own pane. Detached completions are pushed back automatically. A delegated turn cannot delegate back, so keep orchestration one hop deep.",
       inputSchema: buildShape({
         message: { type: "string", description: "The complete task or question for the partner." },
         wait: { type: "boolean", description: "Wait for the partner's turn to finish. Defaults to true." },
@@ -16,7 +16,7 @@ function getToolDefs(handlers) {
     },
     {
       name: "read_partner",
-      description: "Read the partner's current status and recent conversation turns. Use this after a non-waiting delegation or timeout.",
+      description: "Read the partner's current status and recent conversation turns. Use this for an interim check after a non-waiting delegation or timeout; completed results are pushed automatically.",
       inputSchema: buildShape({
         lastTurns: { type: "number", description: "Number of recent user-message-delimited turns, from 1 to 5. Defaults to 1." },
       }),

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -38,6 +38,7 @@ var schema = {
   "split_group_set_pair":     { direction: "c2s", handler: "lib/session-split-groups.js", description: "Assign Driver/Worker roles on a split group (driverId null clears them)" },
   "pair_session_options":     { direction: "c2s", handler: "lib/project-session-pair.js", description: "Request vendors/models for the pair-session dialog (response reuses the same type)" },
   "pair_session_create":      { direction: "c2s", handler: "lib/project-session-pair.js", description: "Create a Driver/Worker session pair as a split group" },
+  "worker_proposal_response": { direction: "c2s", handler: "lib/project-worker-proposal.js", description: "Accept or decline a Fable Worker suggestion with the selected runtime" },
 
   "session_list":             { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Full list of sessions for the sidebar" },
   "session_switched":         { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Confirmation that active session changed" },
@@ -53,6 +54,8 @@ var schema = {
   "split_groups":             { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Full persistent split-group list for the current user" },
   "split_group_result":       { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Result of a split-group mutation" },
   "pair_session_created":     { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Result of pair_session_create; carries the new group" },
+  "worker_proposal":          { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Inline Fable suggestion to delegate execution to a Worker" },
+  "worker_proposal_update":   { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Worker suggestion lifecycle update" },
   "split_delegation":         { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "A pair delegation started or ended (drives the split-view flow indicator)" },
 
   // -----------------------------------------------------------------------

--- a/test/session-pair.test.js
+++ b/test/session-pair.test.js
@@ -6,7 +6,8 @@ function parseToolResult(result) {
   return JSON.parse(result.content[0].text);
 }
 
-function fixture(configured) {
+function fixture(configured, options) {
+  options = options || {};
   var driver = { localId: 1, ownerId: null, title: "Planner", vendor: "claude", history: [], isProcessing: false };
   var worker = { localId: 2, ownerId: null, title: "Builder", vendor: "codex", history: [], isProcessing: false };
   var sessions = new Map([[1, driver], [2, worker]]);
@@ -14,6 +15,8 @@ function fixture(configured) {
   if (configured) group.pair = { driverId: 1, workerId: 2 };
   var events = [];
   var starts = [];
+  var driverPushes = [];
+  var attached;
   var sm = {
     sessions: sessions,
     installedVendors: ["claude", "codex"],
@@ -24,17 +27,26 @@ function fixture(configured) {
     broadcastSessionList: function () {},
   };
   var sdk = {
-    pushMessage: function () { return false; },
+    pushMessage: function (session, text) {
+      if (session === driver) {
+        driverPushes.push(text);
+        return options.driverPushAccepted !== false;
+      }
+      return false;
+    },
     startQuery: function (session, text) {
       starts.push({ session: session, text: text });
+      if (session !== worker) return Promise.resolve();
       setTimeout(function () {
-        session.history.push({ type: "delta", text: "Partner result" });
+        if (options.workerError) session.history.push({ type: "error", text: options.workerError });
+        else session.history.push({ type: "delta", text: "Partner result" });
         session.isProcessing = false;
-      }, 20);
+        if (options.autoTurnDone !== false) attached.handleTurnDone(session);
+      }, options.workerDelay || 20);
       return Promise.resolve();
     },
   };
-  var attached = pairModule.attachSessionPair({
+  attached = pairModule.attachSessionPair({
     sm: sm,
     splitStore: { groupForMember: function (id) { return group.members.indexOf(id) === -1 ? null : group; }, create: function () {} },
     getSdk: function () { return sdk; },
@@ -44,7 +56,7 @@ function fixture(configured) {
     getLinuxUserForSession: function () { return null; },
     onProcessingChanged: function () {},
   });
-  return { attached: attached, driver: driver, worker: worker, events: events, starts: starts };
+  return { attached: attached, driver: driver, worker: worker, group: group, events: events, starts: starts, driverPushes: driverPushes };
 }
 
 test("configured pairs expose partner tools only to the Driver", function () {
@@ -72,6 +84,66 @@ test("send_to_partner records attribution and returns the response", async funct
   assert.strictEqual(f.starts[0].text, "Inspect the tests");
   assert.deepStrictEqual(f.events.map(function (event) { return event.active; }), [true, false]);
   assert.strictEqual(f.worker._delegatedBy, undefined);
+  assert.deepStrictEqual(f.driverPushes, []);
+});
+
+test("a detached delegated turn pushes its result to the Driver once", async function () {
+  var f = fixture(true);
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  var result = parseToolResult(await tool.handler({ message: "Inspect the tests", wait: false }));
+  assert.strictEqual(result.status, "running");
+  await new Promise(function (resolve) { setTimeout(resolve, 50); });
+
+  assert.strictEqual(f.driverPushes.length, 1);
+  assert.match(f.driverPushes[0], /Worker result:\nPartner result/);
+  assert.strictEqual(f.driver.history.length, 1);
+  assert.strictEqual(f.driver.history[0]._internal, true);
+  assert.strictEqual(f.driver.history[0].partnerResult, true);
+  assert.deepStrictEqual(f.events.map(function (event) { return event.active; }), [true, false]);
+});
+
+test("a detached result starts a fresh Driver query when push is rejected", async function () {
+  var f = fixture(true, { driverPushAccepted: false });
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  await tool.handler({ message: "Inspect the tests", wait: false });
+  await new Promise(function (resolve) { setTimeout(resolve, 50); });
+
+  var driverStarts = f.starts.filter(function (start) { return start.session === f.driver; });
+  assert.strictEqual(driverStarts.length, 1);
+  assert.match(driverStarts[0].text, /Worker result:\nPartner result/);
+});
+
+test("the detached monitor delivers failures even when no normal turn-done event arrives", async function () {
+  var f = fixture(true, { autoTurnDone: false, workerError: "Worker crashed" });
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  await tool.handler({ message: "Inspect the tests", wait: false });
+  await new Promise(function (resolve) { setTimeout(resolve, 550); });
+
+  assert.strictEqual(f.driverPushes.length, 1);
+  assert.match(f.driverPushes[0], /Worker error:\nWorker crashed/);
+  assert.strictEqual(f.worker._pairDelegation, undefined);
+});
+
+test("a user-started Worker turn never pushes to the Driver", function () {
+  var f = fixture(true);
+  f.worker.history.push({ type: "user_message", text: "User request" });
+  f.worker.history.push({ type: "delta", text: "User-requested result" });
+
+  assert.strictEqual(f.attached.handleTurnDone(f.worker), false);
+  assert.deepStrictEqual(f.driverPushes, []);
+  assert.deepStrictEqual(f.driver.history, []);
+});
+
+test("a role change invalidates a detached Worker completion", async function () {
+  var f = fixture(true);
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  await tool.handler({ message: "Inspect the tests", wait: false });
+  f.group.pair = { driverId: 2, workerId: 1 };
+  await new Promise(function (resolve) { setTimeout(resolve, 50); });
+
+  assert.deepStrictEqual(f.driverPushes, []);
+  assert.deepStrictEqual(f.driver.history, []);
+  assert.strictEqual(f.worker._pairDelegation, undefined);
 });
 
 test("a delegated session cannot delegate back", async function () {

--- a/test/worker-proposal-ui.test.js
+++ b/test/worker-proposal-ui.test.js
@@ -1,0 +1,34 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+
+var root = path.join(__dirname, "..");
+
+test("Worker proposal card exposes runtime controls and sends one decision message", function () {
+  var source = fs.readFileSync(path.join(root, "lib/public/modules/worker-proposal.js"), "utf8");
+  assert.match(source, /worker-proposal-vendor/);
+  assert.match(source, /worker-proposal-model/);
+  assert.match(source, /worker-proposal-effort-btn/);
+  assert.match(source, /type: "worker_proposal_response"/);
+  assert.match(source, /Run with Worker/);
+});
+
+test("message routing renders and updates Worker proposal lifecycle events", function () {
+  var source = fs.readFileSync(path.join(root, "lib/public/modules/app-messages.js"), "utf8");
+  assert.match(source, /case "worker_proposal":\s*renderWorkerProposal\(msg\)/);
+  assert.match(source, /case "worker_proposal_update":\s*updateWorkerProposal\(msg\)/);
+  assert.match(source, /msg\.name\.indexOf\("propose_worker"\)/);
+});
+
+test("posting the approval card does not trigger a redundant tool permission prompt", function () {
+  var source = fs.readFileSync(path.join(root, "lib/sdk-bridge.js"), "utf8");
+  assert.match(source, /propose_worker: true/);
+});
+
+test("Worker proposal card keeps responsive controls inside split panes", function () {
+  var source = fs.readFileSync(path.join(root, "lib/public/css/worker-proposal.css"), "utf8");
+  assert.match(source, /width: min\(var\(--content-width\), calc\(100% - 40px\)\)/);
+  assert.match(source, /@media \(max-width: 720px\)/);
+  assert.match(source, /grid-template-columns: 1fr 1fr/);
+});

--- a/test/worker-proposal.test.js
+++ b/test/worker-proposal.test.js
@@ -1,0 +1,176 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var proposalModule = require("../lib/project-worker-proposal");
+
+function parseToolResult(result) {
+  return JSON.parse(result.content[0].text);
+}
+
+function nextTurn() {
+  return new Promise(function (resolve) { setImmediate(resolve); });
+}
+
+function fixture() {
+  var session = {
+    localId: 1,
+    ownerId: null,
+    title: "Planner",
+    vendor: "claude",
+    model: "claude-fable",
+    mode: "gui",
+    history: [],
+    sentToolResults: {},
+    isProcessing: false,
+  };
+  var sessions = new Map([[session.localId, session]]);
+  var updates = [];
+  var directEvents = [];
+  var starts = [];
+  var pairs = [];
+  var delegations = [];
+  var sm = {
+    sessions: sessions,
+    installedVendors: ["claude", "codex"],
+    currentModel: "claude-sonnet-4-6",
+    modelsByVendor: {
+      claude: [{ value: "claude-fable", displayName: "Claude Fable" }],
+      codex: [{ value: "gpt-5.6-sol", displayName: "GPT-5.6 Sol" }],
+    },
+    capabilitiesByVendor: { claude: { effort: true }, codex: { effort: true } },
+    sendAndRecord: function (target, message) { target.history.push(message); },
+    saveSessionFile: function () {},
+    sendToSession: function (target, message) { updates.push(message); },
+  };
+  var sdk = {
+    pushMessage: function () { return false; },
+    startQuery: function (target, text) {
+      starts.push({ session: target, text: text });
+      return Promise.resolve();
+    },
+  };
+  var attached = proposalModule.attachWorkerProposal({
+    sm: sm,
+    isMate: false,
+    splitStore: { groupForMember: function () { return null; } },
+    getSdk: function () { return sdk; },
+    sendTo: function (ws, message) { directEvents.push(message); },
+    usersModule: { isMultiUser: function () { return false; } },
+    getLinuxUserForSession: function () { return null; },
+    onProcessingChanged: function () {},
+    adapters: {},
+    createPairRecord: function (ws, message) {
+      pairs.push(message);
+      return {
+        worker: { localId: 2 },
+        group: { id: "sg_worker", members: [1, 2], pair: { driverId: 1, workerId: 2 } },
+      };
+    },
+    sendToPartner: function (args, target) {
+      delegations.push({ args: args, session: target });
+      return Promise.resolve({
+        content: [{ type: "text", text: JSON.stringify({ status: "complete", response: "Implemented and tested." }) }],
+      });
+    },
+  });
+  return {
+    attached: attached,
+    session: session,
+    updates: updates,
+    directEvents: directEvents,
+    starts: starts,
+    pairs: pairs,
+    delegations: delegations,
+    sm: sm,
+    ws: { _clayActiveSession: session.localId },
+  };
+}
+
+async function postProposal(f) {
+  var tool = f.attached.getToolDefs(f.session)[0];
+  var result = parseToolResult(await tool.handler({
+    summary: "The implementation is large enough to benefit from a dedicated Worker.",
+    plan: "1. Inspect the current flow\n2. Implement the change\n3. Run focused tests",
+    message: "Implement the approved change and run focused tests.",
+    recommendedVendor: "codex",
+    recommendedModel: "gpt-5.6-sol",
+    recommendedEffort: "high",
+  }));
+  assert.strictEqual(result.status, "posted");
+  return f.session.history.filter(function (item) { return item.type === "worker_proposal"; })[0];
+}
+
+test("Fable detection respects the session model before the global fallback", function () {
+  var models = { claude: [
+    { value: "opaque-fable-id", displayName: "Claude Fable" },
+    { value: "claude-sonnet", displayName: "Claude Sonnet" },
+  ] };
+  assert.strictEqual(proposalModule.isFableSession({ vendor: "claude", model: "opaque-fable-id" }, models), true);
+  assert.strictEqual(proposalModule.isFableSession({ vendor: "claude", model: "claude-sonnet" }, models, "opaque-fable-id"), false);
+  assert.strictEqual(proposalModule.isFableSession({ vendor: "claude" }, models, "opaque-fable-id"), true);
+  assert.strictEqual(proposalModule.isFableSession({ vendor: "codex", model: "claude-fable" }, models), false);
+});
+
+test("only an unpaired Fable session receives the Worker proposal tool and prompt", function () {
+  var f = fixture();
+  assert.deepStrictEqual(f.attached.getToolDefs(f.session).map(function (tool) { return tool.name; }), ["propose_worker"]);
+  assert.match(f.attached.getSystemPrompt(f.session), /implementation-heavy/);
+  f.session.model = "claude-sonnet-4-6";
+  assert.deepStrictEqual(f.attached.getToolDefs(f.session), []);
+  assert.strictEqual(f.attached.getSystemPrompt(f.session), "");
+});
+
+test("declining a Worker suggestion resumes execution in Fable", async function () {
+  var f = fixture();
+  var proposal = await postProposal(f);
+  assert.strictEqual(proposal.status, "pending");
+  assert.strictEqual(proposal.recommendedVendor, "codex");
+  assert.strictEqual(proposal.recommendedModel, "gpt-5.6-sol");
+
+  var response = await f.attached.respondToProposal(f.ws, {
+    proposalId: proposal.proposalId,
+    accepted: false,
+  });
+  assert.deepStrictEqual(response, { ok: true, status: "declined" });
+  assert.strictEqual(proposal.status, "declined");
+  assert.match(f.starts[0].text, /Continue this task in the current session/);
+  assert.strictEqual(f.session.history[f.session.history.length - 1]._internal, true);
+});
+
+test("a same-vendor fallback recommends a non-Fable execution model", async function () {
+  var f = fixture();
+  f.sm.installedVendors = ["claude"];
+  f.sm.modelsByVendor.claude = [
+    { value: "claude-fable", displayName: "Claude Fable" },
+    { value: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6" },
+  ];
+  var proposal = await postProposal(f);
+  assert.strictEqual(proposal.recommendedVendor, "claude");
+  assert.strictEqual(proposal.recommendedModel, "claude-sonnet-4-6");
+});
+
+test("accepting a Worker suggestion creates the split, delegates, and returns the result", async function () {
+  var f = fixture();
+  var proposal = await postProposal(f);
+  var response = await f.attached.respondToProposal(f.ws, {
+    proposalId: proposal.proposalId,
+    accepted: true,
+    vendor: "codex",
+    model: "gpt-5.6-sol",
+    effort: "high",
+  });
+  assert.strictEqual(response.status, "running");
+  assert.deepStrictEqual(f.pairs[0], {
+    driver: { sessionId: 1 },
+    worker: { vendor: "codex", model: "gpt-5.6-sol", effort: "high" },
+  });
+  assert.strictEqual(f.directEvents[0].type, "pair_session_created");
+  assert.strictEqual(f.delegations[0].args.message, "Implement the approved change and run focused tests.");
+
+  await nextTurn();
+  assert.strictEqual(proposal.status, "completed");
+  assert.strictEqual(proposal.resultPreview, "Implemented and tested.");
+  assert.match(f.starts[0].text, /Worker execution completed/);
+  assert.match(f.starts[0].text, /Implemented and tested/);
+  assert.ok(f.updates.some(function (message) { return message.status === "running"; }));
+  assert.ok(f.updates.some(function (message) { return message.status === "completed"; }));
+});


### PR DESCRIPTION
## Summary

- let Claude Fable propose Clay's Driver/Worker workflow before substantial implementation work begins
- render an inline approval card with Worker vendor, model, and reasoning controls
- create the split and begin delegation immediately after approval, or continue in Fable when declined
- return explicitly delegated detached Worker completions to the originating Driver exactly once
- ignore user-started Worker turns and invalidate delivery when pair roles change

## Why

Heavy Fable tasks can consume significant planning and execution context in one session. This flow keeps Fable as the Driver while making the execution model visible and selectable before work starts.

Detached Worker completions were also unreliable because normal project sessions did not wire the SDK turn-complete callback into the pair coordinator. The fallback monitor cleared delegation state without resuming the Driver. This change wires completion delivery and retains a monitor fallback for failed or missing turn-complete events.

## Validation

- `node --test test/session-pair.test.js test/worker-proposal.test.js test/worker-proposal-ui.test.js` — 19/19 passed
- responsive card checked at 390px and 620px widths with no horizontal overflow
- `npm test` — 194/195 passed; the existing parallel file-watcher test timed out, while its standalone run passed 2/2
- JavaScript syntax checks and `git diff --check` passed
