### PR TITLE
fix(yoke): resolve default vendor by shared preference order

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -172,7 +172,9 @@ function createProjectContext(opts) {
   // --- YOKE adapters (multi-vendor, lazy init) ---
   var _yokeState = yoke.createAdapters({ cwd: cwd, slug: slug, osUsers: osUsers });
   var adapters = _yokeState.adapters;
-  var defaultVendor = adapters.claude ? "claude" : Object.keys(adapters)[0] || "claude";
+  // A new project has no remembered vendor. Select the first installed
+  // provider by the shared Claude -> Codex -> Kiro preference order.
+  var defaultVendor = yoke.resolveDefaultVendor(adapters);
   var adapter = adapters[defaultVendor] || null;
 
   // Browser MCP server runs in-process via createSdkMcpServer (no child process spawn).

--- a/lib/yoke/index.js
+++ b/lib/yoke/index.js
@@ -8,6 +8,23 @@ var createClaudeAdapter = require("./adapters/claude").createClaudeAdapter;
 var createCodexAdapter = require("./adapters/codex").createCodexAdapter;
 var createKiroAdapter = require("./adapters/kiro").createKiroAdapter;
 
+// Keep the first session in a new project predictable. This order is also
+// used by the UI when a project has no remembered vendor yet.
+var DEFAULT_VENDOR_ORDER = ["claude", "codex", "kiro"];
+
+function resolveDefaultVendor(availableVendors) {
+  availableVendors = availableVendors || {};
+  for (var i = 0; i < DEFAULT_VENDOR_ORDER.length; i++) {
+    var vendor = DEFAULT_VENDOR_ORDER[i];
+    if (Array.isArray(availableVendors)) {
+      if (availableVendors.indexOf(vendor) !== -1) return vendor;
+    } else if (availableVendors[vendor]) {
+      return vendor;
+    }
+  }
+  return "claude";
+}
+
 /**
  * Wrap adapter.createQuery to inject cross-vendor project instructions.
  *
@@ -371,6 +388,8 @@ async function lazyCreateAdapter(adapters, vendor, opts) {
 module.exports = {
   createAdapter: createAdapter,
   createAdapters: createAdapters,
+  resolveDefaultVendor: resolveDefaultVendor,
+  DEFAULT_VENDOR_ORDER: DEFAULT_VENDOR_ORDER,
   lazyCreateAdapter: lazyCreateAdapter,
   checkAuth: checkAuth,
   checkInstalled: checkInstalled,

--- a/test/yoke-vendor-registry.test.js
+++ b/test/yoke-vendor-registry.test.js
@@ -46,6 +46,13 @@ test("YOKE registry returns null for an unknown vendor", function() {
   assert.strictEqual(yoke.getVendorInfo("nope"), null);
 });
 
+test("default vendor prefers Claude, then Codex, then Kiro", function() {
+  assert.strictEqual(yoke.resolveDefaultVendor({ kiro: {} }), "kiro");
+  assert.strictEqual(yoke.resolveDefaultVendor({ kiro: {}, codex: {} }), "codex");
+  assert.strictEqual(yoke.resolveDefaultVendor({ kiro: {}, codex: {}, claude: {} }), "claude");
+  assert.strictEqual(yoke.resolveDefaultVendor([]), "claude");
+});
+
 test("every YOKE vendor supports GUI sessions", function() {
   for (var i = 0; i < SUPPORTED_VENDORS.length; i++) {
     assert.notStrictEqual(yoke.getVendorInfo(SUPPORTED_VENDORS[i]).sessionModes.indexOf("gui"), -1);


### PR DESCRIPTION
## What

A new project with no remembered vendor previously fell back to `Object.keys(adapters)[0]` when Claude was not installed, which depends on adapter registration order rather than an intentional preference.

This adds a shared `DEFAULT_VENDOR_ORDER` (`claude` -> `codex` -> `kiro`) and `resolveDefaultVendor()` in `lib/yoke/index.js`, and uses it in `createProjectContext`.

`resolveDefaultVendor()` accepts either an adapters object or an array of vendor names, and falls back to `"claude"` when nothing matches.

## Why

Makes the first session in a new project predictable, and gives the UI a single source of truth for the same ordering.

## Test

`test/yoke-vendor-registry.test.js` covers the ordering, the array form, and the fallback. Full suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)