### PR TITLE
fix(sessions): keep stop active for queued turns

### DIFF
--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1605,6 +1605,8 @@ function createSDKBridge(opts) {
       sm.broadcastSessionList();
       return;
     }
+    session._awaitingTurnResult = true;
+    session._queuedTurnCount = 0;
     console.log("[sdk-bridge] pushMessage done, starting processQueryStream...");
 
     // Flush messages that arrived while createQuery was still awaiting
@@ -1615,7 +1617,9 @@ function createSDKBridge(opts) {
       session.pendingPush = [];
       console.log("[sdk-bridge] flushing " + backlog.length + " buffered message(s) into new query");
       for (var bi = 0; bi < backlog.length; bi++) {
-        handle.pushMessage(backlog[bi].text, backlog[bi].images);
+        if (handle.pushMessage(backlog[bi].text, backlog[bi].images) !== false) {
+          session._queuedTurnCount++;
+        }
       }
     }
 
@@ -1664,7 +1668,14 @@ function createSDKBridge(opts) {
       } catch (e) {
         console.error("[sdk-bridge] QueryHandle rejected message for session " + session.localId + ":", e.message || e);
       }
-      if (delivered) return true;
+      if (delivered) {
+        if (session._awaitingTurnResult) {
+          session._queuedTurnCount = (session._queuedTurnCount || 0) + 1;
+        } else {
+          session._awaitingTurnResult = true;
+        }
+        return true;
+      }
 
       // The handle object can outlive its underlying input queue or worker.
       // Retire it before the caller starts a resumed replacement query; the

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -451,6 +451,8 @@ function attachMessageProcessor(ctx) {
         if (parsed.terminalReason) execError += " (reason: " + parsed.terminalReason + ")";
         console.error("[sdk-bridge] Execution error for session " + session.localId + ": " + execError);
         session.isProcessing = false;
+        session._awaitingTurnResult = false;
+        session._queuedTurnCount = 0;
         onProcessingChanged();
         sendAndRecord(session, { type: "error", text: "Claude error: " + execError });
         sendAndRecord(session, { type: "done", code: 1 });
@@ -458,9 +460,17 @@ function attachMessageProcessor(ctx) {
         return;
       }
 
-      session.isProcessing = false;
       session._lastAdapterError = null;
-      onProcessingChanged();
+      var hasQueuedTurn = (session._queuedTurnCount || 0) > 0;
+      if (hasQueuedTurn) {
+        session._queuedTurnCount--;
+        session._awaitingTurnResult = true;
+      } else {
+        session.isProcessing = false;
+        session._awaitingTurnResult = false;
+        session._queuedTurnCount = 0;
+        onProcessingChanged();
+      }
       // Detect "Not logged in" scenario early for the check below
       var previewTrimmed = (session.responsePreview || "").trim();
       var isZeroCost = !parsed.cost || parsed.cost === 0;
@@ -495,6 +505,11 @@ function attachMessageProcessor(ctx) {
         emitAuthRequired(session);
       }
       sendAndRecord(session, { type: "done", code: 0 });
+      if (hasQueuedTurn) {
+        // The adapter immediately continues with the already queued user turn.
+        // Restore the client stop state after the previous turn's done event.
+        sendToSession(session, { type: "status", status: "processing" });
+      }
       var _donePreviewText = (session.responsePreview || "").replace(/\s+/g, " ").trim();
       if (_donePreviewText.length > 140) _donePreviewText = _donePreviewText.substring(0, 140) + "...";
       var _doneTitle = mateDisplayName ? (mateDisplayName + " responded") : (session.title || "Claude");

--- a/test/sdk-bridge-delivery.test.js
+++ b/test/sdk-bridge-delivery.test.js
@@ -3,12 +3,13 @@ var assert = require("node:assert");
 
 var createSDKBridge = require("../lib/sdk-bridge").createSDKBridge;
 
-function createBridge(sessionManager) {
+function createBridge(sessionManager, onProcessingChanged) {
   return createSDKBridge({
     cwd: process.cwd(),
     sessionManager: sessionManager || {},
     adapter: { vendor: "codex" },
     send: function () {},
+    onProcessingChanged: onProcessingChanged || function () {},
   });
 }
 
@@ -147,4 +148,58 @@ test("an old stream ending cannot stop its replacement query", async function() 
   assert.strictEqual(session.isProcessing, true);
   assert.strictEqual(session.queryInstance, replacement);
   assert.strictEqual(recorded.length, 0);
+});
+
+test("accepted pushes track turns queued behind the active turn", function() {
+  var bridge = createBridge();
+  var session = {
+    localId: 12,
+    queryInstance: { pushMessage: function() { return true; } },
+    _awaitingTurnResult: true,
+    _queuedTurnCount: 0,
+  };
+
+  assert.strictEqual(bridge.pushMessage(session, "follow up"), true);
+  assert.strictEqual(session._awaitingTurnResult, true);
+  assert.strictEqual(session._queuedTurnCount, 1);
+});
+
+test("a result keeps processing active while a queued turn continues", function() {
+  var recorded = [];
+  var direct = [];
+  var processingChanges = 0;
+  var bridge = createBridge({
+    sendAndRecord: function(session, msg) { recorded.push(msg); },
+    sendToSession: function(session, msg) { direct.push(msg); },
+    broadcastSessionList: function() {},
+  }, function() { processingChanges++; });
+  var session = {
+    localId: 13,
+    isProcessing: true,
+    _awaitingTurnResult: true,
+    _queuedTurnCount: 1,
+    pendingAskUser: {},
+    pendingPermissions: {},
+    pendingElicitations: {},
+    activeTaskToolIds: {},
+    taskIdMap: {},
+    responsePreview: "first reply",
+    history: [],
+    turnCount: 0,
+  };
+
+  bridge.processSDKMessage(session, { yokeType: "result", cost: 1, duration: 10 });
+
+  assert.strictEqual(session.isProcessing, true);
+  assert.strictEqual(session._awaitingTurnResult, true);
+  assert.strictEqual(session._queuedTurnCount, 0);
+  assert.strictEqual(processingChanges, 0);
+  assert.deepStrictEqual(direct[direct.length - 1], { type: "status", status: "processing" });
+
+  bridge.processSDKMessage(session, { yokeType: "result", cost: 1, duration: 10 });
+
+  assert.strictEqual(session.isProcessing, false);
+  assert.strictEqual(session._awaitingTurnResult, false);
+  assert.strictEqual(processingChanges, 1);
+  assert.strictEqual(recorded[recorded.length - 1].type, "done");
 });


### PR DESCRIPTION
## What

- track user turns queued behind an active Claude or Codex response
- keep the session processing state active until the final queued turn completes
- restore the client processing status after an intermediate `done` event
- add regression coverage for queued delivery and result handling

## Why

The adapter can accept a follow-up message while the current turn is still running. The first turn's result previously marked the whole session idle even though the queued turn immediately continued, which disabled the stop button and caused the server to ignore stop requests.

## Impact

The stop control remains available throughout consecutive queued turns for both Claude and Codex sessions. A session returns to idle only after the final accepted turn finishes.

## Checks

- `node --test test/sdk-bridge-delivery.test.js`
- `PATH=/Users/chad/.nvm/versions/node/v22.22.1/bin:$PATH npm test` (203 passed)
- `git diff --check`
