### PR TITLE
fix(sessions): prevent stalled message delivery

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -863,7 +863,8 @@ function createSDKBridge(opts) {
       // Stream ended normally after a task stop — no "result" message was sent,
       // so the session is still marked as processing. Send interrupted feedback.
       console.log("[sdk-bridge] processQueryStream ended: isProcessing=" + session.isProcessing + " taskStopRequested=" + session.taskStopRequested);
-      if (session.isProcessing && session.taskStopRequested) {
+      var stillOwnsRuntime = session.queryInstance === myQueryInstance;
+      if (session.isProcessing && session.taskStopRequested && stillOwnsRuntime) {
         session.isProcessing = false;
         onProcessingChanged();
         send({ type: "status", processing: false });
@@ -874,9 +875,24 @@ function createSDKBridge(opts) {
         sendAndRecord(session, { type: "info", text: interruptMsg });
         sendAndRecord(session, { type: "done", code: 0 });
         sm.broadcastSessionList();
+      } else if (session.isProcessing && stillOwnsRuntime) {
+        // Codex and Kiro can report a protocol error and then close their
+        // iterator without a result event. Treat any result-less stream end as
+        // a failed turn so the UI cannot remain on processing forever.
+        session.isProcessing = false;
+        onProcessingChanged();
+        if (!session._lastAdapterError) {
+          sendAndRecord(session, {
+            type: "error",
+            text: "The agent connection ended before completing the response.",
+          });
+        }
+        session._lastAdapterError = null;
+        sendAndRecord(session, { type: "done", code: 1 });
+        sm.broadcastSessionList();
       }
     } catch (err) {
-      if (session.isProcessing) {
+      if (session.isProcessing && session.queryInstance === myQueryInstance) {
         session.isProcessing = false;
         onProcessingChanged();
         if (err.name === "AbortError" || (myAbortController && myAbortController.signal.aborted) || session.taskStopRequested) {
@@ -1310,6 +1326,7 @@ function createSDKBridge(opts) {
     session.pendingElicitations = {};
     session.streamedText = false;
     session.responsePreview = "";
+    session._lastAdapterError = null;
 
     // For in-process path, create AbortController. For worker path, the adapter
     // handles abort internally and exposes it via handle.abort().
@@ -1574,7 +1591,20 @@ function createSDKBridge(opts) {
 
     // Push initial user message through the QueryHandle
     console.log("[sdk-bridge] pushing initial message via handle.pushMessage...");
-    handle.pushMessage(text, images);
+    var initialMessageAccepted = handle.pushMessage(text, images) !== false;
+    if (!initialMessageAccepted) {
+      console.error("[sdk-bridge] Query rejected initial message for session " + session.localId);
+      try { handle.close(); } catch (e) {}
+      if (session.queryInstance === handle) session.queryInstance = null;
+      session.messageQueue = null;
+      session.abortController = null;
+      session.isProcessing = false;
+      onProcessingChanged();
+      sendAndRecord(session, { type: "error", text: "The agent connection closed before it received your message. Please send it again." });
+      sendAndRecord(session, { type: "done", code: 1 });
+      sm.broadcastSessionList();
+      return;
+    }
     console.log("[sdk-bridge] pushMessage done, starting processQueryStream...");
 
     // Flush messages that arrived while createQuery was still awaiting

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -459,6 +459,7 @@ function attachMessageProcessor(ctx) {
       }
 
       session.isProcessing = false;
+      session._lastAdapterError = null;
       onProcessingChanged();
       // Detect "Not logged in" scenario early for the check below
       var previewTrimmed = (session.responsePreview || "").trim();
@@ -769,6 +770,14 @@ function attachMessageProcessor(ctx) {
       session.isProcessing = false;
       onProcessingChanged();
       emitAuthRequired(session);
+
+    } else if (parsed.yokeType === "error") {
+      // Adapters use a neutral error event for turn failures that arrive as
+      // protocol messages instead of thrown iterator errors. Remember it so
+      // processQueryStream can finish the turn when the iterator closes.
+      var adapterErrorText = parsed.text || parsed.message || parsed.error || "Agent runtime error";
+      session._lastAdapterError = adapterErrorText;
+      sendAndRecord(session, { type: "error", text: adapterErrorText });
 
     } else if (parsed.yokeType === "model_refusal") {
       // Model declined the request. "fallback" => the CLI retried on another

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -701,12 +701,7 @@ function spawnWorker(linuxUser, workerScriptPath, cwd) {
   });
 
   worker.send = function(msg) {
-    if (!worker.connection || worker.connection.destroyed) return;
-    try {
-      worker.connection.write(JSON.stringify(serializeWorkerValue(msg)) + "\n");
-    } catch (e) {
-      console.error("[yoke/claude] Failed to send to worker:", e.message);
-    }
+    return sendWorkerMessage(worker, msg);
   };
 
   worker.onMessage = function(handler) {
@@ -730,6 +725,36 @@ function spawnWorker(linuxUser, workerScriptPath, cwd) {
   };
 
   return worker;
+}
+
+function hasWritableWorkerConnection(worker) {
+  var connection = worker && worker.connection;
+  return !!connection
+    && !connection.destroyed
+    && !connection.writableEnded
+    && connection.writable !== false;
+}
+
+function sendWorkerMessage(worker, msg) {
+  if (!hasWritableWorkerConnection(worker)) return false;
+  try {
+    // A false return from socket.write means backpressure, not rejection. The
+    // bytes are still queued, so delivery is accepted unless write throws.
+    worker.connection.write(JSON.stringify(serializeWorkerValue(msg)) + "\n");
+    return true;
+  } catch (e) {
+    console.error("[yoke/claude] Failed to send to worker:", e.message);
+    return false;
+  }
+}
+
+function canReuseWorker(worker) {
+  return !!worker
+    && worker.ready
+    && worker.process
+    && !worker.process.killed
+    && worker.process.exitCode == null
+    && hasWritableWorkerConnection(worker);
 }
 
 function cleanupWorker(worker) {
@@ -1009,12 +1034,7 @@ function createWorkerQueryHandle(worker, canUseTool, onElicitation, callMcpTool,
       }
       if (text) content.push({ type: "text", text: text });
       var userMsg = { type: "user", message: { role: "user", content: content } };
-      try {
-        worker.send({ type: "push_message", content: userMsg });
-        return true;
-      } catch (e) {
-        return false;
-      }
+      return worker.send({ type: "push_message", content: userMsg }) === true;
     },
 
     setModel: function(model) {
@@ -1498,7 +1518,8 @@ function createClaudeAdapter(opts) {
     var reusingWorker = false;
 
     // Wait for previous worker exit if needed
-    if (workerState && workerState.exitPromise && !workerState.worker) {
+    if (workerState && workerState.exitPromise
+        && (!workerState.worker || !canReuseWorker(workerState.worker))) {
       await Promise.race([
         workerState.exitPromise,
         new Promise(function(resolve) { setTimeout(resolve, 3000); }),
@@ -1506,8 +1527,7 @@ function createClaudeAdapter(opts) {
     }
 
     // Reuse existing worker if alive
-    if (workerState && workerState.worker && workerState.worker.ready &&
-        workerState.worker.process && !workerState.worker.process.killed) {
+    if (workerState && canReuseWorker(workerState.worker)) {
       worker = workerState.worker;
       reusingWorker = true;
       // Clear old message handlers so they don't fire for the new query
@@ -1564,7 +1584,7 @@ function createClaudeAdapter(opts) {
     // will push the initial message and the worker receives it via push_message.
     // Instead, we send query_start with no prompt; the worker starts a query with
     // the message queue, and the first push_message will arrive.
-    worker.send({
+    if (!worker.send({
       type: "query_start",
       prompt: null,
       options: queryOptions,
@@ -1572,7 +1592,9 @@ function createClaudeAdapter(opts) {
       originalHome: claudeOpts.originalHome || null,
       projectPath: claudeOpts.projectPath || null,
       _perfT0: claudeOpts._perfT0 || Date.now(),
-    });
+    })) {
+      throw new Error("Claude worker IPC connection closed before query start");
+    }
 
     return handle;
   }
@@ -1808,6 +1830,10 @@ module.exports = {
   contractTestKit: {
     createMessageQueue: createMessageQueue,
     createQueryHandle: createQueryHandle,
+    createWorkerQueryHandle: createWorkerQueryHandle,
+    hasWritableWorkerConnection: hasWritableWorkerConnection,
+    sendWorkerMessage: sendWorkerMessage,
+    canReuseWorker: canReuseWorker,
     normalizeEvent: flattenEvent,
   },
 };

--- a/test/sdk-bridge-delivery.test.js
+++ b/test/sdk-bridge-delivery.test.js
@@ -3,13 +3,33 @@ var assert = require("node:assert");
 
 var createSDKBridge = require("../lib/sdk-bridge").createSDKBridge;
 
-function createBridge() {
+function createBridge(sessionManager) {
   return createSDKBridge({
     cwd: process.cwd(),
-    sessionManager: {},
-    adapter: {},
+    sessionManager: sessionManager || {},
+    adapter: { vendor: "codex" },
     send: function () {},
   });
+}
+
+function createEndingHandle(events, beforeDone) {
+  var index = 0;
+  return {
+    pushMessage: function() { return true; },
+    close: function() {},
+    [Symbol.asyncIterator]: function() {
+      return {
+        next: function() {
+          if (index < events.length) {
+            var event = events[index++];
+            return Promise.resolve({ value: event, done: false });
+          }
+          if (beforeDone) beforeDone();
+          return Promise.resolve({ value: undefined, done: true });
+        },
+      };
+    },
+  };
 }
 
 test("pushMessage retires a query handle that rejects delivery", function() {
@@ -70,4 +90,61 @@ test("rejected delivery does not clear resources from a replacement query", func
   assert.strictEqual(session.queryInstance, replacementQuery);
   assert.strictEqual(session.abortController, replacementAbortController);
   assert.strictEqual(session.messageQueue, replacementMessageQueue);
+});
+
+test("adapter errors finish a result-less stream instead of leaving it processing", async function() {
+  var recorded = [];
+  var broadcasts = 0;
+  var bridge = createBridge({
+    sendAndRecord: function(session, msg) { recorded.push(msg); },
+    sendToSession: function() {},
+    broadcastSessionList: function() { broadcasts++; },
+  });
+  var handle = createEndingHandle([{ yokeType: "error", text: "turn failed" }]);
+  var session = {
+    localId: 10,
+    vendor: "codex",
+    queryInstance: handle,
+    isProcessing: true,
+    pendingAskUser: {},
+    pendingPermissions: {},
+    pendingElicitations: {},
+  };
+
+  await bridge.processQueryStream(session);
+
+  assert.strictEqual(session.isProcessing, false);
+  assert.strictEqual(recorded.filter(function(msg) { return msg.type === "error"; }).length, 1);
+  assert.strictEqual(recorded[recorded.length - 1].type, "done");
+  assert.strictEqual(recorded[recorded.length - 1].code, 1);
+  assert.strictEqual(broadcasts, 1);
+});
+
+test("an old stream ending cannot stop its replacement query", async function() {
+  var recorded = [];
+  var replacement = { pushMessage: function() { return true; } };
+  var session;
+  var handle = createEndingHandle([], function() {
+    session.queryInstance = replacement;
+  });
+  var bridge = createBridge({
+    sendAndRecord: function(activeSession, msg) { recorded.push(msg); },
+    sendToSession: function() {},
+    broadcastSessionList: function() {},
+  });
+  session = {
+    localId: 11,
+    vendor: "codex",
+    queryInstance: handle,
+    isProcessing: true,
+    pendingAskUser: {},
+    pendingPermissions: {},
+    pendingElicitations: {},
+  };
+
+  await bridge.processQueryStream(session);
+
+  assert.strictEqual(session.isProcessing, true);
+  assert.strictEqual(session.queryInstance, replacement);
+  assert.strictEqual(recorded.length, 0);
 });

--- a/test/yoke-adapter-contract.test.js
+++ b/test/yoke-adapter-contract.test.js
@@ -74,3 +74,57 @@ test("Claude query handles reject messages after their input queue closes", func
   assert.strictEqual(handle.pushMessage("must not be dropped silently"), false);
   assert.strictEqual(queue.push({ type: "user" }), false);
 });
+
+test("Claude worker transport reports closed and failed IPC writes", function() {
+  var claudeModule = require("../lib/yoke/adapters/claude");
+  var kit = claudeModule.contractTestKit;
+  var writes = [];
+  var worker = {
+    connection: {
+      destroyed: false,
+      writableEnded: false,
+      writable: true,
+      write: function(data) { writes.push(data); return false; },
+    },
+  };
+
+  assert.strictEqual(kit.sendWorkerMessage(worker, { type: "probe" }), true);
+  assert.strictEqual(writes.length, 1);
+
+  worker.connection.destroyed = true;
+  assert.strictEqual(kit.sendWorkerMessage(worker, { type: "closed" }), false);
+
+  worker.connection.destroyed = false;
+  worker.connection.write = function() { throw new Error("closed during write"); };
+  assert.strictEqual(kit.sendWorkerMessage(worker, { type: "failed" }), false);
+});
+
+test("Claude worker handles reject a message when IPC delivery fails", function() {
+  var claudeModule = require("../lib/yoke/adapters/claude");
+  var kit = claudeModule.contractTestKit;
+  var handler;
+  var worker = {
+    process: { killed: false, exitCode: null },
+    exitPromise: Promise.resolve(),
+    send: function() { return false; },
+    onMessage: function(fn) { handler = fn; },
+  };
+  var handle = kit.createWorkerQueryHandle(worker);
+
+  assert.strictEqual(typeof handler, "function");
+  assert.strictEqual(handle.pushMessage("must be retried"), false);
+});
+
+test("Claude only reuses workers with a live writable IPC connection", function() {
+  var claudeModule = require("../lib/yoke/adapters/claude");
+  var kit = claudeModule.contractTestKit;
+  var worker = {
+    ready: true,
+    process: { killed: false, exitCode: null },
+    connection: { destroyed: false, writableEnded: false, writable: true },
+  };
+
+  assert.strictEqual(kit.canReuseWorker(worker), true);
+  worker.connection.writableEnded = true;
+  assert.strictEqual(kit.canReuseWorker(worker), false);
+});


### PR DESCRIPTION
## What changed

- reject dead Claude worker IPC transports instead of reporting successful delivery
- stop reusing workers whose IPC connection is no longer writable
- surface adapter protocol errors from Codex and Kiro
- finish result-less streams so sessions cannot remain stuck in the processing state
- prevent an older stream from clobbering its replacement query
- add regression coverage for rejected worker delivery and result-less stream termination

## Why

A stale query or closed runtime transport could accept a user message at the Clay layer without delivering it to the agent. Codex and Kiro could also close an errored stream without a result event, leaving the UI processing indicator running indefinitely.

## Impact

Failed delivery now either starts the existing fresh-query recovery path or terminates visibly instead of silently hanging. The fix applies at the shared session bridge and covers Claude, Codex, and Kiro failure paths.

## Validation

- `node --test test/sdk-bridge-delivery.test.js test/yoke-adapter-contract.test.js`
- `node --test test/project-file-watch.test.js`
- `git diff --check`
- full suite completed with 215/216 tests on the final run; the sole file-watch timeout passed immediately in isolation and had passed in the preceding full run
