### PR TITLE
feat: add presentation and agent-aware Git workflows

### DIFF
--- a/lib/git-cli.js
+++ b/lib/git-cli.js
@@ -1,0 +1,370 @@
+// Git CLI integration for project status, safe common actions, and file diffs.
+
+var fs = require("fs");
+var path = require("path");
+var { execFile, execFileSync } = require("child_process");
+var { wrapSpawnAsUser } = require("./os-users");
+
+var MAX_DIFF_BYTES = 2 * 1024 * 1024;
+
+function gitEnvironment(osUserInfo) {
+  var overrides = { GIT_TERMINAL_PROMPT: "0" };
+  if (osUserInfo && osUserInfo.home) overrides.HOME = osUserInfo.home;
+  if (osUserInfo && osUserInfo.user) {
+    overrides.USER = osUserInfo.user;
+    overrides.LOGNAME = osUserInfo.user;
+  }
+  return Object.assign({}, process.env, overrides);
+}
+
+function runGitSync(cwd, args, options, osUserInfo) {
+  var opts = Object.assign({
+    cwd: cwd,
+    encoding: "utf8",
+    timeout: 5000,
+    maxBuffer: 8 * 1024 * 1024,
+    stdio: "pipe",
+    env: gitEnvironment(osUserInfo),
+  }, options || {});
+  if (osUserInfo) {
+    opts.uid = osUserInfo.uid;
+    opts.gid = osUserInfo.gid;
+  }
+  var wrapped = wrapSpawnAsUser("git", args, opts);
+  return execFileSync(wrapped.command, wrapped.args, wrapped.options);
+}
+
+function runGit(cwd, args, timeout, osUserInfo) {
+  return new Promise(function (resolve, reject) {
+    var opts = {
+      cwd: cwd,
+      encoding: "utf8",
+      timeout: timeout || 30000,
+      maxBuffer: 8 * 1024 * 1024,
+      env: gitEnvironment(osUserInfo),
+    };
+    if (osUserInfo) {
+      opts.uid = osUserInfo.uid;
+      opts.gid = osUserInfo.gid;
+    }
+    var wrapped = wrapSpawnAsUser("git", args, opts);
+    execFile(wrapped.command, wrapped.args, wrapped.options, function (err, stdout, stderr) {
+      if (err) {
+        var detail = String(stderr || stdout || err.message || "Git command failed").trim();
+        err.userMessage = detail;
+        reject(err);
+        return;
+      }
+      resolve(String(stdout || stderr || "").trim());
+    });
+  });
+}
+
+function parseBranchHeader(record, result) {
+  var space = record.indexOf(" ", 2);
+  if (space === -1) return;
+  var key = record.slice(2, space);
+  var value = record.slice(space + 1);
+  if (key === "branch.oid") result.oid = value;
+  else if (key === "branch.head") result.branch = value;
+  else if (key === "branch.upstream") result.upstream = value;
+  else if (key === "branch.ab") {
+    var match = value.match(/^\+(\d+) -(\d+)$/);
+    if (match) {
+      result.ahead = parseInt(match[1], 10);
+      result.behind = parseInt(match[2], 10);
+    }
+  }
+}
+
+function parseTrackedRecord(record, kind) {
+  var pattern = kind === "2"
+    ? /^2 ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) (.*)$/
+    : /^1 ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) (.*)$/;
+  var match = record.match(pattern);
+  if (!match) return null;
+  var xy = match[1];
+  return {
+    path: match[match.length - 1],
+    originalPath: null,
+    code: xy,
+    staged: xy.charAt(0) !== ".",
+    unstaged: xy.charAt(1) !== ".",
+    untracked: false,
+    conflicted: false,
+    kind: kind === "2" ? "renamed" : "changed",
+  };
+}
+
+function parseUnmergedRecord(record) {
+  var match = record.match(/^u ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) ([^ ]+) (.*)$/);
+  if (!match) return null;
+  return {
+    path: match[match.length - 1],
+    originalPath: null,
+    code: match[1],
+    staged: true,
+    unstaged: true,
+    untracked: false,
+    conflicted: true,
+    kind: "conflicted",
+  };
+}
+
+function parsePorcelainV2(raw) {
+  var result = {
+    oid: null,
+    branch: null,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    files: [],
+  };
+  var records = String(raw || "").split("\0");
+  for (var i = 0; i < records.length; i++) {
+    var record = records[i];
+    if (!record) continue;
+    if (record.indexOf("# ") === 0) {
+      parseBranchHeader(record, result);
+      continue;
+    }
+    if (record.indexOf("? ") === 0) {
+      result.files.push({
+        path: record.slice(2), originalPath: null, code: "??",
+        staged: false, unstaged: true, untracked: true,
+        conflicted: false, kind: "untracked",
+      });
+      continue;
+    }
+    if (record.indexOf("u ") === 0) {
+      var conflict = parseUnmergedRecord(record);
+      if (conflict) result.files.push(conflict);
+      continue;
+    }
+    if (record.indexOf("1 ") === 0 || record.indexOf("2 ") === 0) {
+      var kind = record.charAt(0);
+      var file = parseTrackedRecord(record, kind);
+      if (file && kind === "2" && i + 1 < records.length) {
+        file.originalPath = records[++i] || null;
+      }
+      if (file) result.files.push(file);
+    }
+  }
+  return result;
+}
+
+function normalizeGitPath(cwd, value) {
+  return path.normalize(path.isAbsolute(value) ? value : path.resolve(cwd, value));
+}
+
+function parseWorktrees(raw) {
+  var blocks = String(raw || "").trim().split(/\n\n+/);
+  var result = [];
+  for (var i = 0; i < blocks.length; i++) {
+    if (!blocks[i]) continue;
+    var lines = blocks[i].split("\n");
+    var item = { path: null, branch: null, head: null, bare: false, detached: false };
+    for (var j = 0; j < lines.length; j++) {
+      var line = lines[j];
+      if (line.indexOf("worktree ") === 0) item.path = line.slice(9);
+      else if (line.indexOf("HEAD ") === 0) item.head = line.slice(5);
+      else if (line.indexOf("branch ") === 0) item.branch = line.slice(7).replace(/^refs\/heads\//, "");
+      else if (line === "bare") item.bare = true;
+      else if (line === "detached") item.detached = true;
+    }
+    if (item.path) result.push(item);
+  }
+  return result;
+}
+
+function getStatus(cwd, osUserInfo) {
+  try {
+    var inside = runGitSync(cwd, ["rev-parse", "--is-inside-work-tree"], null, osUserInfo).trim();
+    if (inside !== "true") return { isRepository: false };
+  } catch (e) {
+    return { isRepository: false };
+  }
+
+  var root = runGitSync(cwd, ["rev-parse", "--show-toplevel"], null, osUserInfo).trim();
+  var raw = runGitSync(root, ["status", "--porcelain=v2", "--branch", "-z"], null, osUserInfo);
+  var parsed = parsePorcelainV2(raw);
+  var origin = null;
+  var gitDir = null;
+  var commonDir = null;
+  var worktrees = [];
+  try { origin = runGitSync(cwd, ["remote", "get-url", "origin"], null, osUserInfo).trim() || null; } catch (e) {}
+  try { gitDir = normalizeGitPath(cwd, runGitSync(cwd, ["rev-parse", "--absolute-git-dir"], null, osUserInfo).trim()); } catch (e) {}
+  try { commonDir = normalizeGitPath(cwd, runGitSync(cwd, ["rev-parse", "--git-common-dir"], null, osUserInfo).trim()); } catch (e) {}
+  try { worktrees = parseWorktrees(runGitSync(cwd, ["worktree", "list", "--porcelain"], null, osUserInfo)); } catch (e) {}
+
+  var normalizedRoot = path.normalize(root);
+  var currentWorktree = null;
+  for (var i = 0; i < worktrees.length; i++) {
+    if (path.normalize(worktrees[i].path) === normalizedRoot) {
+      currentWorktree = worktrees[i];
+      break;
+    }
+  }
+  var detached = parsed.branch === "(detached)" || !!(currentWorktree && currentWorktree.detached);
+  return {
+    isRepository: true,
+    name: path.basename(root),
+    root: root,
+    branch: detached ? null : parsed.branch,
+    detached: detached,
+    oid: parsed.oid === "(initial)" ? null : parsed.oid,
+    upstream: parsed.upstream,
+    ahead: parsed.ahead,
+    behind: parsed.behind,
+    origin: origin,
+    gitDir: gitDir,
+    commonDir: commonDir,
+    isWorktree: !!(gitDir && commonDir && gitDir !== commonDir),
+    mainWorktree: worktrees.length > 0 ? worktrees[0].path : root,
+    worktrees: worktrees,
+    files: parsed.files,
+    dirty: parsed.files.length > 0,
+  };
+}
+
+function resolveChangedPaths(status, requestedPaths) {
+  if (!Array.isArray(requestedPaths) || requestedPaths.length === 0 || requestedPaths.length > 200) {
+    throw new Error("Select at least one changed file");
+  }
+  var byPath = {};
+  for (var i = 0; i < status.files.length; i++) byPath[status.files[i].path] = status.files[i];
+  var result = [];
+  var seen = {};
+  for (var j = 0; j < requestedPaths.length; j++) {
+    var requested = requestedPaths[j];
+    var entry = typeof requested === "string" ? byPath[requested] : null;
+    if (!entry) throw new Error("File is no longer changed: " + String(requested));
+    if (!seen[entry.path]) { result.push(entry.path); seen[entry.path] = true; }
+    if (entry.originalPath && !seen[entry.originalPath]) {
+      result.push(entry.originalPath);
+      seen[entry.originalPath] = true;
+    }
+  }
+  return result;
+}
+
+function runAction(cwd, body, osUserInfo) {
+  var action = body && body.action;
+  var status = getStatus(cwd, osUserInfo);
+  if (!status.isRepository) return Promise.reject(new Error("This project is not a Git repository"));
+
+  if (action === "stage" || action === "unstage") {
+    var paths = resolveChangedPaths(status, body.paths);
+    if (action === "stage") return runGit(status.root, ["add", "-A", "--"].concat(paths), null, osUserInfo);
+    if (status.oid) return runGit(status.root, ["restore", "--staged", "--"].concat(paths), null, osUserInfo);
+    return runGit(status.root, ["rm", "--cached", "-r", "--"].concat(paths), null, osUserInfo);
+  }
+  if (action === "stage_all") return runGit(status.root, ["add", "-A"], null, osUserInfo);
+  if (action === "unstage_all") {
+    if (status.oid) return runGit(status.root, ["reset"], null, osUserInfo);
+    return runGit(status.root, ["rm", "--cached", "-r", "."], null, osUserInfo);
+  }
+  if (action === "pull") {
+    if (!status.upstream) return Promise.reject(new Error("The current branch has no upstream"));
+    return runGit(status.root, ["pull", "--ff-only"], 60000, osUserInfo);
+  }
+  if (action === "push") {
+    if (status.upstream) return runGit(status.root, ["push"], 60000, osUserInfo);
+    if (!status.origin || !status.branch) return Promise.reject(new Error("Set an origin and check out a branch before pushing"));
+    return runGit(status.root, ["push", "--set-upstream", "origin", status.branch], 60000, osUserInfo);
+  }
+  return Promise.reject(new Error("Unsupported Git action"));
+}
+
+function bufferIsBinary(buffer) {
+  var limit = Math.min(buffer.length, 8000);
+  for (var i = 0; i < limit; i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}
+
+function getHeadFile(cwd, filePath, osUserInfo) {
+  try {
+    return runGitSync(cwd, ["show", "HEAD:" + filePath], { encoding: null, maxBuffer: MAX_DIFF_BYTES }, osUserInfo);
+  } catch (e) {
+    return Buffer.alloc(0);
+  }
+}
+
+function fileBufferResult(buffer) {
+  var binary = bufferIsBinary(buffer);
+  return { content: binary ? "" : buffer.toString("utf8"), binary: binary };
+}
+
+function readWorkingTreeFile(cwd, filePath) {
+  var root = path.resolve(cwd);
+  var absolutePath = path.resolve(root, filePath);
+  if (absolutePath !== root && absolutePath.indexOf(root + path.sep) !== 0) throw new Error("Invalid file path");
+  try {
+    var stat = fs.lstatSync(absolutePath);
+    if (stat.isSymbolicLink()) return fileBufferResult(Buffer.from(fs.readlinkSync(absolutePath), "utf8"));
+    if (!stat.isFile()) return { content: "", binary: false };
+    if (stat.size > MAX_DIFF_BYTES) throw new Error("File is too large to preview");
+    return fileBufferResult(fs.readFileSync(absolutePath));
+  } catch (e) {
+    if (e.code === "ENOENT") return { content: "", binary: false };
+    throw e;
+  }
+}
+
+function getFileAtCommit(cwd, commit, filePath, osUserInfo) {
+  if (!commit) return { content: "", binary: false };
+  try {
+    var buffer = runGitSync(cwd, ["show", commit + ":" + filePath], { encoding: null, maxBuffer: MAX_DIFF_BYTES }, osUserInfo);
+    return fileBufferResult(buffer);
+  } catch (e) {
+    return { content: "", binary: false };
+  }
+}
+
+function getFileDiff(cwd, requestedPath, osUserInfo) {
+  var status = getStatus(cwd, osUserInfo);
+  if (!status.isRepository) throw new Error("This project is not a Git repository");
+  var entry = null;
+  for (var i = 0; i < status.files.length; i++) {
+    if (status.files[i].path === requestedPath) { entry = status.files[i]; break; }
+  }
+  if (!entry) throw new Error("File is no longer changed");
+
+  var oldPath = entry.originalPath || entry.path;
+  var oldBuffer = getHeadFile(status.root, oldPath, osUserInfo);
+  var newBuffer = Buffer.alloc(0);
+  var absolutePath = path.resolve(status.root, entry.path);
+  var rootPrefix = path.resolve(status.root) + path.sep;
+  if (absolutePath.indexOf(rootPrefix) !== 0) throw new Error("Invalid changed file path");
+  try {
+    var stat = fs.lstatSync(absolutePath);
+    if (stat.isSymbolicLink()) {
+      newBuffer = Buffer.from(fs.readlinkSync(absolutePath), "utf8");
+    } else if (stat.isFile()) {
+      if (stat.size > MAX_DIFF_BYTES) throw new Error("File is too large to preview");
+      newBuffer = fs.readFileSync(absolutePath);
+    }
+  } catch (e) {
+    if (e.message === "File is too large to preview") throw e;
+  }
+  var binary = bufferIsBinary(oldBuffer) || bufferIsBinary(newBuffer);
+  return {
+    path: entry.path,
+    oldPath: oldPath,
+    oldContent: binary ? "" : oldBuffer.toString("utf8"),
+    newContent: binary ? "" : newBuffer.toString("utf8"),
+    binary: binary,
+  };
+}
+
+module.exports = {
+  getFileAtCommit: getFileAtCommit,
+  getFileDiff: getFileDiff,
+  getStatus: getStatus,
+  parsePorcelainV2: parsePorcelainV2,
+  parseWorktrees: parseWorktrees,
+  readWorkingTreeFile: readWorkingTreeFile,
+  runAction: runAction,
+};

--- a/lib/git-session-attribution.js
+++ b/lib/git-session-attribution.js
@@ -1,0 +1,219 @@
+// Connect working-tree changes to the Clay sessions that were active while they changed.
+
+var crypto = require("crypto");
+var fs = require("fs");
+var path = require("path");
+var config = require("./config");
+var gitCli = require("./git-cli");
+var utils = require("./utils");
+
+var MAX_BASELINE_BYTES = 2 * 1024 * 1024;
+var MAX_DIGEST_BYTES = 8 * 1024 * 1024;
+var MAX_SESSION_RECORDS = 80;
+
+function attachGitSessionAttribution(options) {
+  var cwd = options.cwd;
+  var getOsUserInfoForSession = options.getOsUserInfoForSession || function () { return null; };
+  var storageDir = options.storageDir || path.join(config.CONFIG_DIR, "git-attribution");
+  var storagePath = path.join(storageDir, utils.encodeCwd(cwd) + ".json");
+  var state = loadState();
+
+  function loadState() {
+    try {
+      var parsed = JSON.parse(fs.readFileSync(storagePath, "utf8"));
+      if (parsed && parsed.version === 1 && parsed.sessions) return parsed;
+    } catch (e) {}
+    return { version: 1, sessions: {} };
+  }
+
+  function saveState() {
+    try {
+      fs.mkdirSync(storageDir, { recursive: true });
+      var keys = Object.keys(state.sessions).sort(function (left, right) {
+        return (state.sessions[right].lastChangedAt || 0) - (state.sessions[left].lastChangedAt || 0);
+      });
+      for (var i = MAX_SESSION_RECORDS; i < keys.length; i++) delete state.sessions[keys[i]];
+      var temporaryPath = storagePath + ".tmp." + process.pid;
+      fs.writeFileSync(temporaryPath, JSON.stringify(state, null, 2) + "\n");
+      if (process.platform !== "win32") {
+        try { fs.chmodSync(temporaryPath, 0o600); } catch (chmodError) {}
+      }
+      fs.renameSync(temporaryPath, storagePath);
+    } catch (e) {
+      console.error("[git-attribution] Unable to save session change data:", e.message);
+    }
+  }
+
+  function sessionKey(session) {
+    return session.cliSessionId || ("local:" + session.localId);
+  }
+
+  function digestPath(root, file) {
+    var absolutePath = path.resolve(root, file.path);
+    var rootPrefix = path.resolve(root) + path.sep;
+    if (absolutePath.indexOf(rootPrefix) !== 0) return "invalid:" + file.code;
+    try {
+      var stat = fs.lstatSync(absolutePath);
+      var hash = crypto.createHash("sha256");
+      hash.update(file.code || "");
+      if (stat.isSymbolicLink()) hash.update(fs.readlinkSync(absolutePath));
+      else if (stat.isFile() && stat.size <= MAX_DIGEST_BYTES) hash.update(fs.readFileSync(absolutePath));
+      else if (stat.isFile()) hash.update("large:" + stat.size + ":" + stat.mtimeMs);
+      else hash.update("non-file");
+      return hash.digest("hex");
+    } catch (e) {
+      return "missing:" + (file.code || "");
+    }
+  }
+
+  function readBaseline(root, file) {
+    var absolutePath = path.resolve(root, file.path);
+    var rootPrefix = path.resolve(root) + path.sep;
+    if (absolutePath.indexOf(rootPrefix) !== 0) return null;
+    try {
+      var stat = fs.lstatSync(absolutePath);
+      var buffer;
+      if (stat.isSymbolicLink()) buffer = Buffer.from(fs.readlinkSync(absolutePath), "utf8");
+      else if (stat.isFile() && stat.size <= MAX_BASELINE_BYTES) buffer = fs.readFileSync(absolutePath);
+      else return null;
+      return { content: buffer.toString("base64"), binary: buffer.indexOf(0) !== -1 };
+    } catch (e) {
+      return { missing: true };
+    }
+  }
+
+  function captureSnapshot(includeBaseline, osUserInfo) {
+    var status = gitCli.getStatus(cwd, osUserInfo);
+    if (!status.isRepository) return null;
+    var files = {};
+    for (var i = 0; i < status.files.length; i++) {
+      var file = status.files[i];
+      files[file.path] = {
+        fingerprint: digestPath(status.root, file),
+        baseline: includeBaseline ? readBaseline(status.root, file) : undefined,
+      };
+    }
+    return { root: status.root, head: status.oid || null, files: files, capturedAt: Date.now() };
+  }
+
+  function beginTurn(session) {
+    if (!session || session._gitAttributionTurn) return;
+    try {
+      var osUserInfo = getOsUserInfoForSession(session);
+      var snapshot = captureSnapshot(false, osUserInfo);
+      if (!snapshot) return;
+      var key = sessionKey(session);
+      var oldLocalKey = "local:" + session.localId;
+      if (key !== oldLocalKey && state.sessions[oldLocalKey] && !state.sessions[key]) {
+        state.sessions[key] = state.sessions[oldLocalKey];
+        delete state.sessions[oldLocalKey];
+      }
+      if (!state.sessions[key]) {
+        var baseline = captureSnapshot(true, osUserInfo);
+        state.sessions[key] = {
+          key: key,
+          title: session.title || "Untitled session",
+          vendor: session.vendor || null,
+          startedAt: Date.now(),
+          baseline: baseline,
+          changedPaths: {},
+        };
+        saveState();
+      }
+      session._gitAttributionTurn = snapshot;
+      session._gitAttributionOsUserInfo = osUserInfo;
+    } catch (e) {
+      console.error("[git-attribution] Unable to capture turn start:", e.message);
+    }
+  }
+
+  function finishTurn(session) {
+    if (!session || !session._gitAttributionTurn) return;
+    var before = session._gitAttributionTurn;
+    session._gitAttributionTurn = null;
+    try {
+      var after = captureSnapshot(false, session._gitAttributionOsUserInfo);
+      session._gitAttributionOsUserInfo = null;
+      if (!after) return;
+      var key = sessionKey(session);
+      var record = state.sessions[key] || state.sessions["local:" + session.localId];
+      if (!record) return;
+      record.title = session.title || record.title;
+      record.vendor = session.vendor || record.vendor;
+      var paths = {};
+      Object.keys(before.files).forEach(function (filePath) { paths[filePath] = true; });
+      Object.keys(after.files).forEach(function (filePath) { paths[filePath] = true; });
+      var changedAt = Date.now();
+      Object.keys(paths).forEach(function (filePath) {
+        var oldFingerprint = before.files[filePath] ? before.files[filePath].fingerprint : null;
+        var newFingerprint = after.files[filePath] ? after.files[filePath].fingerprint : null;
+        if (oldFingerprint !== newFingerprint) record.changedPaths[filePath] = changedAt;
+      });
+      record.lastChangedAt = changedAt;
+      saveState();
+    } catch (e) {
+      console.error("[git-attribution] Unable to capture turn result:", e.message);
+    }
+  }
+
+  function decorateStatus(status, sessions) {
+    if (!status || !status.isRepository) return status;
+    var liveByKey = {};
+    sessions.forEach(function (session) {
+      liveByKey[sessionKey(session)] = session;
+      liveByKey["local:" + session.localId] = session;
+    });
+    for (var i = 0; i < status.files.length; i++) {
+      var file = status.files[i];
+      var matches = [];
+      Object.keys(state.sessions).forEach(function (key) {
+        var record = state.sessions[key];
+        if (!record.changedPaths || !record.changedPaths[file.path]) return;
+        var live = liveByKey[key];
+        if (!live) return;
+        matches.push({
+          key: key,
+          sessionId: live ? live.localId : null,
+          title: live ? (live.title || record.title) : record.title,
+          vendor: record.vendor || null,
+          changedAt: record.changedPaths[file.path],
+          preExisting: !!(record.baseline && record.baseline.files && record.baseline.files[file.path]),
+        });
+      });
+      matches.sort(function (left, right) { return right.changedAt - left.changedAt; });
+      file.sessions = matches.slice(0, 4);
+    }
+    return status;
+  }
+
+  function getSessionBaselineDiff(key, filePath, osUserInfo) {
+    var record = state.sessions[key];
+    if (!record || !record.baseline) throw new Error("Session baseline is unavailable");
+    var current = gitCli.readWorkingTreeFile(record.baseline.root || cwd, filePath);
+    var saved = record.baseline.files && record.baseline.files[filePath];
+    var oldFile;
+    if (saved && saved.baseline) {
+      oldFile = saved.baseline.missing
+        ? { content: "", binary: false }
+        : { content: Buffer.from(saved.baseline.content || "", "base64").toString("utf8"), binary: !!saved.baseline.binary };
+    } else {
+      oldFile = gitCli.getFileAtCommit(record.baseline.root || cwd, record.baseline.head, filePath, osUserInfo);
+    }
+    return {
+      path: filePath,
+      oldContent: oldFile.binary ? "" : oldFile.content,
+      newContent: current.binary ? "" : current.content,
+      binary: oldFile.binary || current.binary,
+      sessionTitle: record.title,
+    };
+  }
+
+  return {
+    beginTurn: beginTurn,
+    decorateStatus: decorateStatus,
+    finishTurn: finishTurn,
+    getSessionBaselineDiff: getSessionBaselineDiff,
+  };
+}
+
+module.exports = { attachGitSessionAttribution: attachGitSessionAttribution };

--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -272,22 +272,8 @@ function attachConnection(ctx) {
 
     if (active && !ws._clayPane) {
       userPresence.setPresence(slug, presenceKey, active.localId, storedPresence ? storedPresence.mateDm : null);
-      // For auto-created sessions, apply project email defaults
       if (autoCreated) {
-        var _emailMod = ctx._email;
-        var _saveCtx = ctx.saveContextSources;
-        if (_emailMod && _emailMod.getEmailDefaults && _saveCtx) {
-          var emailDefs = _emailMod.getEmailDefaults();
-          if (emailDefs.length > 0) {
-            var defSources = emailDefs.map(function (id) { return "email:" + id; });
-            _saveCtx(slug, active.localId, defSources);
-            sendTo(ws, { type: "context_sources_state", active: defSources });
-          } else {
-            sendTo(ws, { type: "context_sources_state", active: [] });
-          }
-        } else {
-          sendTo(ws, { type: "context_sources_state", active: [] });
-        }
+        sendTo(ws, { type: "context_sources_state", active: [] });
       }
     }
     if (storedPresence && storedPresence.mateDm && !isMate) {

--- a/lib/project-email.js
+++ b/lib/project-email.js
@@ -9,31 +9,6 @@ var smtp = require("./smtp");
 var { CONFIG_DIR } = require("./config");
 
 var AUDIT_LOG_PATH = path.join(CONFIG_DIR, "email-audit.jsonl");
-var EMAIL_DEFAULTS_DIR = path.join(CONFIG_DIR, "email-defaults");
-
-// --- Project-level email defaults ---
-// Stores which email accounts should be auto-enabled for every new session.
-
-function loadEmailDefaults(slug) {
-  try {
-    var filePath = path.join(EMAIL_DEFAULTS_DIR, slug + ".json");
-    var data = JSON.parse(fs.readFileSync(filePath, "utf8"));
-    return data.accounts || [];
-  } catch (e) {
-    return [];
-  }
-}
-
-function saveEmailDefaults(slug, accountIds) {
-  try {
-    fs.mkdirSync(EMAIL_DEFAULTS_DIR, { recursive: true });
-    var filePath = path.join(EMAIL_DEFAULTS_DIR, slug + ".json");
-    fs.writeFileSync(filePath, JSON.stringify({ accounts: accountIds }), "utf8");
-  } catch (e) {
-    console.error("[email] Failed to save defaults:", e.message);
-  }
-}
-
 // --- Audit log (Server SMTP only) ---
 
 function appendAuditLog(entry) {
@@ -185,7 +160,6 @@ function formatTimeAgo(date) {
 function attachEmail(ctx) {
   var slug = ctx.slug;
   var send = ctx.send;
-  var sendTo = ctx.sendTo;
   var clients = ctx.clients;
   var loadContextSources = ctx.loadContextSources;
   var getUserIdForWs = ctx.getUserIdForWs;
@@ -327,17 +301,6 @@ function attachEmail(ctx) {
         }
       }
     }
-    // Fallback: if no session-level sources found, check project email defaults
-    if (result.length === 0) {
-      var defaults = loadEmailDefaults(slug);
-      for (var di = 0; di < defaults.length; di++) {
-        var dec = emailAccounts.getAccountDecrypted(userId, defaults[di]);
-        if (dec && !seen[dec.id]) {
-          seen[dec.id] = true;
-          result.push(dec);
-        }
-      }
-    }
     return result;
   }
 
@@ -376,28 +339,6 @@ function attachEmail(ctx) {
     };
   }
 
-  function handleEmailMessage(ws, msg) {
-    if (msg.type === "email_defaults_get") {
-      var defaults = loadEmailDefaults(slug);
-      sendTo(ws, { type: "email_defaults", accounts: defaults });
-      return true;
-    }
-    if (msg.type === "email_defaults_save") {
-      var accountIds = msg.accounts || [];
-      saveEmailDefaults(slug, accountIds);
-      // Broadcast to all clients on this project
-      var _defMsg = JSON.stringify({ type: "email_defaults", accounts: accountIds });
-      for (var c of clients) { if (c.readyState === 1) c.send(_defMsg); }
-      return true;
-    }
-    return false;
-  }
-
-  // Get default email account IDs for new sessions
-  function getEmailDefaults() {
-    return loadEmailDefaults(slug);
-  }
-
   function destroy() {
     if (pollTimer) {
       clearInterval(pollTimer);
@@ -421,10 +362,8 @@ function attachEmail(ctx) {
   }
 
   return {
-    handleEmailMessage: handleEmailMessage,
     getEmailContext: getEmailContext,
     getCheckedEmailAccounts: getCheckedEmailAccounts,
-    getEmailDefaults: getEmailDefaults,
     createMcpDeps: createMcpDeps,
     hasEmailCapability: hasEmailCapability,
     destroy: destroy,

--- a/lib/project-http.js
+++ b/lib/project-http.js
@@ -5,6 +5,7 @@ var crypto = require("crypto");
 var { execFileSync, spawn } = require("child_process");
 var { fsAsUser } = require("./os-users");
 var usersModule = require("./users");
+var gitCli = require("./git-cli");
 
 var IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".ico"]);
 var MIME_TYPES = {
@@ -47,6 +48,7 @@ function attachHTTP(ctx) {
   var slug = ctx.slug;
   var project = ctx.project;
   var sm = ctx.sm;
+  var gitAttribution = ctx.gitAttribution;
   var send = ctx.send;
   var imagesDir = ctx.imagesDir;
   var osUsers = ctx.osUsers;
@@ -643,7 +645,108 @@ function attachHTTP(ctx) {
       return true;
     }
 
-    // Git dirty check
+    // Git panel status and actions
+    var isGitPanelRequest = urlPath === "/api/git/status" ||
+      urlPath === "/api/git/action" || urlPath.indexOf("/api/git/file-diff?") === 0 ||
+      urlPath.indexOf("/api/git/session-diff?") === 0;
+    if (isGitPanelRequest && usersModule.isMultiUser()) {
+      var gitRequestUser = req._clayUser;
+      var gitPermissions = gitRequestUser ? usersModule.getEffectivePermissions(gitRequestUser, osUsers) : null;
+      if (!gitPermissions || !gitPermissions.fileBrowser) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end('{"error":"Git access is not permitted"}');
+        return true;
+      }
+    }
+
+    if (req.method === "GET" && urlPath === "/api/git/status") {
+      var gitUserInfo = getOsUserInfoForReq(req);
+      try {
+        var gitStatus = gitCli.getStatus(cwd, gitUserInfo);
+        if (gitAttribution) {
+          var visibleGitSessions = sm.sessions;
+          if (usersModule.isMultiUser() && req._clayUser) {
+            visibleGitSessions = new Map();
+            sm.sessions.forEach(function (session, id) {
+              if (usersModule.canAccessSession(req._clayUser.id, session, { visibility: "public" })) {
+                visibleGitSessions.set(id, session);
+              }
+            });
+          }
+          gitAttribution.decorateStatus(gitStatus, visibleGitSessions);
+        }
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+        res.end(JSON.stringify(gitStatus));
+      } catch (e) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: e.message || "Unable to read Git status" }));
+      }
+      return true;
+    }
+
+    if (req.method === "GET" && urlPath.indexOf("/api/git/file-diff?") === 0) {
+      var gitDiffParams = new URLSearchParams(urlPath.slice(urlPath.indexOf("?")));
+      var gitDiffPath = gitDiffParams.get("path");
+      if (!gitDiffPath) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end('{"error":"Missing file path"}');
+        return true;
+      }
+      try {
+        var gitDiffResult = gitCli.getFileDiff(cwd, gitDiffPath, getOsUserInfoForReq(req));
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+        res.end(JSON.stringify(gitDiffResult));
+      } catch (e) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: e.message || "Unable to read file diff" }));
+      }
+      return true;
+    }
+
+    if (req.method === "GET" && urlPath.indexOf("/api/git/session-diff?") === 0) {
+      var sessionDiffParams = new URLSearchParams(urlPath.slice(urlPath.indexOf("?")));
+      var sessionDiffKey = sessionDiffParams.get("session");
+      var sessionDiffPath = sessionDiffParams.get("path");
+      if (!gitAttribution || !sessionDiffKey || !sessionDiffPath) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end('{"error":"Missing session comparison"}');
+        return true;
+      }
+      try {
+        var requestedSessionVisible = false;
+        sm.sessions.forEach(function (session) {
+          var key = session.cliSessionId || ("local:" + session.localId);
+          if (key !== sessionDiffKey) return;
+          requestedSessionVisible = !usersModule.isMultiUser() ||
+            (req._clayUser && usersModule.canAccessSession(req._clayUser.id, session, { visibility: "public" }));
+        });
+        if (!requestedSessionVisible) throw new Error("Session comparison is unavailable");
+        var sessionDiff = gitAttribution.getSessionBaselineDiff(sessionDiffKey, sessionDiffPath, getOsUserInfoForReq(req));
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+        res.end(JSON.stringify(sessionDiff));
+      } catch (e) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: e.message || "Unable to compare session changes" }));
+      }
+      return true;
+    }
+
+    if (req.method === "POST" && urlPath === "/api/git/action") {
+      var gitActionUserInfo = getOsUserInfoForReq(req);
+      parseJsonBody(req).then(function (body) {
+        return gitCli.runAction(cwd, body, gitActionUserInfo);
+      }).then(function (output) {
+        var updatedStatus = gitCli.getStatus(cwd, gitActionUserInfo);
+        res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+        res.end(JSON.stringify({ ok: true, output: output, status: updatedStatus }));
+      }).catch(function (err) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: err.userMessage || err.message || "Git action failed" }));
+      });
+      return true;
+    }
+
+    // Legacy dirty check used by the Ralph Loop flow
     if (req.method === "GET" && urlPath === "/api/git-dirty") {
       try {
         var out = execFileSync("git", ["status", "--porcelain"], { cwd: cwd, encoding: "utf8", timeout: 5000 });

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -104,7 +104,6 @@ function attachSessions(ctx) {
   var getLatestVersion = ctx.getLatestVersion;
   var setLatestVersion = ctx.setLatestVersion;
   var loadContextSources = ctx.loadContextSources;
-  var saveContextSources = ctx.saveContextSources;
 
   // Resolve the active user's Claude open-mode preference ('gui' or 'tui').
   // Multi-user mode reads per-user storage; single-user mode falls back to
@@ -541,15 +540,6 @@ function attachSessions(ctx) {
           opts.onSetProjectLastVendor(slug, msg.vendor);
         }
         send({ type: "last_vendor", vendor: msg.vendor });
-      }
-      // Apply project-level email defaults to new session
-      if (typeof ctx._email === "object" && ctx._email.getEmailDefaults) {
-        var emailDefaults = ctx._email.getEmailDefaults();
-        if (emailDefaults.length > 0) {
-          var defaultSources = emailDefaults.map(function (id) { return "email:" + id; });
-          saveContextSources(slug, newSess.localId, defaultSources);
-          sendTo(ws, { type: "context_sources_state", active: defaultSources });
-        }
       }
       var nsPresKey = ws._clayUser ? ws._clayUser.id : "_default";
       if (!ws._clayPane) userPresence.setPresence(slug, nsPresKey, newSess.localId, null);

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -515,7 +515,7 @@ function attachSessions(ctx) {
         // Reuse an existing blank GUI session instead of stacking another
         // one. A vendor-less blank is acceptable: nothing has happened in it,
         // so stamping the requested vendor is equivalent to a fresh create.
-        var reusable = sm.findReusableBlankSession({
+        var reusable = msg.forceNew === true ? null : sm.findReusableBlankSession({
           vendor: sessionOpts.vendor || null,
           ownerId: sessionOpts.ownerId || null,
         });

--- a/lib/project-user-message.js
+++ b/lib/project-user-message.js
@@ -57,6 +57,7 @@ function attachUserMessage(ctx) {
   var imagesDir = ctx.imagesDir;
 
   var onProcessingChanged = ctx.onProcessingChanged;
+  var gitAttribution = ctx.gitAttribution;
 
   var _loop = ctx._loop;
   var browserState = ctx.browserState;
@@ -293,6 +294,7 @@ function attachUserMessage(ctx) {
 
     var session = getSessionForWs(ws);
     if (!session) return true;
+    if (gitAttribution) gitAttribution.beginTurn(session);
 
     // Bind vendor to session on first message (if not already set)
     if (!session.vendor && msg.vendor) {

--- a/lib/project.js
+++ b/lib/project.js
@@ -1154,9 +1154,6 @@ function createProjectContext(opts) {
       return;
     }
 
-    // --- Email defaults (project-level) ---
-    if (_email.handleEmailMessage(ws, msg)) return;
-
     // --- MCP bridge (remote MCP servers via extension) ---
     if (_mcp.handleMcpMessage(ws, msg)) return;
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -3,6 +3,7 @@ var path = require("path");
 var os = require("os");
 var crypto = require("crypto");
 var { createSessionManager } = require("./sessions");
+var { attachGitSessionAttribution } = require("./git-session-attribution");
 var { createSDKBridge, createMessageQueue } = require("./sdk-bridge");
 var { createTerminalManager } = require("./terminal-manager");
 var { createNotesManager } = require("./notes");
@@ -401,6 +402,7 @@ function createProjectContext(opts) {
   var stopAllDirWatches = _fileWatch.stopAllDirWatches;
 
   // --- Session manager ---
+  var _gitAttribution = null;
   var sm = createSessionManager({
     cwd: cwd,
     send: send,
@@ -419,7 +421,17 @@ function createProjectContext(opts) {
         fn(ws, filterFn);
       }
     },
-    onSessionDone: onSessionDone,
+    onSessionDone: function (session) {
+      if (_gitAttribution) _gitAttribution.finishTurn(session);
+      onSessionDone();
+    },
+  });
+  _gitAttribution = attachGitSessionAttribution({
+    cwd: cwd,
+    getOsUserInfoForSession: function (session) {
+      var linuxUser = getLinuxUserForSession(session);
+      return linuxUser ? resolveOsUserInfo(linuxUser) : null;
+    },
   });
   sm.availableVendors = Object.keys(adapters);
   sm.defaultVendor = defaultVendor;
@@ -1407,6 +1419,7 @@ function createProjectContext(opts) {
     saveImageFile: saveImageFile,
     imagesDir: imagesDir,
     onProcessingChanged: onProcessingChanged,
+    gitAttribution: _gitAttribution,
     _loop: _loop,
     browserState: browserState,
     sendExtensionCommandAny: sendExtensionCommandAny,
@@ -1618,6 +1631,7 @@ function createProjectContext(opts) {
     slug: slug,
     project: title || project,
     sm: sm,
+    gitAttribution: _gitAttribution,
     send: send,
     imagesDir: imagesDir,
     osUsers: osUsers,

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -25,6 +25,7 @@ import { initNotifications, showDoneNotification, playDoneSound, isNotifAlertEna
 import { initInput, clearPendingImages, handleInputSync, autoResize, builtinCommands, sendMessage, hasSendableContent, setScheduleBtnDisabled, setScheduleDelayMs, clearScheduleDelay } from './modules/input.js';
 import { initQrCode, triggerShare } from './modules/qrcode.js';
 import { initFileBrowser, loadRootDirectory, refreshTree, handleFsList, handleFsRead, handleDirChanged, refreshIfOpen, handleFileChanged, handleFileHistory, handleGitDiff, handleFileAt, getPendingNavigate, closeFileViewer, resetFileBrowser } from './modules/filebrowser.js';
+import { initGitPanel } from './modules/git-panel.js';
 import { initTerminal, openTerminal, closeTerminal, resetTerminals, handleTermList, handleTermCreated, handleTermOutput, handleTermResized, handleTermExited, handleTermClosed, sendTerminalCommand } from './modules/terminal.js';
 import { initContextSources, updateTerminalList, updateBrowserTabList, handleContextSourcesState, getActiveSources, hasActiveSources } from './modules/context-sources.js';
 import { initStickyNotes, handleNotesList, handleNoteCreated, handleNoteUpdated, handleNoteDeleted, openArchive, closeArchive, isArchiveOpen, hideNotes, showNotes, isNotesVisible, createNote } from './modules/sticky-notes.js';
@@ -882,6 +883,8 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
       if (!_perms.fileBrowser) {
         var fbBtn = document.getElementById("file-browser-btn");
         if (fbBtn) fbBtn.style.display = "none";
+        var gitBtn = document.getElementById("git-sidebar-btn");
+        if (gitBtn) gitBtn.style.display = "none";
       }
       if (!_perms.skills) {
         var sBtn = document.getElementById("skills-btn");
@@ -970,6 +973,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     fileTreeEl: $("file-tree"),
     fileViewerEl: $("file-viewer"),
   });
+  initGitPanel();
 
   // --- Terminal ---
   initTerminal({
@@ -1054,8 +1058,10 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
   // Close archive / scheduler panel when switching to other sidebar panels
   var fileBrowserBtn = $("file-browser-btn");
+  var gitSidebarBtn = $("git-sidebar-btn");
   var terminalSidebarBtn = $("terminal-sidebar-btn");
   if (fileBrowserBtn) fileBrowserBtn.addEventListener("click", function () { if (isArchiveOpen()) closeArchive(); if (isSchedulerOpen()) closeScheduler(); });
+  if (gitSidebarBtn) gitSidebarBtn.addEventListener("click", function () { if (isArchiveOpen()) closeArchive(); if (isSchedulerOpen()) closeScheduler(); });
   if (terminalSidebarBtn) terminalSidebarBtn.addEventListener("click", function () { if (isArchiveOpen()) closeArchive(); if (isSchedulerOpen()) closeScheduler(); });
 
   // --- Ralph Loop UI (delegated to app-loop-ui.js + app-loop-wizard.js) ---

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -26,7 +26,7 @@ import { initInput, clearPendingImages, handleInputSync, autoResize, builtinComm
 import { initQrCode, triggerShare } from './modules/qrcode.js';
 import { initFileBrowser, loadRootDirectory, refreshTree, handleFsList, handleFsRead, handleDirChanged, refreshIfOpen, handleFileChanged, handleFileHistory, handleGitDiff, handleFileAt, getPendingNavigate, closeFileViewer, resetFileBrowser } from './modules/filebrowser.js';
 import { initTerminal, openTerminal, closeTerminal, resetTerminals, handleTermList, handleTermCreated, handleTermOutput, handleTermResized, handleTermExited, handleTermClosed, sendTerminalCommand } from './modules/terminal.js';
-import { initContextSources, initEmailDefaultsModal, updateTerminalList, updateBrowserTabList, handleContextSourcesState, getActiveSources, hasActiveSources } from './modules/context-sources.js';
+import { initContextSources, updateTerminalList, updateBrowserTabList, handleContextSourcesState, getActiveSources, hasActiveSources } from './modules/context-sources.js';
 import { initStickyNotes, handleNotesList, handleNoteCreated, handleNoteUpdated, handleNoteDeleted, openArchive, closeArchive, isArchiveOpen, hideNotes, showNotes, isNotesVisible, createNote } from './modules/sticky-notes.js';
 import { initTheme, getThemeColor, getComputedVar, onThemeChange, getCurrentTheme, getChatLayout } from './modules/theme.js';
 import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionResolved, markPermissionCancelled, renderElicitationRequest, markElicitationResolved, renderPlanBanner, renderPlanCard, handleTodoWrite, handleTaskCreate, handleTaskUpdate, startThinking, appendThinking, stopThinking, resetThinkingGroup, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, addTurnMeta, resetTurnMetaCost, enableMainInput, getTools, getPlanContent, setPlanContent, isPlanFilePath, getTodoTools, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, updateSubagentProgress, initSubagentStop, closeToolGroup, removeToolFromGroup } from './modules/tools.js';
@@ -1121,7 +1121,6 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
 
   // --- MCP Servers ---
   initMcp();
-  initEmailDefaultsModal();
 
   // --- Skills ---
   initSkills();

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -324,6 +324,13 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     currentFullText: "",
     matePreThinkingEl: null,
     // panels
+    fileViewerFullscreen: false,
+    markdownSlidesActive: false,
+    markdownSlideIndex: 0,
+    markdownSlideCount: 0,
+    markdownSlideLevel: 1,
+    markdownSlidePreferredLevel: 1,
+    markdownSlideLevelExplicit: false,
     currentModel: "",
     currentModels: [],
     // Project's last-used vendor; seeds the sidebar's "New session" button.

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -974,9 +974,16 @@
     max-width: 1200px;
   }
   #file-viewer.panel-fullscreen {
+    position: fixed;
+    inset: 0;
     width: 100%;
+    height: 100dvh;
     max-width: none;
     min-width: 0;
+    z-index: 10000;
+    border: 0;
+    background: var(--bg);
+    box-shadow: none;
   }
 }
 
@@ -1036,6 +1043,94 @@
 .file-viewer-btn.hidden { display: none; }
 .file-viewer-btn .lucide { width: 16px; height: 16px; }
 
+.file-viewer-slide-level {
+  width: auto;
+  min-width: 44px;
+  gap: 2px;
+  padding: 0 6px 0 8px;
+  font-family: "Roboto Mono", monospace;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.file-viewer-slide-level .lucide {
+  width: 12px;
+  height: 12px;
+}
+
+.markdown-slide-level-menu {
+  position: fixed;
+  z-index: 10002;
+  width: 248px;
+  padding: 7px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-alt);
+  box-shadow: 0 18px 55px rgba(var(--shadow-rgb), 0.38);
+}
+
+.markdown-slide-level-title {
+  padding: 7px 9px 8px;
+  color: var(--text-dimmer);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.markdown-slide-level-option {
+  display: grid;
+  grid-template-columns: 32px 40px 1fr 16px;
+  align-items: center;
+  width: 100%;
+  min-height: 40px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+}
+
+.markdown-slide-level-option:hover:not(:disabled) {
+  background: var(--sidebar-hover);
+  color: var(--text);
+}
+
+.markdown-slide-level-option:disabled {
+  opacity: 0.36;
+  cursor: default;
+}
+
+.markdown-slide-level-name {
+  color: var(--text);
+  font-family: "Roboto Mono", monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.markdown-slide-level-option code {
+  color: var(--accent);
+  font-family: "Roboto Mono", monospace;
+  font-size: 12px;
+}
+
+.markdown-slide-level-count {
+  font-size: 12px;
+}
+
+.markdown-slide-level-option .lucide {
+  width: 14px;
+  height: 14px;
+  opacity: 0;
+}
+
+.markdown-slide-level-option.selected .lucide {
+  opacity: 1;
+  color: var(--accent);
+}
+
 .file-viewer-live-status {
   display: inline-flex;
   align-items: center;
@@ -1077,6 +1172,231 @@
   font-size: 14px;
   line-height: 1.7;
   color: var(--text);
+}
+
+#file-viewer.panel-fullscreen .file-viewer-header {
+  padding-left: clamp(18px, 3vw, 48px);
+  padding-right: clamp(18px, 3vw, 48px);
+  background: var(--bg);
+}
+
+#file-viewer.panel-fullscreen .file-viewer-body {
+  overscroll-behavior: contain;
+}
+
+#file-viewer.panel-fullscreen .file-viewer-markdown {
+  width: min(100%, 1040px);
+  margin: 0 auto;
+  padding: clamp(36px, 6vh, 72px) clamp(28px, 6vw, 88px) 18vh;
+  font-size: clamp(16px, 1.2vw, 19px);
+  line-height: 1.78;
+}
+
+/* --- H1 slide presentation --- */
+#file-viewer.markdown-slides-active .file-viewer-header {
+  display: none;
+}
+
+#file-viewer.markdown-slides-active .file-viewer-body {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 12% 8%, var(--accent-8), transparent 34%),
+    radial-gradient(circle at 88% 92%, var(--accent-8), transparent 32%),
+    var(--bg);
+}
+
+#file-viewer.markdown-slides-active .file-viewer-markdown {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  font-size: clamp(18px, 1.55vw, 24px);
+  line-height: 1.65;
+}
+
+.markdown-slide-deck {
+  width: 100%;
+  height: 100%;
+}
+
+.markdown-slide {
+  display: none;
+  width: min(1120px, 100%);
+  height: 100%;
+  margin: 0 auto;
+  padding: clamp(72px, 10vh, 128px) clamp(44px, 8vw, 120px) clamp(120px, 16vh, 170px);
+  overflow: auto;
+  flex-direction: column;
+  justify-content: safe center;
+  scrollbar-width: thin;
+}
+
+.markdown-slide.active {
+  display: flex;
+  animation: markdown-slide-forward 0.38s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
+.markdown-slide > * {
+  flex-shrink: 0;
+}
+
+.markdown-slide > .mermaid-diagram {
+  width: 100%;
+  overflow: auto;
+}
+
+.markdown-slide > .mermaid-diagram svg {
+  display: block;
+  margin: 0 auto;
+}
+
+#file-viewer[data-slide-direction="backward"] .markdown-slide.active {
+  animation-name: markdown-slide-backward;
+}
+
+.markdown-slide > .markdown-slide-heading,
+#file-viewer.markdown-slides-active .markdown-slide-cover > h1 {
+  margin: 0 0 0.6em;
+  padding: 0 0 0.28em;
+  border-bottom: 1px solid var(--border-subtle);
+  font-family: "Nunito", sans-serif;
+  font-size: clamp(42px, 6vw, 78px);
+  font-weight: 800;
+  line-height: 1.04;
+  letter-spacing: -0.035em;
+}
+
+.markdown-slide-cover {
+  justify-content: safe center;
+}
+
+.markdown-slide > h2 {
+  margin-top: 1.2em;
+  font-size: 1.45em;
+}
+
+.markdown-slide > p,
+.markdown-slide > ul,
+.markdown-slide > ol,
+.markdown-slide > blockquote {
+  max-width: 920px;
+}
+
+.markdown-slide-controls {
+  position: absolute;
+  left: 50%;
+  bottom: max(24px, env(safe-area-inset-bottom));
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-alt);
+  box-shadow: 0 18px 50px rgba(var(--shadow-rgb), 0.32);
+  transform: translateX(-50%);
+}
+
+.markdown-slide-nav,
+.markdown-slide-exit {
+  height: 36px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.markdown-slide-nav {
+  width: 36px;
+  padding: 0;
+}
+
+.markdown-slide-nav:hover:not(:disabled),
+.markdown-slide-exit:hover {
+  background: var(--sidebar-hover);
+  color: var(--text);
+}
+
+.markdown-slide-nav:disabled {
+  opacity: 0.28;
+  cursor: default;
+}
+
+.markdown-slide-counter {
+  min-width: 52px;
+  color: var(--text);
+  font-family: "Roboto Mono", monospace;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.markdown-slide-progress {
+  width: clamp(70px, 10vw, 140px);
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--border-subtle);
+}
+
+.markdown-slide-progress > span {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width 0.28s ease;
+}
+
+.markdown-slide-exit {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 13px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.markdown-slide-controls .lucide {
+  width: 15px;
+  height: 15px;
+}
+
+@keyframes markdown-slide-forward {
+  from { opacity: 0; transform: translateX(32px) scale(0.992); }
+  to { opacity: 1; transform: translateX(0) scale(1); }
+}
+
+@keyframes markdown-slide-backward {
+  from { opacity: 0; transform: translateX(-32px) scale(0.992); }
+  to { opacity: 1; transform: translateX(0) scale(1); }
+}
+
+@media (max-width: 700px) {
+  .markdown-slide {
+    padding: 64px 24px 112px;
+  }
+  .markdown-slide > h1 {
+    font-size: clamp(36px, 12vw, 56px);
+  }
+  .markdown-slide-progress,
+  .markdown-slide-exit span {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .markdown-slide.active {
+    animation: none;
+  }
+  .markdown-slide-progress > span {
+    transition: none;
+  }
 }
 
 .file-viewer-markdown h1,

--- a/lib/public/css/git-panel.css
+++ b/lib/public/css/git-panel.css
@@ -1,0 +1,424 @@
+/* Project Git panel — compact, information-dense, and native to the sidebar. */
+
+#sidebar-panel-git {
+  background: var(--filebrowser-bg);
+  border: 1px solid var(--filebrowser-border);
+  border-radius: 8px;
+  margin: 6px 6px 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  font-family: "Pretendard", "Twemoji", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+#sidebar-panel-git.hidden { display: none; }
+#sidebar-panel-git.fb-enter { animation: fb-in 0.2s ease-out both; }
+#sidebar-panel-git.fb-exit { animation: fb-out 0.15s ease-in both; }
+#sidebar-panel-git button { font-family: inherit; }
+
+.git-panel-titlebar {
+  display: grid;
+  grid-template-columns: 24px 1fr 24px;
+  align-items: center;
+  gap: 4px;
+  padding: 6px;
+  border-bottom: 1px solid var(--filebrowser-border);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.git-panel-titlebar button,
+.git-icon-btn {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-dimmer);
+  cursor: pointer;
+  padding: 0;
+}
+
+.git-panel-titlebar button:hover,
+.git-icon-btn:hover { color: var(--text); background: var(--sidebar-hover); }
+.git-panel-titlebar svg,
+.git-icon-btn svg { width: 13px; height: 13px; }
+#git-panel-refresh.spinning svg { animation: git-panel-spin 0.65s linear infinite; }
+
+@keyframes git-panel-spin { to { transform: rotate(360deg); } }
+
+.git-panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+.git-panel-loading,
+.git-panel-empty {
+  min-height: 150px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--text-dimmer);
+  text-align: center;
+  font-size: 12px;
+  line-height: 1.5;
+  padding: 18px;
+}
+
+.git-panel-loading { flex-direction: row; min-height: 90px; }
+.git-panel-empty svg { width: 26px; height: 26px; opacity: 0.55; }
+
+.git-panel-spinner {
+  width: 13px;
+  height: 13px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: git-panel-spin 0.7s linear infinite;
+}
+
+.git-repo-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-alt);
+  padding: 9px;
+  margin-bottom: 9px;
+  flex-shrink: 0;
+}
+
+.git-repo-primary {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+
+.git-repo-primary > svg { width: 15px; height: 15px; color: var(--accent); flex-shrink: 0; }
+.git-repo-name { color: var(--text); font-size: 12px; font-weight: 800; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.git-branch-name { color: var(--text-muted); font-size: 11px; font-weight: 500; line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.git-badges { display: flex; gap: 4px; margin: 7px 0 0 22px; flex-wrap: wrap; }
+.git-badge {
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-dimmer);
+  background: var(--bg);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.git-badge.detached { color: var(--warning, #d89b42); }
+
+.git-origin,
+.git-repo-path {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--text-dimmer);
+  font-size: 10px;
+  font-weight: 450;
+  line-height: 1.3;
+}
+.git-repo-path { margin-top: 7px; }
+.git-origin { margin-top: 7px; padding-top: 7px; border-top: 1px solid var(--border-subtle); }
+.git-origin svg,
+.git-repo-path svg { width: 12px; height: 12px; flex-shrink: 0; }
+.git-origin span,
+.git-repo-path span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.git-sync-row { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-bottom: 12px; flex-shrink: 0; }
+.git-action-btn {
+  min-height: 30px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--bg-alt);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  cursor: pointer;
+  padding: 5px 8px;
+}
+.git-action-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--text); }
+.git-action-btn:disabled { opacity: 0.42; cursor: default; }
+.git-action-btn svg { width: 13px; height: 13px; }
+.git-sync-count { color: var(--accent); font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums; }
+
+.git-review-all {
+  width: 100%;
+  min-height: 36px;
+  margin-bottom: 9px;
+  padding: 7px 9px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border-subtle));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg));
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  font-size: 10px;
+  flex-shrink: 0;
+}
+.git-review-all:hover { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, var(--bg)); }
+.git-review-all > span { display: inline-flex; align-items: center; gap: 6px; }
+.git-review-all svg { width: 12px; height: 12px; color: var(--accent); }
+.git-review-count { color: var(--text-dimmer); font-size: 9px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.git-review-count svg { width: 9px; height: 9px; color: currentColor; }
+
+.git-section {
+  min-height: 0;
+  margin-bottom: 11px;
+  display: flex;
+  flex-direction: column;
+}
+.git-section-staged { flex: 0 1 auto; max-height: 32%; }
+.git-section-changes { flex: 1 1 120px; }
+.git-section-only { flex: 1 1 120px; max-height: none; }
+.git-section-header {
+  min-height: 25px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 2px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.git-section-count { color: var(--text-dimmer); font-size: 9px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.git-section-header .git-action-btn { min-height: 22px; margin-left: auto; padding: 2px 7px; font-size: 9px; }
+
+.git-file-list {
+  min-height: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+.git-file-row {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr) 27px;
+  min-height: 42px;
+  align-items: center;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border-subtle);
+  cursor: pointer;
+  transition: background-color 180ms ease, box-shadow 180ms ease;
+}
+.git-file-row:last-child { border-bottom: 0; }
+.git-file-row:hover { background: var(--sidebar-hover); }
+.git-file-row.active {
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg));
+  box-shadow: inset 2px 0 0 color-mix(in srgb, var(--accent) 70%, transparent);
+}
+.git-file-status {
+  text-align: center;
+  color: var(--text-dimmer);
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 750;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.git-file-status.untracked { color: #48a868; }
+.git-file-status.conflicted { color: var(--danger, #d85b5b); }
+.git-file-main { min-width: 0; padding: 5px 2px; cursor: pointer; outline: none; }
+.git-file-main:focus-visible { border-radius: 4px; box-shadow: 0 0 0 1px var(--accent); }
+.git-file-name { color: var(--text); font-size: 11px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.git-file-subline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  margin-top: 1px;
+  height: 14px;
+  color: var(--text-dimmer);
+  font-size: 9px;
+  font-weight: 450;
+  line-height: 1.2;
+}
+.git-file-dir { min-width: 24px; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.git-file-meta-separator { flex-shrink: 0; color: var(--border); }
+.git-session-link {
+  min-width: 0;
+  max-width: 92px;
+  border: 0;
+  background: transparent;
+  color: var(--text-dimmer);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  overflow: hidden;
+  flex-shrink: 1;
+  font: inherit;
+  letter-spacing: 0;
+  text-align: left;
+}
+.git-session-link span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.git-session-link:hover:not(:disabled) { color: var(--accent); }
+.git-session-link:disabled { cursor: default; }
+.git-file-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+  max-height: 0;
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 1px solid transparent;
+  opacity: 0;
+  overflow: hidden;
+  visibility: hidden;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition:
+    max-height 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    margin-top 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    padding-top 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 160ms ease,
+    opacity 140ms ease,
+    transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    visibility 0s linear 220ms;
+}
+.git-file-actions.open {
+  max-height: 64px;
+  margin-top: 5px;
+  padding-top: 5px;
+  border-top-color: var(--border-subtle);
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+  transition-delay: 0s;
+}
+.git-file-text-action {
+  min-width: 0;
+  min-height: 26px;
+  padding: 3px 5px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: var(--bg-alt);
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 550;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.git-file-actions > .git-file-text-action:only-child { grid-column: 1 / -1; }
+.git-file-text-action-wide { grid-column: 1 / -1; }
+.git-file-text-action:hover { color: var(--text); border-color: var(--accent); }
+.git-file-text-action svg { width: 11px; height: 11px; color: var(--accent); flex-shrink: 0; }
+
+@media (prefers-reduced-motion: reduce) {
+  .git-file-row,
+  .git-file-actions { transition: none; }
+}
+
+.git-diff-review-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  color: var(--text-dimmer);
+  font-family: "Pretendard", "Twemoji", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.git-diff-review-nav button {
+  min-width: 25px;
+  height: 24px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+.git-diff-review-nav button:hover:not(:disabled) { border-color: var(--accent); color: var(--text); }
+.git-diff-review-nav button:disabled { opacity: 0.35; cursor: default; }
+.git-diff-review-nav .git-diff-ask-agent {
+  width: auto;
+  padding: 0 7px;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  border-color: var(--border-subtle);
+  color: var(--text-muted);
+}
+.git-diff-review-nav .git-diff-ask-agent svg { width: 11px; height: 11px; color: var(--accent); }
+.git-diff-review-nav .git-diff-ask-agent:hover { background: var(--sidebar-hover); }
+
+.git-agent-commit {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 10px;
+  margin-top: 5px;
+  flex-shrink: 0;
+}
+
+.git-agent-commit-copy {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.git-agent-commit-icon {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--border-subtle));
+  border-radius: 8px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg));
+}
+.git-agent-commit-icon svg { width: 14px; height: 14px; }
+.git-agent-commit-copy strong { display: block; color: var(--text); font-size: 11px; line-height: 1.3; }
+.git-agent-commit-copy span:not(.git-agent-commit-icon) { display: block; color: var(--text-dimmer); font-size: 9px; line-height: 1.4; margin-top: 2px; }
+.git-agent-commit-btn { width: 100%; background: var(--accent); border-color: var(--accent); color: #fff; }
+.git-agent-commit-btn:hover:not(:disabled) { color: #fff; filter: brightness(1.05); }
+.git-next-action { padding-top: 8px; }
+
+.git-panel-error {
+  margin-bottom: 8px;
+  padding: 7px 8px;
+  border: 1px solid color-mix(in srgb, var(--danger, #d85b5b) 35%, transparent);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--danger, #d85b5b) 8%, transparent);
+  color: var(--danger, #d85b5b);
+  font-size: 10px;
+  line-height: 1.4;
+  word-break: break-word;
+}

--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -512,9 +512,6 @@
 }
 
 /* --- Email setup modal --- */
-#email-defaults-modal { position: fixed; inset: 0; z-index: 300; display: flex; align-items: center; justify-content: center; }
-#email-defaults-modal.hidden { display: none; }
-
 .email-setup-overlay {
   position: fixed;
   inset: 0;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -1705,21 +1705,6 @@
   </div>
 </div>
 
-<!-- Email Defaults Modal -->
-<div id="email-defaults-modal" class="hidden">
-  <div class="confirm-backdrop"></div>
-  <div class="confirm-dialog mcp-dialog">
-    <div class="mcp-header">
-      <span class="mcp-title"><i data-lucide="mail"></i> Email</span>
-      <button class="skills-close" id="email-defaults-close"><i data-lucide="x"></i></button>
-    </div>
-    <div class="mcp-content" id="email-defaults-content">
-      <p class="mcp-desc">Toggle email accounts to auto-enable them for every new session in this project.</p>
-      <div id="email-defaults-list"></div>
-    </div>
-  </div>
-</div>
-
 <!-- Debate Modal (Wizard) -->
 <div id="debate-modal" class="hidden">
   <div class="debate-modal-backdrop"></div>

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -642,6 +642,8 @@
       </span>
       <button class="file-viewer-btn hidden" id="file-viewer-render" title="Toggle rendered view"><i data-lucide="book-open"></i></button>
       <button class="file-viewer-btn hidden" id="file-viewer-pdf" title="Export PDF"><i data-lucide="file-down"></i></button>
+      <button class="file-viewer-btn hidden" id="file-viewer-slides" title="Present as slides" aria-label="Present Markdown as slides" aria-pressed="false"><i data-lucide="presentation"></i></button>
+      <button class="file-viewer-btn file-viewer-slide-level hidden" id="file-viewer-slide-level" title="Split slides by heading level" aria-haspopup="menu" aria-expanded="false"><span>H1</span><i data-lucide="chevron-down"></i></button>
       <button class="file-viewer-btn hidden" id="file-viewer-history" title="Edit history"><i data-lucide="clock"></i></button>
       <button class="file-viewer-btn" id="file-viewer-refresh" title="Refresh"><i data-lucide="refresh-cw"></i></button>
       <button class="file-viewer-btn" id="file-viewer-copy" title="Copy contents" aria-label="Copy contents"><i data-lucide="copy"></i></button>

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -268,6 +268,16 @@
             <kbd>&#8629;</kbd><span>open</span>
           </div>
         </div>
+        <div id="sidebar-panel-git" class="sidebar-panel hidden">
+          <div class="git-panel-titlebar">
+            <button id="git-panel-refresh" type="button" title="Refresh Git status"><i data-lucide="refresh-cw"></i></button>
+            <span>Git</span>
+            <button id="git-panel-close" type="button" title="Close Git panel"><i data-lucide="x"></i></button>
+          </div>
+          <div id="git-panel-body" class="git-panel-body">
+            <div class="git-panel-loading"><span class="git-panel-spinner"></span> Reading repository</div>
+          </div>
+        </div>
       </div>
     </div>
     <div id="sidebar-resize-handle"></div>

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -33,7 +33,7 @@ import { handleTermList, handleTermCreated, sendTerminalCommand, handleTermOutpu
 import { attachTuiView, detachTuiView, setTuiSuspendedView, tuiHandleTermOutput, tuiHandleTermResized, tuiHandleTermExited, tuiHandleTermClosed } from './session-tui-view.js';
 import { handleTuiTranscriptState } from './tui-grab.js';
 import { tuiModalHandleTermOutput, tuiModalHandleTermResized, tuiModalHandleTermExited, tuiModalHandleTermClosed, openTuiModal } from './tui-attention.js';
-import { updateTerminalList, handleContextSourcesState, updateEmailAccountList, updateEmailUnreadCounts, handleEmailTestResult, handleEmailAddResult, handleEmailRemoveResult, handleEmailDefaults } from './context-sources.js';
+import { updateTerminalList, handleContextSourcesState, updateEmailAccountList, updateEmailUnreadCounts, handleEmailTestResult, handleEmailAddResult, handleEmailRemoveResult } from './context-sources.js';
 import { refreshEmailSettings } from './user-settings.js';
 import { handleNotesList, handleNoteCreated, handleNoteUpdated, handleNoteDeleted, handleNoteWritten } from './sticky-notes.js';
 import { handleSkillInstalled, handleSkillUninstalled } from './skills.js';
@@ -1391,10 +1391,6 @@ export function processMessage(msg) {
 
       case "email_account_remove_result":
         handleEmailRemoveResult(msg);
-        break;
-
-      case "email_defaults":
-        handleEmailDefaults(msg);
         break;
 
       case "extension_command":

--- a/lib/public/modules/context-sources.js
+++ b/lib/public/modules/context-sources.js
@@ -10,7 +10,6 @@ var emailUnreadCounts = {}; // accountId -> unread count
 var _emailTestPassed = false;
 var _emailPendingSave = false;
 var _emailDoSave = null; // set by showEmailSetupModal
-var emailDefaultAccountIds = []; // project-level defaults
 
 export function initContextSources(_ctx) {
   ctx = _ctx;
@@ -756,95 +755,6 @@ export function getActiveSources() {
 // Check if any sources are active
 export function hasActiveSources() {
   return activeSourceIds.size > 0;
-}
-
-// --- Email Defaults Modal (project-level) ---
-
-export function handleEmailDefaults(msg) {
-  emailDefaultAccountIds = msg.accounts || [];
-  renderEmailDefaultsList();
-}
-
-export function initEmailDefaultsModal() {
-  var btn = document.getElementById("email-sidebar-btn");
-  var modal = document.getElementById("email-defaults-modal");
-  var closeBtn = document.getElementById("email-defaults-close");
-  if (!btn || !modal) return;
-
-  btn.addEventListener("click", function () {
-    modal.classList.remove("hidden");
-    // Request current defaults from server
-    if (ctx && ctx.ws && ctx.connected) {
-      ctx.ws.send(JSON.stringify({ type: "email_defaults_get" }));
-    }
-    renderEmailDefaultsList();
-    if (typeof lucide !== "undefined") lucide.createIcons();
-  });
-
-  if (closeBtn) {
-    closeBtn.addEventListener("click", function () {
-      modal.classList.add("hidden");
-    });
-  }
-
-  var backdrop = modal.querySelector(".confirm-backdrop");
-  if (backdrop) {
-    backdrop.addEventListener("click", function () {
-      modal.classList.add("hidden");
-    });
-  }
-}
-
-function renderEmailDefaultsList() {
-  var listEl = document.getElementById("email-defaults-list");
-  if (!listEl) return;
-  listEl.innerHTML = "";
-
-  if (emailAccountList.length === 0) {
-    var emptyEl = document.createElement("div");
-    emptyEl.className = "mcp-empty";
-    emptyEl.innerHTML = '<p>No email accounts connected.</p>' +
-      '<button class="us-email-add-btn" type="button" style="margin:12px auto 0">+ Add Account</button>';
-    var addBtn = emptyEl.querySelector("button");
-    addBtn.addEventListener("click", function () {
-      document.getElementById("email-defaults-modal").classList.add("hidden");
-      showEmailSetupModal();
-    });
-    listEl.appendChild(emptyEl);
-    return;
-  }
-
-  for (var i = 0; i < emailAccountList.length; i++) {
-    var acc = emailAccountList[i];
-    var isOn = emailDefaultAccountIds.indexOf(acc.id) !== -1;
-
-    var row = document.createElement("label");
-    row.className = "settings-toggle-row";
-    row.innerHTML =
-      '<div>' +
-        '<span class="settings-label">' + escapeHtml(acc.email) + '</span>' +
-        '<div class="settings-hint">' + escapeHtml(acc.label || acc.provider || "Custom") + '</div>' +
-      '</div>' +
-      '<input type="checkbox" data-account-id="' + escapeHtml(acc.id) + '"' + (isOn ? ' checked' : '') + '>' +
-      '<span class="toggle-track"><span class="toggle-thumb"></span></span>';
-
-    var checkbox = row.querySelector("input");
-    checkbox.addEventListener("change", function () {
-      var accId = this.getAttribute("data-account-id");
-      var idx = emailDefaultAccountIds.indexOf(accId);
-      if (this.checked && idx === -1) {
-        emailDefaultAccountIds.push(accId);
-      } else if (!this.checked && idx !== -1) {
-        emailDefaultAccountIds.splice(idx, 1);
-      }
-      // Save to server
-      if (ctx && ctx.ws && ctx.connected) {
-        ctx.ws.send(JSON.stringify({ type: "email_defaults_save", accounts: emailDefaultAccountIds }));
-      }
-    });
-
-    listEl.appendChild(row);
-  }
 }
 
 function escapeHtml(str) {

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -521,6 +521,23 @@ export function openFile(filePath, opts) {
   requestFileContent(filePath);
 }
 
+export function openWorkingTreeDiff(diff) {
+  if (!diff || !diff.path) return;
+  pendingRenderedOpen = false;
+  pendingOpenMode = diff.binary ? null : {
+    type: "diff",
+    oldStr: diff.oldContent || "",
+    newStr: diff.newContent || "",
+    review: diff.review || null,
+  };
+  showFileContent({
+    path: diff.path,
+    content: diff.newContent || "",
+    size: (diff.newContent || "").length,
+    binary: !!diff.binary,
+  });
+}
+
 export function presentMarkdownEdit(msg) {
   if (!msg || !beginMarkdownPresentation(msg.path)) return;
   pendingOpenMode = null;
@@ -1099,7 +1116,7 @@ function showFileContent(msg) {
     historyBtn2.classList.add("hidden");
     historyBtn2.classList.remove("active");
     requestFileHistory(msg.path);
-    showInlineDiff(diffOpts.oldStr, diffOpts.newStr);
+    showInlineDiff(diffOpts.oldStr, diffOpts.newStr, diffOpts.review);
     pendingRenderedOpen = false;
     return;
   }
@@ -1141,7 +1158,7 @@ export function handleFileChanged(msg) {
   if (bodyEl) bodyEl.scrollTop = scrollPos;
 }
 
-function showInlineDiff(oldStr, newStr) {
+function showInlineDiff(oldStr, newStr, review) {
   var bodyEl = document.getElementById("file-viewer-body");
   inlineDiffActive = true;
   ctx.fileViewerEl.classList.add("file-viewer-wide");
@@ -1177,6 +1194,40 @@ function showInlineDiff(oldStr, newStr) {
       rerenderFileContent();
     });
     topBar.appendChild(backBtn);
+
+    if (review) {
+      var reviewNav = document.createElement("div");
+      reviewNav.className = "git-diff-review-nav";
+      var reviewCount = document.createElement("span");
+      reviewCount.textContent = (review.index + 1) + " of " + review.total;
+      reviewNav.appendChild(reviewCount);
+      var previousBtn = document.createElement("button");
+      previousBtn.type = "button";
+      previousBtn.textContent = "\u2190";
+      previousBtn.title = "Previous changed file";
+      previousBtn.disabled = !review.previous;
+      if (review.previous) previousBtn.addEventListener("click", review.previous);
+      reviewNav.appendChild(previousBtn);
+      var nextBtn = document.createElement("button");
+      nextBtn.type = "button";
+      nextBtn.textContent = "\u2192";
+      nextBtn.title = "Next changed file";
+      nextBtn.disabled = !review.next;
+      if (review.next) nextBtn.addEventListener("click", review.next);
+      reviewNav.appendChild(nextBtn);
+      if (review.askAgent) {
+        var askBtn = document.createElement("button");
+        askBtn.type = "button";
+        askBtn.className = "git-diff-ask-agent";
+        askBtn.innerHTML = iconHtml("sparkles") + "<span>Review with Agent</span>";
+        askBtn.setAttribute("data-tip", "Start a new agent session to review this file's current Git changes");
+        askBtn.setAttribute("aria-label", "Review this file's Git changes with an agent");
+        askBtn.addEventListener("click", review.askAgent);
+        reviewNav.appendChild(askBtn);
+        refreshIcons(askBtn);
+      }
+      topBar.appendChild(reviewNav);
+    }
 
     var toggleWrap = document.createElement("div");
     toggleWrap.className = "file-history-view-toggle";

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -7,6 +7,8 @@ import { renderUnifiedDiff, renderSplitDiff } from './diff.js';
 import { initFileIcons, getFileIconSvg, getFolderIconSvg } from './fileicons.js';
 import { copyMarkdownFormatting } from './rich-clipboard.js';
 import { animateMarkdownChange, beginMarkdownPresentation, cancelMarkdownFollow, isFollowingMarkdown } from './markdown-live-edit.js';
+import { store } from './store.js';
+import { enterMarkdownSlides, exitMarkdownSlides, handleMarkdownSlideKey, syncMarkdownSlidesButton, toggleMarkdownSlideLevelMenu } from './markdown-slides.js';
 
 var ctx;
 var showDropHint = function () {};
@@ -134,14 +136,26 @@ export function initFileBrowser(_ctx) {
     closeFileViewer();
   });
 
-  // Fullscreen toggle
-  document.getElementById("file-viewer-fullscreen").addEventListener("click", function () {
-    var isFs = ctx.fileViewerEl.classList.toggle("panel-fullscreen");
-    var icon = this.querySelector("[data-lucide]");
-    if (icon) {
-      icon.setAttribute("data-lucide", isFs ? "minimize-2" : "maximize-2");
-      refreshIcons();
+  // Full-viewport presentation toggle
+  var fullscreenBtn = document.getElementById("file-viewer-fullscreen");
+  fullscreenBtn.setAttribute("aria-pressed", "false");
+  fullscreenBtn.addEventListener("click", function () {
+    if (store.get('markdownSlidesActive')) exitMarkdownSlides();
+    setFileViewerFullscreen(!store.get('fileViewerFullscreen'));
+  });
+
+  document.getElementById("file-viewer-slides").addEventListener("click", function () {
+    if (store.get('markdownSlidesActive')) {
+      exitMarkdownSlides();
+      return;
     }
+    var markdownEl = document.querySelector("#file-viewer-body .file-viewer-markdown");
+    if (enterMarkdownSlides(markdownEl, 0)) setFileViewerFullscreen(true);
+  });
+
+  document.getElementById("file-viewer-slide-level").addEventListener("click", function () {
+    var markdownEl = document.querySelector("#file-viewer-body .file-viewer-markdown");
+    toggleMarkdownSlideLevelMenu(markdownEl);
   });
 
   // Copy button
@@ -221,7 +235,13 @@ export function initFileBrowser(_ctx) {
 
   // ESC to close
   document.addEventListener("keydown", function (e) {
+    if (handleMarkdownSlideKey(e)) return;
     if (e.key === "Escape" && !ctx.fileViewerEl.classList.contains("hidden")) {
+      if (store.get('fileViewerFullscreen')) {
+        e.preventDefault();
+        setFileViewerFullscreen(false);
+        return;
+      }
       closeFileViewer();
     }
   });
@@ -412,13 +432,25 @@ export function closeFileViewer() {
   if (currentFilePath && isFollowingMarkdown(currentFilePath)) cancelMarkdownFollow();
   sendUnwatch();
   inlineDiffActive = false;
+  exitMarkdownSlides();
   ctx.fileViewerEl.classList.remove("file-viewer-wide");
-  ctx.fileViewerEl.classList.remove("panel-fullscreen");
+  setFileViewerFullscreen(false);
   ctx.fileViewerEl.classList.add("hidden");
-  // Reset fullscreen icon
-  var fsIcon = document.querySelector("#file-viewer-fullscreen [data-lucide]");
-  if (fsIcon) {
-    fsIcon.setAttribute("data-lucide", "maximize-2");
+}
+
+export function setFileViewerFullscreen(enabled) {
+  var isFullscreen = !!enabled;
+  var viewer = ctx && ctx.fileViewerEl ? ctx.fileViewerEl : document.getElementById("file-viewer");
+  var button = document.getElementById("file-viewer-fullscreen");
+  if (viewer) viewer.classList.toggle("panel-fullscreen", isFullscreen);
+  store.set({ fileViewerFullscreen: isFullscreen });
+  if (!button) return;
+  button.setAttribute("aria-pressed", isFullscreen ? "true" : "false");
+  button.setAttribute("aria-label", isFullscreen ? "Exit presentation mode" : "Enter presentation mode");
+  button.title = isFullscreen ? "Exit presentation mode (Esc)" : "Enter presentation mode";
+  var icon = button.querySelector("[data-lucide]");
+  if (icon) {
+    icon.setAttribute("data-lucide", isFullscreen ? "minimize-2" : "maximize-2");
     refreshIcons();
   }
 }
@@ -486,11 +518,14 @@ function followedFileChanged(filePath) {
   return currentFilePath && isFollowingMarkdown(currentFilePath) && !isFollowingMarkdown(filePath);
 }
 
-function renderBody(previousMarkdown) {
+function renderBody(previousMarkdown, requestedSlideIndex) {
   var bodyEl = document.getElementById("file-viewer-body");
   var renderBtn = document.getElementById("file-viewer-render");
   var pdfBtn = document.getElementById("file-viewer-pdf");
   var formattedCopyBtn = document.getElementById("file-viewer-copy-formatted");
+  var resumeSlides = store.get('markdownSlidesActive') || typeof requestedSlideIndex === "number";
+  var resumeSlideIndex = typeof requestedSlideIndex === "number" ? requestedSlideIndex : (store.get('markdownSlideIndex') || 0);
+  if (store.get('markdownSlidesActive')) exitMarkdownSlides();
 
   if (isRendered) {
     bodyEl.innerHTML = '<div class="file-viewer-markdown">' + renderMarkdown(currentContent) + '</div>';
@@ -510,6 +545,8 @@ function renderBody(previousMarkdown) {
     }
     highlightCodeBlocks(bodyEl);
     renderMermaidBlocks(bodyEl);
+    var slideCount = syncMarkdownSlidesButton(markdownEl);
+    if (resumeSlides && slideCount > 0) enterMarkdownSlides(markdownEl, resumeSlideIndex);
     renderBtn.classList.add("active");
     renderBtn.title = "Show raw";
     pdfBtn.classList.remove("hidden");
@@ -529,6 +566,7 @@ function renderBody(previousMarkdown) {
     renderBtn.title = "Render markdown";
     pdfBtn.classList.add("hidden");
     formattedCopyBtn.classList.add("hidden");
+    syncMarkdownSlidesButton(null);
   }
   refreshIcons();
 }
@@ -964,6 +1002,11 @@ function showFileContent(msg) {
   var previousContent = currentContent;
   var previousPath = currentFilePath;
   var previousWasMarkdown = currentIsMarkdown;
+  var refreshSlideIndex = pendingRefresh && store.get('markdownSlidesActive')
+    ? store.get('markdownSlideIndex') || 0
+    : null;
+
+  exitMarkdownSlides();
 
   pathEl.textContent = msg.path;
   var keepRenderState = pendingRefresh && msg.path === currentFilePath;
@@ -982,6 +1025,7 @@ function showFileContent(msg) {
   renderBtn.classList.remove("active");
   document.getElementById("file-viewer-pdf").classList.add("hidden");
   document.getElementById("file-viewer-copy-formatted").classList.add("hidden");
+  document.getElementById("file-viewer-slides").classList.add("hidden");
 
   if (msg.error) {
     bodyEl.innerHTML = '<div class="file-tree-error">' + escapeHtml(msg.error) + '</div>';
@@ -1011,7 +1055,7 @@ function showFileContent(msg) {
         isFollowingMarkdown(msg.path) && pathsReferToSameFile(previousPath, msg.path)
         ? (previousContent == null ? "" : previousContent)
         : null;
-      renderBody(transitionFrom);
+      renderBody(transitionFrom, refreshSlideIndex);
     } else {
       renderCodeWithLineNumbers(bodyEl, msg.content, ext);
     }

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -149,12 +149,12 @@ export function initFileBrowser(_ctx) {
       exitMarkdownSlides();
       return;
     }
-    var markdownEl = document.querySelector("#file-viewer-body .file-viewer-markdown");
+    var markdownEl = ensureRenderedMarkdown();
     if (enterMarkdownSlides(markdownEl, 0)) setFileViewerFullscreen(true);
   });
 
   document.getElementById("file-viewer-slide-level").addEventListener("click", function () {
-    var markdownEl = document.querySelector("#file-viewer-body .file-viewer-markdown");
+    var markdownEl = markdownElementForActions();
     toggleMarkdownSlideLevelMenu(markdownEl);
   });
 
@@ -164,7 +164,7 @@ export function initFileBrowser(_ctx) {
   });
 
   document.getElementById("file-viewer-copy-formatted").addEventListener("click", function () {
-    if (!isRendered || !currentIsMarkdown) return;
+    if (!currentIsMarkdown) return;
     copyMarkdownFormatting(currentContent).catch(function (err) {
       console.error("Markdown formatting copy failed:", err);
     });
@@ -180,8 +180,8 @@ export function initFileBrowser(_ctx) {
 
   // PDF export button
   document.getElementById("file-viewer-pdf").addEventListener("click", function () {
-    if (!isRendered || !currentIsMarkdown) return;
-    var mdEl = document.querySelector(".file-viewer-markdown");
+    if (!currentIsMarkdown) return;
+    var mdEl = ensureRenderedMarkdown();
     if (!mdEl) return;
     var btn = document.getElementById("file-viewer-pdf");
     btn.disabled = true;
@@ -428,6 +428,25 @@ function sendUnwatch() {
   }
 }
 
+function markdownElementForActions() {
+  var rendered = document.querySelector("#file-viewer-body .file-viewer-markdown");
+  if (rendered) return rendered;
+  if (!currentIsMarkdown || currentContent == null) return null;
+  var preview = document.createElement("div");
+  preview.className = "file-viewer-markdown";
+  preview.innerHTML = renderMarkdown(currentContent);
+  return preview;
+}
+
+function ensureRenderedMarkdown() {
+  if (!currentIsMarkdown || currentContent == null) return null;
+  if (!isRendered) {
+    isRendered = true;
+    renderBody();
+  }
+  return document.querySelector("#file-viewer-body .file-viewer-markdown");
+}
+
 export function closeFileViewer() {
   if (currentFilePath && isFollowingMarkdown(currentFilePath)) cancelMarkdownFollow();
   sendUnwatch();
@@ -564,9 +583,9 @@ function renderBody(previousMarkdown, requestedSlideIndex) {
     }
     renderBtn.classList.remove("active");
     renderBtn.title = "Render markdown";
-    pdfBtn.classList.add("hidden");
-    formattedCopyBtn.classList.add("hidden");
-    syncMarkdownSlidesButton(null);
+    pdfBtn.classList.remove("hidden");
+    formattedCopyBtn.classList.remove("hidden");
+    syncMarkdownSlidesButton(markdownElementForActions());
   }
   refreshIcons();
 }

--- a/lib/public/modules/git-panel.js
+++ b/lib/public/modules/git-panel.js
@@ -1,0 +1,456 @@
+import { store } from './store.js';
+import { refreshIcons, iconHtml } from './icons.js';
+import { escapeHtml, showToast } from './utils.js';
+import { openWorkingTreeDiff } from './filebrowser.js';
+import { sendTextMessage } from './input.js';
+import { resolveDefaultVendor, startNewSession } from './sidebar-sessions.js';
+import { getWs } from './ws-ref.js';
+
+var currentStatus = null;
+var busy = false;
+var lastError = "";
+var statusBasePath = null;
+var expandedFileActionsPath = null;
+
+function apiPath(path) {
+  return store.get('basePath') + "api/git/" + path;
+}
+
+function requestJson(url, options) {
+  return fetch(url, options).then(function (response) {
+    return response.json().catch(function () { return {}; }).then(function (body) {
+      if (!response.ok || body.error) throw new Error(body.error || "Git request failed");
+      return body;
+    });
+  });
+}
+
+function shortOrigin(origin) {
+  if (!origin) return "No origin configured";
+  return origin
+    .replace(/^git@([^:]+):/, "$1/")
+    .replace(/^https?:\/\//, "")
+    .replace(/\.git$/, "");
+}
+
+function splitFilePath(filePath) {
+  var slash = filePath.lastIndexOf("/");
+  if (slash === -1) return { name: filePath, dir: "" };
+  return { name: filePath.slice(slash + 1), dir: filePath.slice(0, slash + 1) };
+}
+
+function fileStatusLabel(file, staged) {
+  if (file.conflicted) return "!";
+  if (file.untracked) return "U";
+  var code = staged ? file.code.charAt(0) : file.code.charAt(1);
+  return code === "." ? "M" : code;
+}
+
+function compactSessionTitle(title) {
+  var value = String(title || "Agent session").replace(/\s+/g, " ").trim();
+  if (/^Review the current uncommitted changes/i.test(value)) return "File review";
+  if (/^Create a Git commit for the currently staged changes/i.test(value)) return "Commit session";
+  return value;
+}
+
+function renderFileMeta(file, directory) {
+  var sessions = Array.isArray(file.sessions) ? file.sessions : [];
+  var first = sessions.length > 0 ? sessions[0] : null;
+  var html = '<div class="git-file-subline">' +
+    (directory ? '<span class="git-file-dir">' + escapeHtml(directory) + '</span>' : '<span class="git-file-dir">Project root</span>');
+  if (first) {
+    var title = first.title || "Agent session";
+    var compactTitle = compactSessionTitle(title);
+    var timing = first.preExisting
+      ? "This file already had changes when the session started"
+      : "This file became changed during the session";
+    html += '<span class="git-file-meta-separator">\u00b7</span>' +
+      '<button type="button" class="git-session-link" data-git-session-id="' + (first.sessionId == null ? '' : first.sessionId) + '"' +
+        (first.sessionId == null ? ' disabled' : '') + ' data-tip="Return to ' + escapeHtml(title) + '\n' + timing + '">' +
+        '<span>' + escapeHtml(compactTitle) + (sessions.length > 1 ? ' +' + (sessions.length - 1) : '') + '</span></button>';
+  }
+  var actionsOpen = expandedFileActionsPath === file.path;
+  html += '</div><div class="git-file-actions' + (actionsOpen ? ' open' : '') + '" aria-hidden="' + (actionsOpen ? 'false' : 'true') + '">' +
+    '<button type="button" data-git-open-diff="' + encodeURIComponent(file.path) + '" class="git-file-text-action">' +
+      iconHtml("file-diff") + '<span>Open diff</span></button>';
+  if (first) {
+    html += '<button type="button" data-git-session-key="' + encodeURIComponent(first.key) + '" data-git-path="' + encodeURIComponent(file.path) + '" class="git-file-text-action git-session-compare">' +
+      iconHtml("history") + '<span>Compare to start</span></button>';
+  }
+  html += '<button type="button" data-git-agent-review="' + encodeURIComponent(file.path) + '" class="git-file-text-action' + (first ? ' git-file-text-action-wide' : '') + '">' +
+      iconHtml("sparkles") + '<span>Review with Agent</span></button></div>';
+  return html;
+}
+
+function renderFileRow(file, staged) {
+  var parts = splitFilePath(file.path);
+  var pathKey = encodeURIComponent(file.path);
+  var statusClass = file.conflicted ? " conflicted" : (file.untracked ? " untracked" : "");
+  var action = staged ? "unstage" : "stage";
+  var actionTitle = staged ? "Unstage file — keep its changes" : "Stage file for commit";
+  var actionIcon = staged ? "minus" : "plus";
+  var actionsOpen = expandedFileActionsPath === file.path;
+  return '<div class="git-file-row' + (actionsOpen ? ' active' : '') + '">' +
+    '<span class="git-file-status' + statusClass + '">' + escapeHtml(fileStatusLabel(file, staged)) + '</span>' +
+    '<div class="git-file-main" data-git-file-item="' + pathKey + '" tabindex="0" aria-label="File actions for ' + escapeHtml(parts.name) + '" aria-expanded="' + (actionsOpen ? 'true' : 'false') + '">' +
+      '<div class="git-file-name">' + escapeHtml(parts.name) + '</div>' +
+      renderFileMeta(file, parts.dir) +
+    '</div>' +
+    '<button type="button" class="git-icon-btn git-file-action" data-git-action="' + action + '" data-git-path="' + pathKey + '" data-tip="' + actionTitle + '" aria-label="' + actionTitle + '"' + (busy ? ' disabled' : '') + '>' +
+      iconHtml(actionIcon) +
+    '</button>' +
+  '</div>';
+}
+
+function renderFileSection(title, files, staged, onlySection) {
+  if (files.length === 0) return "";
+  var bulkAction = staged ? "unstage_all" : "stage_all";
+  var bulkLabel = staged ? "Unstage all" : "Stage all";
+  var sectionClass = staged ? " git-section-staged" : " git-section-changes";
+  if (onlySection) sectionClass += " git-section-only";
+  var html = '<section class="git-section' + sectionClass + '">' +
+    '<div class="git-section-header"><span>' + title + '</span><span class="git-section-count">' + files.length + '</span>' +
+      '<button type="button" class="git-action-btn" data-git-action="' + bulkAction + '"' + (busy ? ' disabled' : '') + '>' + bulkLabel + '</button>' +
+    '</div><div class="git-file-list">';
+  for (var i = 0; i < files.length; i++) html += renderFileRow(files[i], staged);
+  return html + '</div></section>';
+}
+
+function renderRepository(status) {
+  var staged = [];
+  var unstaged = [];
+  for (var i = 0; i < status.files.length; i++) {
+    if (status.files[i].staged) staged.push(status.files[i]);
+    if (status.files[i].unstaged || status.files[i].untracked) unstaged.push(status.files[i]);
+  }
+  var branchLabel = status.detached ? "Detached at " + String(status.oid || "").slice(0, 8) : (status.branch || "No commits yet");
+  var badges = "";
+  if (status.isWorktree) badges += '<span class="git-badge">Linked worktree</span>';
+  else if (status.worktrees && status.worktrees.length > 1) badges += '<span class="git-badge">Main checkout</span>';
+  if (status.detached) badges += '<span class="git-badge detached">Detached HEAD</span>';
+
+  var pullDisabled = busy || !status.upstream;
+  var pushDisabled = busy || !status.origin || status.detached;
+  var html = lastError ? '<div class="git-panel-error">' + escapeHtml(lastError) + '</div>' : '';
+  html += '<div class="git-repo-card">' +
+    '<div class="git-repo-primary">' + iconHtml("git-branch") +
+      '<div style="min-width:0"><div class="git-repo-name">' + escapeHtml(status.name || "Repository") + '</div>' +
+      '<div class="git-branch-name">' + escapeHtml(branchLabel) + '</div></div>' +
+    '</div>' +
+    (badges ? '<div class="git-badges">' + badges + '</div>' : '') +
+    '<div class="git-repo-path">' + iconHtml("folder") + '<span>' + escapeHtml(status.root || "") + '</span></div>' +
+    (status.isWorktree ? '<div class="git-repo-path">' + iconHtml("trees") + '<span>Main: ' + escapeHtml(status.mainWorktree || "") + '</span></div>' : '') +
+    '<div class="git-origin">' + iconHtml("cloud") + '<span>' + escapeHtml(shortOrigin(status.origin)) + '</span></div>' +
+  '</div>' +
+  '<div class="git-sync-row">' +
+    '<button type="button" class="git-action-btn" data-git-action="pull"' + (pullDisabled ? ' disabled' : '') + '>' + iconHtml("download") + ' Pull' +
+      (status.behind ? '<span class="git-sync-count">' + status.behind + '</span>' : '') + '</button>' +
+    '<button type="button" class="git-action-btn" data-git-action="push"' + (pushDisabled ? ' disabled' : '') + '>' + iconHtml("upload") + ' Push' +
+      (status.ahead ? '<span class="git-sync-count">' + status.ahead + '</span>' : '') + '</button>' +
+  '</div>';
+
+  if (status.files.length === 0) {
+    html += '<div class="git-panel-empty" style="min-height:80px">' + iconHtml("check-circle-2") + '<span>Working tree clean</span></div>';
+  } else {
+    html += '<button type="button" class="git-review-all" data-git-review-all>' +
+      '<span>' + iconHtml("scan-search") + '<strong>Review all changes</strong></span>' +
+      '<span class="git-review-count">' + status.files.length + ' files ' + iconHtml("chevron-right") + '</span>' +
+    '</button>';
+    html += renderFileSection("Staged changes", staged, true, unstaged.length === 0);
+    html += renderFileSection("Changes", unstaged, false, staged.length === 0);
+  }
+
+  if (staged.length > 0) {
+    html += '<div class="git-agent-commit">' +
+      '<div class="git-agent-commit-copy"><span class="git-agent-commit-icon">' + iconHtml("sparkles") + '</span>' +
+        '<div><strong>Commit with Agent</strong><span>Review and commit exactly ' + staged.length + ' staged file' + (staged.length === 1 ? '' : 's') + '.</span></div></div>' +
+      '<button type="button" class="git-action-btn git-agent-commit-btn" data-git-agent-commit' + (busy ? ' disabled' : '') + '>' +
+        iconHtml("message-square-code") + ' Commit ' + staged.length + ' file' + (staged.length === 1 ? '' : 's') + '</button>' +
+    '</div>';
+  } else if (status.files.length > 0) {
+    html += '<div class="git-agent-commit git-next-action">' +
+      '<button type="button" class="git-action-btn git-agent-commit-btn" data-git-review-all>' +
+        iconHtml("scan-search") + ' Review ' + status.files.length + ' changed file' + (status.files.length === 1 ? '' : 's') + '</button>' +
+    '</div>';
+  } else if (status.ahead > 0) {
+    html += '<div class="git-agent-commit git-next-action"><button type="button" class="git-action-btn git-agent-commit-btn" data-git-action="push">' +
+      iconHtml("upload") + ' Push ' + status.ahead + ' commit' + (status.ahead === 1 ? '' : 's') + '</button></div>';
+  }
+  return html;
+}
+
+function render() {
+  var body = document.getElementById("git-panel-body");
+  if (!body) return;
+  var previousChangesList = body.querySelector(".git-section-changes .git-file-list");
+  var previousStagedList = body.querySelector(".git-section-staged .git-file-list");
+  var changesScrollTop = previousChangesList ? previousChangesList.scrollTop : 0;
+  var stagedScrollTop = previousStagedList ? previousStagedList.scrollTop : 0;
+  if (!currentStatus) {
+    body.innerHTML = '<div class="git-panel-loading"><span class="git-panel-spinner"></span> Reading repository</div>';
+  } else if (currentStatus.loadError) {
+    body.innerHTML = '<div class="git-panel-empty">' + iconHtml("circle-alert") + '<span>' + escapeHtml(currentStatus.loadError) + '</span></div>';
+  } else if (!currentStatus.isRepository) {
+    body.innerHTML = '<div class="git-panel-empty">' + iconHtml("folder-git-2") + '<span>This project is not a Git repository.</span></div>';
+  } else {
+    body.innerHTML = renderRepository(currentStatus);
+  }
+  refreshIcons(body);
+  var changesList = body.querySelector(".git-section-changes .git-file-list");
+  var stagedList = body.querySelector(".git-section-staged .git-file-list");
+  if (changesList) changesList.scrollTop = changesScrollTop;
+  if (stagedList) stagedList.scrollTop = stagedScrollTop;
+  updateBadge();
+}
+
+function updateBadge() {
+  var badge = document.getElementById("git-sidebar-count");
+  if (!badge) return;
+  if (!currentStatus || !currentStatus.isRepository) {
+    badge.classList.add("hidden");
+    return;
+  }
+  var count = currentStatus.files.length;
+  badge.textContent = count > 99 ? "99+" : String(count);
+  badge.classList.toggle("hidden", count === 0);
+}
+
+export function refreshGitStatus() {
+  if (busy) return Promise.resolve(currentStatus);
+  var basePath = store.get('basePath');
+  if (statusBasePath !== basePath) {
+    statusBasePath = basePath;
+    currentStatus = null;
+    lastError = "";
+    expandedFileActionsPath = null;
+    render();
+  }
+  var refreshBtn = document.getElementById("git-panel-refresh");
+  if (refreshBtn) refreshBtn.classList.add("spinning");
+  return requestJson(basePath + "api/git/status", { cache: "no-store" }).then(function (status) {
+    if (statusBasePath !== basePath) return status;
+    currentStatus = status;
+    if (expandedFileActionsPath && !status.files.some(function (file) { return file.path === expandedFileActionsPath; })) {
+      expandedFileActionsPath = null;
+    }
+    lastError = "";
+    render();
+    return status;
+  }).catch(function (err) {
+    if (statusBasePath !== basePath) return;
+    lastError = err.message;
+    if (!currentStatus) currentStatus = { isRepository: false, loadError: err.message };
+    render();
+  }).finally(function () {
+    if (refreshBtn) refreshBtn.classList.remove("spinning");
+  });
+}
+
+function actionLabel(action) {
+  if (action === "stage" || action === "stage_all") return "Staged changes";
+  if (action === "unstage" || action === "unstage_all") return "Unstaged changes";
+  if (action === "pull") return "Pulled changes";
+  if (action === "push") return "Pushed changes";
+  return "Git action completed";
+}
+
+function runAction(action, paths) {
+  if (busy) return;
+  var payload = { action: action };
+  if (paths) payload.paths = paths;
+  busy = true;
+  lastError = "";
+  render();
+  requestJson(apiPath("action"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  }).then(function (result) {
+    currentStatus = result.status;
+    showToast(actionLabel(action), null, result.output || "");
+  }).catch(function (err) {
+    lastError = err.message;
+    showToast("Git action failed", "warn", err.message);
+  }).finally(function () {
+    busy = false;
+    render();
+  });
+}
+
+function openFileDiff(filePath, reviewIndex) {
+  requestJson(apiPath("file-diff?path=" + encodeURIComponent(filePath)), { cache: "no-store" }).then(function (result) {
+    var paths = currentStatus ? currentStatus.files.map(function (file) { return file.path; }) : [filePath];
+    var index = typeof reviewIndex === "number" ? reviewIndex : paths.indexOf(filePath);
+    if (index < 0) index = 0;
+    result.review = {
+      index: index,
+      total: paths.length,
+      previous: index > 0 ? function () { openFileDiff(paths[index - 1], index - 1); } : null,
+      next: index + 1 < paths.length ? function () { openFileDiff(paths[index + 1], index + 1); } : null,
+      askAgent: function () { startAgentFileReview(filePath); },
+    };
+    openWorkingTreeDiff(result);
+  }).catch(function (err) {
+    showToast("Unable to open Git diff", "warn", err.message);
+  });
+}
+
+function openSessionDiff(sessionKey, filePath) {
+  var url = apiPath("session-diff?session=" + encodeURIComponent(sessionKey) + "&path=" + encodeURIComponent(filePath));
+  requestJson(url, { cache: "no-store" }).then(function (result) {
+    openWorkingTreeDiff(result);
+    showToast("Compared with start of " + (result.sessionTitle || "session"));
+  }).catch(function (err) {
+    showToast("Unable to compare session changes", "warn", err.message);
+  });
+}
+
+function returnToSession(sessionId) {
+  var ws = getWs();
+  if (!ws || ws.readyState !== WebSocket.OPEN || !sessionId) return;
+  ws.send(JSON.stringify({ type: "switch_session", id: sessionId }));
+  var gitBtn = document.getElementById("git-sidebar-btn");
+  var gitPanel = document.getElementById("sidebar-panel-git");
+  if (gitBtn && gitPanel && !gitPanel.classList.contains("hidden")) gitBtn.click();
+}
+
+function startFocusedAgentSession(prompt, successMessage, sessionTitle) {
+  if (!store.get('connected')) {
+    showToast("Not connected — agent session was not started.", "warn");
+    return;
+  }
+  var previousSessionId = store.get('activeSessionId');
+  var unsubscribe = null;
+  var sessionReady = false;
+  var timer = setTimeout(function () {
+    if (unsubscribe) unsubscribe();
+    showToast("Agent session could not be started", "warn");
+  }, 10000);
+  unsubscribe = store.subscribe(function (state) {
+    if (sessionReady || !state.activeSessionId || state.activeSessionId === previousSessionId) return;
+    sessionReady = true;
+    clearTimeout(timer);
+    setTimeout(function () {
+      if (unsubscribe) unsubscribe();
+      unsubscribe = null;
+      var newSessionId = store.get('activeSessionId');
+      var ws = getWs();
+      if (sessionTitle && ws && ws.readyState === WebSocket.OPEN && newSessionId) {
+        ws.send(JSON.stringify({ type: "rename_session", id: newSessionId, title: sessionTitle }));
+      }
+      var gitBtn = document.getElementById("git-sidebar-btn");
+      var gitPanel = document.getElementById("sidebar-panel-git");
+      if (gitBtn && gitPanel && !gitPanel.classList.contains("hidden")) gitBtn.click();
+      if (sendTextMessage(prompt)) showToast(successMessage || "Agent session started");
+    }, 0);
+  });
+  startNewSession(resolveDefaultVendor(), { mode: "gui", forceNew: true });
+}
+
+function startAgentCommitSession() {
+  if (busy || !currentStatus) return;
+  var hasStaged = currentStatus.files.some(function (file) { return file.staged; });
+  if (!hasStaged) return;
+  var prompt = "Create a Git commit for the currently staged changes.\n\n" +
+    "Inspect `git diff --cached` and the repository instructions before committing. " +
+    "Commit exactly the staged changes; do not stage additional files. " +
+    "Write a concise Angular Commit Convention message, use the angular-commit skill, " +
+    "and do not add Co-Authored-By lines. If nothing is staged, explain that and stop.";
+  startFocusedAgentSession(prompt, "Commit session started", "Commit staged changes");
+}
+
+function startAgentFileReview(filePath) {
+  var prompt = "Review the current uncommitted changes in `" + filePath + "`.\n\n" +
+    "Inspect the Git diff and relevant repository context. Explain the intent of the change, " +
+    "identify correctness or regression risks, and suggest specific improvements. " +
+    "Do not edit files or run Git actions unless I ask in this session.";
+  var parts = splitFilePath(filePath);
+  startFocusedAgentSession(prompt, "File review session started", "Review \u00b7 " + parts.name);
+}
+
+function toggleFileActions(fileMain) {
+  if (!fileMain) return;
+  var filePath = decodeURIComponent(fileMain.dataset.gitFileItem);
+  var fileActions = fileMain.querySelector(".git-file-actions");
+  var wasOpen = fileActions && fileActions.classList.contains("open");
+  var openActions = document.querySelectorAll("#git-panel-body .git-file-actions.open");
+  for (var openIndex = 0; openIndex < openActions.length; openIndex++) {
+    openActions[openIndex].classList.remove("open");
+    openActions[openIndex].setAttribute("aria-hidden", "true");
+    var openMain = openActions[openIndex].closest(".git-file-main");
+    var openRow = openActions[openIndex].closest(".git-file-row");
+    if (openMain) openMain.setAttribute("aria-expanded", "false");
+    if (openRow) openRow.classList.remove("active");
+  }
+  if (fileActions && !wasOpen) {
+    expandedFileActionsPath = filePath;
+    fileActions.classList.add("open");
+    fileActions.setAttribute("aria-hidden", "false");
+    fileMain.setAttribute("aria-expanded", "true");
+    var fileRow = fileMain.closest(".git-file-row");
+    if (fileRow) fileRow.classList.add("active");
+  } else {
+    expandedFileActionsPath = null;
+  }
+}
+
+export function initGitPanel() {
+  var body = document.getElementById("git-panel-body");
+  var refreshBtn = document.getElementById("git-panel-refresh");
+  if (!body || !refreshBtn) return;
+  refreshBtn.addEventListener("click", function () { refreshGitStatus(); });
+  body.addEventListener("click", function (event) {
+    var openDiff = event.target.closest("[data-git-open-diff]");
+    if (openDiff) {
+      openFileDiff(decodeURIComponent(openDiff.dataset.gitOpenDiff));
+      return;
+    }
+    var agentReview = event.target.closest("[data-git-agent-review]");
+    if (agentReview) {
+      startAgentFileReview(decodeURIComponent(agentReview.dataset.gitAgentReview));
+      return;
+    }
+    var reviewAll = event.target.closest("[data-git-review-all]");
+    if (reviewAll) {
+      if (currentStatus && currentStatus.files.length > 0) openFileDiff(currentStatus.files[0].path, 0);
+      return;
+    }
+    var sessionCompare = event.target.closest(".git-session-compare");
+    if (sessionCompare) {
+      openSessionDiff(decodeURIComponent(sessionCompare.dataset.gitSessionKey), decodeURIComponent(sessionCompare.dataset.gitPath));
+      return;
+    }
+    var sessionLink = event.target.closest(".git-session-link");
+    if (sessionLink) {
+      if (!sessionLink.disabled) returnToSession(parseInt(sessionLink.dataset.gitSessionId, 10));
+      return;
+    }
+    var agentCommitButton = event.target.closest("[data-git-agent-commit]");
+    if (agentCommitButton) {
+      if (!agentCommitButton.disabled) startAgentCommitSession();
+      return;
+    }
+    var actionButton = event.target.closest("[data-git-action]");
+    if (actionButton) {
+      if (!actionButton.disabled) {
+        var action = actionButton.dataset.gitAction;
+        var filePath = actionButton.dataset.gitPath ? decodeURIComponent(actionButton.dataset.gitPath) : null;
+        runAction(action, filePath ? [filePath] : null);
+      }
+      return;
+    }
+    var fileRow = event.target.closest(".git-file-row");
+    var fileItem = fileRow ? fileRow.querySelector("[data-git-file-item]") : null;
+    if (fileItem) toggleFileActions(fileItem);
+  });
+  body.addEventListener("keydown", function (event) {
+    var fileItem = event.target.closest("[data-git-file-item]");
+    if (!fileItem || event.target !== fileItem || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
+    toggleFileActions(fileItem);
+  });
+  setInterval(function () {
+    var panel = document.getElementById("sidebar-panel-git");
+    if (panel && !panel.classList.contains("hidden") && store.get('connected') && !busy) refreshGitStatus();
+  }, 2500);
+}

--- a/lib/public/modules/input.js
+++ b/lib/public/modules/input.js
@@ -346,6 +346,14 @@ export function sendMessage() {
   }
 }
 
+export function sendTextMessage(text) {
+  if (!ctx || !ctx.inputEl || typeof text !== "string" || !text.trim()) return false;
+  clearPendingImages();
+  ctx.inputEl.value = text;
+  sendMessage();
+  return true;
+}
+
 export function autoResize() {
   ctx.inputEl.style.height = "auto";
   ctx.inputEl.style.height = Math.min(ctx.inputEl.scrollHeight, 120) + "px";

--- a/lib/public/modules/markdown-slides.js
+++ b/lib/public/modules/markdown-slides.js
@@ -1,0 +1,292 @@
+import { store } from './store.js';
+import { refreshIcons } from './icons.js';
+
+var levelMenu = null;
+
+function normalizedLevel(level) {
+  var parsed = Number(level);
+  return parsed >= 1 && parsed <= 3 ? parsed : 1;
+}
+
+function directHeadings(markdownEl, level) {
+  if (!markdownEl) return [];
+  var tagName = "H" + normalizedLevel(level);
+  return Array.from(markdownEl.children).filter(function (child) {
+    return child.tagName === tagName;
+  });
+}
+
+export function countMarkdownSlides(markdownEl, level) {
+  return directHeadings(markdownEl, level).length;
+}
+
+export function suggestedMarkdownSlideLevel(markdownEl) {
+  var counts = [0, 1, 2, 3].map(function (level) {
+    return level === 0 ? 0 : countMarkdownSlides(markdownEl, level);
+  });
+  var selected = normalizedLevel(store.get('markdownSlidePreferredLevel') || store.get('markdownSlideLevel'));
+  if (store.get('markdownSlideLevelExplicit') && counts[selected] > 0) return selected;
+  if (counts[1] === 1 && counts[2] > 1) return 2;
+  if (counts[1] > 0) return 1;
+  if (counts[2] > 0) return 2;
+  if (counts[3] > 0) return 3;
+  return selected;
+}
+
+function updateSlideButton(active, available, level) {
+  var button = document.getElementById("file-viewer-slides");
+  var levelButton = document.getElementById("file-viewer-slide-level");
+  var selectedLevel = normalizedLevel(level || store.get('markdownSlideLevel'));
+  if (!button) return;
+  button.classList.toggle("hidden", !available);
+  button.classList.toggle("active", active);
+  button.setAttribute("aria-pressed", active ? "true" : "false");
+  button.setAttribute("aria-label", active ? "Exit slide show" : "Present Markdown by H" + selectedLevel + " headings");
+  button.title = active ? "Exit slide show (Esc)" : "Present by H" + selectedLevel + " sections";
+  if (levelButton) {
+    levelButton.classList.toggle("hidden", !available || active);
+    levelButton.setAttribute("aria-label", "Choose slide heading level. Current: H" + selectedLevel);
+    levelButton.title = "Split slides by heading level";
+    var label = levelButton.querySelector("span");
+    if (label) label.textContent = "H" + selectedLevel;
+  }
+}
+
+export function syncMarkdownSlidesButton(markdownEl) {
+  if (!markdownEl) {
+    closeMarkdownSlideLevelMenu();
+    updateSlideButton(false, false, store.get('markdownSlideLevel'));
+    return 0;
+  }
+  var level = suggestedMarkdownSlideLevel(markdownEl);
+  var count = countMarkdownSlides(markdownEl, level);
+  store.set({ markdownSlideLevel: level });
+  updateSlideButton(false, count > 0, level);
+  return count;
+}
+
+function closeLevelMenuOnOutside(event) {
+  var button = document.getElementById("file-viewer-slide-level");
+  if (levelMenu && (levelMenu.contains(event.target) || (button && button.contains(event.target)))) return;
+  closeMarkdownSlideLevelMenu();
+}
+
+export function closeMarkdownSlideLevelMenu() {
+  if (levelMenu) levelMenu.remove();
+  levelMenu = null;
+  document.removeEventListener("pointerdown", closeLevelMenuOnOutside);
+  var button = document.getElementById("file-viewer-slide-level");
+  if (button) button.setAttribute("aria-expanded", "false");
+}
+
+export function toggleMarkdownSlideLevelMenu(markdownEl) {
+  if (levelMenu) {
+    closeMarkdownSlideLevelMenu();
+    return;
+  }
+  if (!markdownEl) return;
+  var button = document.getElementById("file-viewer-slide-level");
+  if (!button) return;
+  var selected = normalizedLevel(store.get('markdownSlideLevel'));
+  var menu = document.createElement("div");
+  menu.className = "markdown-slide-level-menu";
+  menu.setAttribute("role", "menu");
+  menu.setAttribute("aria-label", "Slide heading level");
+  menu.innerHTML = '<div class="markdown-slide-level-title">Start a new slide at</div>';
+  for (var level = 1; level <= 3; level++) {
+    var count = countMarkdownSlides(markdownEl, level);
+    var option = document.createElement("button");
+    option.type = "button";
+    option.className = "markdown-slide-level-option" + (level === selected ? " selected" : "");
+    option.disabled = count === 0;
+    option.dataset.level = String(level);
+    option.setAttribute("role", "menuitemradio");
+    option.setAttribute("aria-checked", level === selected ? "true" : "false");
+    option.innerHTML = '<span class="markdown-slide-level-name">H' + level + '</span>' +
+      '<code>' + "#".repeat(level) + '</code>' +
+      '<span class="markdown-slide-level-count">' + count + (count === 1 ? " heading" : " headings") + '</span>' +
+      '<i data-lucide="check"></i>';
+    option.addEventListener("click", function () {
+      var nextLevel = normalizedLevel(this.dataset.level);
+      store.set({ markdownSlideLevel: nextLevel, markdownSlidePreferredLevel: nextLevel, markdownSlideLevelExplicit: true });
+      updateSlideButton(false, true, nextLevel);
+      closeMarkdownSlideLevelMenu();
+      refreshIcons();
+    });
+    menu.appendChild(option);
+  }
+  document.body.appendChild(menu);
+  levelMenu = menu;
+  button.setAttribute("aria-expanded", "true");
+  var rect = button.getBoundingClientRect();
+  menu.style.left = Math.max(12, rect.right - menu.offsetWidth) + "px";
+  menu.style.top = Math.min(window.innerHeight - menu.offsetHeight - 12, rect.bottom + 8) + "px";
+  setTimeout(function () { document.addEventListener("pointerdown", closeLevelMenuOnOutside); }, 0);
+  refreshIcons();
+}
+
+function createControls(viewer) {
+  var controls = document.createElement("div");
+  controls.className = "markdown-slide-controls";
+  controls.innerHTML =
+    '<button type="button" class="markdown-slide-nav markdown-slide-prev" aria-label="Previous slide"><i data-lucide="arrow-left"></i></button>' +
+    '<span class="markdown-slide-counter" aria-live="polite"></span>' +
+    '<span class="markdown-slide-progress" aria-hidden="true"><span></span></span>' +
+    '<button type="button" class="markdown-slide-nav markdown-slide-next" aria-label="Next slide"><i data-lucide="arrow-right"></i></button>' +
+    '<button type="button" class="markdown-slide-exit" aria-label="Exit slide show"><i data-lucide="minimize-2"></i><span>Exit slides</span></button>';
+  controls.querySelector(".markdown-slide-prev").addEventListener("click", function () {
+    moveMarkdownSlide(-1);
+  });
+  controls.querySelector(".markdown-slide-next").addEventListener("click", function () {
+    moveMarkdownSlide(1);
+  });
+  controls.querySelector(".markdown-slide-exit").addEventListener("click", function () {
+    exitMarkdownSlides();
+  });
+  viewer.appendChild(controls);
+  return controls;
+}
+
+function showMarkdownSlide(index) {
+  var viewer = document.getElementById("file-viewer");
+  if (!viewer || !store.get('markdownSlidesActive')) return;
+  var slides = viewer.querySelectorAll(".markdown-slide");
+  if (!slides.length) return;
+  var previous = store.get('markdownSlideIndex') || 0;
+  var next = Math.max(0, Math.min(index, slides.length - 1));
+  viewer.dataset.slideDirection = next < previous ? "backward" : "forward";
+  for (var i = 0; i < slides.length; i++) {
+    var active = i === next;
+    slides[i].classList.toggle("active", active);
+    slides[i].setAttribute("aria-hidden", active ? "false" : "true");
+    slides[i].toggleAttribute("inert", !active);
+  }
+  store.set({ markdownSlideIndex: next, markdownSlideCount: slides.length });
+  var counter = viewer.querySelector(".markdown-slide-counter");
+  if (counter) counter.textContent = (next + 1) + " / " + slides.length;
+  var progress = viewer.querySelector(".markdown-slide-progress > span");
+  if (progress) progress.style.width = (((next + 1) / slides.length) * 100) + "%";
+  var prevButton = viewer.querySelector(".markdown-slide-prev");
+  var nextButton = viewer.querySelector(".markdown-slide-next");
+  if (prevButton) prevButton.disabled = next === 0;
+  if (nextButton) nextButton.disabled = next === slides.length - 1;
+  slides[next].scrollTop = 0;
+}
+
+export function moveMarkdownSlide(delta) {
+  showMarkdownSlide((store.get('markdownSlideIndex') || 0) + delta);
+}
+
+export function enterMarkdownSlides(markdownEl, startIndex, requestedLevel) {
+  var level = normalizedLevel(requestedLevel || store.get('markdownSlideLevel'));
+  var headingTag = "H" + level;
+  var headings = directHeadings(markdownEl, level);
+  if (!headings.length) return false;
+  exitMarkdownSlides();
+
+  var viewer = document.getElementById("file-viewer");
+  var deck = document.createElement("div");
+  deck.className = "markdown-slide-deck";
+  var children = Array.from(markdownEl.children);
+  var prelude = [];
+  var slide = null;
+  for (var i = 0; i < children.length; i++) {
+    var child = children[i];
+    if (child.tagName === headingTag) {
+      if (!slide && prelude.length) {
+        var cover = document.createElement("section");
+        cover.className = "markdown-slide markdown-slide-cover";
+        cover.setAttribute("role", "group");
+        cover.setAttribute("aria-roledescription", "slide");
+        for (var p = 0; p < prelude.length; p++) cover.appendChild(prelude[p]);
+        deck.appendChild(cover);
+        prelude = [];
+      }
+      slide = document.createElement("section");
+      slide.className = "markdown-slide";
+      slide.setAttribute("role", "group");
+      slide.setAttribute("aria-roledescription", "slide");
+      child.classList.add("markdown-slide-heading");
+      slide.appendChild(child);
+      deck.appendChild(slide);
+    } else if (slide) {
+      slide.appendChild(child);
+    } else {
+      prelude.push(child);
+    }
+  }
+
+  var slides = Array.from(deck.children);
+  for (var j = 0; j < slides.length; j++) {
+    slides[j].setAttribute("aria-label", "Slide " + (j + 1) + " of " + slides.length);
+  }
+  markdownEl.appendChild(deck);
+  viewer.classList.add("markdown-slides-active");
+  viewer.dataset.slideLevel = String(level);
+  createControls(viewer);
+  store.set({ markdownSlidesActive: true, markdownSlideCount: slides.length, markdownSlideIndex: 0, markdownSlideLevel: level });
+  updateSlideButton(true, true, level);
+  showMarkdownSlide(typeof startIndex === "number" ? startIndex : 0);
+  refreshIcons();
+  return true;
+}
+
+export function exitMarkdownSlides() {
+  var viewer = document.getElementById("file-viewer");
+  if (!viewer) return;
+  var markdownEl = viewer.querySelector(".file-viewer-markdown");
+  var deck = markdownEl ? markdownEl.querySelector(":scope > .markdown-slide-deck") : null;
+  if (deck) {
+    var fragment = document.createDocumentFragment();
+    var slides = Array.from(deck.children);
+    for (var i = 0; i < slides.length; i++) {
+      while (slides[i].firstChild) {
+        slides[i].firstChild.classList.remove("markdown-slide-heading");
+        fragment.appendChild(slides[i].firstChild);
+      }
+    }
+    markdownEl.insertBefore(fragment, deck);
+    deck.remove();
+  }
+  var controls = viewer.querySelector(".markdown-slide-controls");
+  if (controls) controls.remove();
+  viewer.classList.remove("markdown-slides-active");
+  delete viewer.dataset.slideDirection;
+  delete viewer.dataset.slideLevel;
+  store.set({ markdownSlidesActive: false, markdownSlideCount: 0, markdownSlideIndex: 0 });
+  closeMarkdownSlideLevelMenu();
+  var level = normalizedLevel(store.get('markdownSlideLevel'));
+  updateSlideButton(false, countMarkdownSlides(markdownEl, level) > 0, level);
+}
+
+export function handleMarkdownSlideKey(event) {
+  if (levelMenu && event.key === "Escape") {
+    event.preventDefault();
+    closeMarkdownSlideLevelMenu();
+    return true;
+  }
+  if (!store.get('markdownSlidesActive')) return false;
+  var key = event.key;
+  if (key === "Escape") {
+    event.preventDefault();
+    exitMarkdownSlides();
+    return true;
+  }
+  if (event.target && event.target.closest && event.target.closest("button, a, input, textarea, select")) return false;
+  if (key === "ArrowRight" || key === "ArrowDown" || key === "PageDown" || key === " ") {
+    event.preventDefault();
+    moveMarkdownSlide(1);
+    return true;
+  }
+  if (key === "ArrowLeft" || key === "ArrowUp" || key === "PageUp") {
+    event.preventDefault();
+    moveMarkdownSlide(-1);
+    return true;
+  }
+  if (key === "Home" || key === "End") {
+    event.preventDefault();
+    showMarkdownSlide(key === "Home" ? 0 : (store.get('markdownSlideCount') || 1) - 1);
+    return true;
+  }
+  return false;
+}

--- a/lib/public/modules/mate-sidebar.js
+++ b/lib/public/modules/mate-sidebar.js
@@ -109,13 +109,6 @@ export function initMateSidebar(wsGetter) {
       if (origBtn) origBtn.click();
     });
   }
-  var mateEmailBtn = document.getElementById("mate-email-btn");
-  if (mateEmailBtn) {
-    mateEmailBtn.addEventListener("click", function () {
-      var origBtn = document.getElementById("email-sidebar-btn");
-      if (origBtn) origBtn.click();
-    });
-  }
   var mateSkillsBtn = document.getElementById("mate-skills-btn");
   if (mateSkillsBtn) {
     mateSkillsBtn.addEventListener("click", function () {

--- a/lib/public/modules/sidebar.js
+++ b/lib/public/modules/sidebar.js
@@ -2,6 +2,7 @@ import { closeArchive } from './sticky-notes.js';
 import { closeScheduler } from './scheduler.js';
 import { initSidebarSessions } from './sidebar-sessions.js';
 import { focusFileTree } from './filebrowser.js';
+import { refreshGitStatus } from './git-panel.js';
 import { initSidebarProjects, closeProjectCtxMenu } from './sidebar-projects.js';
 import {
   initSidebarMates,
@@ -118,16 +119,20 @@ export function initSidebar(_ctx) {
 
   // --- Panel switch (sessions / files / projects) ---
   var fileBrowserBtn = ctx.$("file-browser-btn");
+  var gitBtn = ctx.$("git-sidebar-btn");
   var projectsPanel = ctx.$("sidebar-panel-projects");
   var sessionsPanel = ctx.$("sidebar-panel-sessions");
   var filesPanel = ctx.$("sidebar-panel-files");
+  var gitPanel = ctx.$("sidebar-panel-git");
   var sessionsHeaderContent = ctx.$("sessions-header-content");
   var filePanelClose = ctx.$("file-panel-close");
+  var gitPanelClose = ctx.$("git-panel-close");
 
   function hideAllPanels() {
     if (projectsPanel) projectsPanel.classList.add("hidden");
     if (sessionsPanel) sessionsPanel.classList.add("hidden");
     if (filesPanel) filesPanel.classList.add("hidden");
+    if (gitPanel) gitPanel.classList.add("hidden");
     if (sessionsHeaderContent) sessionsHeaderContent.classList.add("hidden");
   }
 
@@ -155,6 +160,16 @@ export function initSidebar(_ctx) {
     requestAnimationFrame(function () { focusFileTree(); });
   }
 
+  function showGitPanel() {
+    hideAllPanels();
+    if (gitPanel) {
+      gitPanel.classList.remove("hidden");
+      gitPanel.classList.remove("fb-exit");
+      gitPanel.classList.add("fb-enter");
+    }
+    refreshGitStatus();
+  }
+
   function hideFilesPanel(cb) {
     if (!filesPanel || filesPanel.classList.contains("hidden")) { if (cb) cb(); return; }
     filesPanel.classList.remove("fb-enter");
@@ -166,6 +181,20 @@ export function initSidebar(_ctx) {
       if (cb) cb();
     }
     filesPanel.addEventListener("animationend", onDone);
+  }
+
+  function hideGitPanel(cb) {
+    if (!gitPanel || gitPanel.classList.contains("hidden")) { if (cb) cb(); return; }
+    gitPanel.classList.remove("fb-enter");
+    gitPanel.classList.add("fb-exit");
+    function onDone(e) {
+      if (e.target !== gitPanel) return;
+      gitPanel.removeEventListener("animationend", onDone);
+      gitPanel.classList.remove("fb-exit");
+      gitPanel.classList.add("hidden");
+      if (cb) cb();
+    }
+    gitPanel.addEventListener("animationend", onDone);
   }
 
   if (fileBrowserBtn) {
@@ -185,6 +214,19 @@ export function initSidebar(_ctx) {
       hideFilesPanel(function() {
         showSessionsPanel();
       });
+    });
+  }
+  if (gitBtn) {
+    gitBtn.addEventListener("click", function () {
+      if (gitPanel && !gitPanel.classList.contains("hidden")) {
+        hideGitPanel(function () { showSessionsPanel(); });
+      }
+      else showGitPanel();
+    });
+  }
+  if (gitPanelClose) {
+    gitPanelClose.addEventListener("click", function () {
+      hideGitPanel(function () { showSessionsPanel(); });
     });
   }
 

--- a/lib/public/modules/tool-palette.js
+++ b/lib/public/modules/tool-palette.js
@@ -25,7 +25,6 @@ var SESSION_TOOLS = [
   { id: "sticky-notes-sidebar-btn", icon: "sticky-note",   label: "Sticky Notes",    countId: "sticky-notes-sidebar-count" },
   { id: "scheduler-btn",           icon: "calendar-clock", label: "Scheduled Tasks" },
   { id: "loop-tool-btn",           icon: "repeat",         label: "Loop" },
-  { id: "email-sidebar-btn",       icon: "mail",           label: "Email" },
   { id: "mcp-btn",                 icon: "cable",          label: "MCP Servers",     countId: "mcp-sidebar-count" },
   { id: "skills-btn",              icon: "puzzle",         label: "Skills" },
 ];
@@ -36,7 +35,6 @@ var MATE_TOOLS = [
   { id: "mate-sticky-notes-btn", icon: "sticky-note",    label: "Sticky Notes" },
   { id: "mate-scheduler-btn",    icon: "calendar-clock", label: "Scheduled Tasks" },
   { id: "mate-debate-btn",       icon: "mic",            label: "Debate" },
-  { id: "mate-email-btn",        icon: "mail",           label: "Email" },
   { id: "mate-mcp-btn",          icon: "cable",          label: "MCP Servers",     countId: "mate-mcp-sidebar-count" },
   { id: "mate-skills-btn",       icon: "puzzle",         label: "Skills" },
 ];

--- a/lib/public/modules/tool-palette.js
+++ b/lib/public/modules/tool-palette.js
@@ -25,6 +25,7 @@ var SESSION_TOOLS = [
   { id: "sticky-notes-sidebar-btn", icon: "sticky-note",   label: "Sticky Notes",    countId: "sticky-notes-sidebar-count" },
   { id: "scheduler-btn",           icon: "calendar-clock", label: "Scheduled Tasks" },
   { id: "loop-tool-btn",           icon: "repeat",         label: "Loop" },
+  { id: "git-sidebar-btn",         icon: "git-branch",     label: "Git",             countId: "git-sidebar-count" },
   { id: "mcp-btn",                 icon: "cable",          label: "MCP Servers",     countId: "mcp-sidebar-count" },
   { id: "skills-btn",              icon: "puzzle",         label: "Skills" },
 ];

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -10,6 +10,7 @@
 @import url("css/rewind.css");
 @import url("css/input.css");
 @import url("css/filebrowser.css");
+@import url("css/git-panel.css");
 @import url("css/diff.css");
 @import url("css/highlight.css");
 @import url("css/server-settings.css");

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -926,7 +926,7 @@ function createSessionManager(opts) {
       }
     }
     // Notify server for cross-project unread tracking
-    if (obj.type === "done") onSessionDone();
+    if (obj.type === "done") onSessionDone(session);
   }
 
   function resumeSession(cliSessionId, opts, targetWs) {

--- a/test/filebrowser-rich-copy.test.js
+++ b/test/filebrowser-rich-copy.test.js
@@ -3,13 +3,13 @@ var assert = require("node:assert");
 var fs = require("node:fs");
 var path = require("node:path");
 
-test("rendered Markdown exposes a separate formatting copy action", function () {
+test("Markdown exposes a separate formatting copy action in source and preview views", function () {
   var html = fs.readFileSync(path.join(__dirname, "../lib/public/index.html"), "utf8");
   var fileBrowser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
   assert.match(html, /id="file-viewer-copy-formatted"[^>]*title="Copy Markdown formatting"/);
   assert.match(fileBrowser, /copyMarkdownFormatting\(currentContent\)/);
   assert.match(fileBrowser, /formattedCopyBtn\.classList\.remove\("hidden"\)/);
-  assert.match(fileBrowser, /formattedCopyBtn\.classList\.add\("hidden"\)/);
+  assert.doesNotMatch(fileBrowser, /if \(!isRendered \|\| !currentIsMarkdown\) return;[\s\S]{0,120}copyMarkdownFormatting/);
 });
 
 test("Markdown formatting copy writes clean semantic clipboard flavors", function () {

--- a/test/git-cli.test.js
+++ b/test/git-cli.test.js
@@ -1,0 +1,86 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var { execFileSync } = require("child_process");
+var gitCli = require("../lib/git-cli");
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd: cwd, encoding: "utf8" });
+}
+
+function createRepository(t) {
+  var repo = fs.mkdtempSync(path.join(os.tmpdir(), "clay-git-cli-"));
+  t.after(function () { fs.rmSync(repo, { recursive: true, force: true }); });
+  git(repo, ["init", "-q"]);
+  git(repo, ["config", "user.name", "Clay Test"]);
+  git(repo, ["config", "user.email", "clay@example.test"]);
+  fs.writeFileSync(path.join(repo, "tracked.txt"), "before\n");
+  git(repo, ["add", "tracked.txt"]);
+  git(repo, ["commit", "-qm", "initial"]);
+  return repo;
+}
+
+test("porcelain parser preserves branch sync and changed path details", function () {
+  var raw = "# branch.oid abc123\0" +
+    "# branch.head feature/git panel\0" +
+    "# branch.upstream origin/feature/git-panel\0" +
+    "# branch.ab +2 -3\0" +
+    "1 .M N... 100644 100644 100644 abc123 abc123 folder/file name.js\0" +
+    "2 R. N... 100644 100644 100644 abc123 def456 R100 renamed file.js\0old file.js\0" +
+    "? new file.txt\0";
+  var parsed = gitCli.parsePorcelainV2(raw);
+
+  assert.equal(parsed.branch, "feature/git panel");
+  assert.equal(parsed.upstream, "origin/feature/git-panel");
+  assert.equal(parsed.ahead, 2);
+  assert.equal(parsed.behind, 3);
+  assert.equal(parsed.files.length, 3);
+  assert.equal(parsed.files[0].path, "folder/file name.js");
+  assert.equal(parsed.files[0].unstaged, true);
+  assert.equal(parsed.files[1].originalPath, "old file.js");
+  assert.equal(parsed.files[1].staged, true);
+  assert.equal(parsed.files[2].untracked, true);
+});
+
+test("Git status, diffs, and safe stage actions operate on the working tree", async function (t) {
+  var repo = createRepository(t);
+  fs.writeFileSync(path.join(repo, "tracked.txt"), "after\n");
+  fs.writeFileSync(path.join(repo, "new file.txt"), "new\n");
+
+  var status = gitCli.getStatus(repo);
+  assert.equal(status.isRepository, true);
+  assert.equal(status.dirty, true);
+  assert.deepEqual(status.files.map(function (file) { return file.path; }).sort(), ["new file.txt", "tracked.txt"]);
+
+  var diff = gitCli.getFileDiff(repo, "tracked.txt");
+  assert.equal(diff.binary, false);
+  assert.equal(diff.oldContent, "before\n");
+  assert.equal(diff.newContent, "after\n");
+
+  await gitCli.runAction(repo, { action: "stage", paths: ["tracked.txt"] });
+  status = gitCli.getStatus(repo);
+  var tracked = status.files.find(function (file) { return file.path === "tracked.txt"; });
+  assert.equal(tracked.staged, true);
+  assert.equal(tracked.unstaged, false);
+
+  await gitCli.runAction(repo, { action: "unstage", paths: ["tracked.txt"] });
+  status = gitCli.getStatus(repo);
+  tracked = status.files.find(function (file) { return file.path === "tracked.txt"; });
+  assert.equal(tracked.staged, false);
+  assert.equal(tracked.unstaged, true);
+
+  var target = path.join(repo, "outside-target.txt");
+  fs.writeFileSync(target, "secret target contents\n");
+  fs.symlinkSync(target, path.join(repo, "link.txt"));
+
+  var symlinkDiff = gitCli.getFileDiff(repo, "link.txt");
+  assert.equal(symlinkDiff.newContent, target);
+  assert.doesNotMatch(symlinkDiff.newContent, /secret target contents/);
+
+  assert.throws(
+    function () { gitCli.runAction(repo, { action: "stage", paths: ["../outside.txt"] }); },
+    /no longer changed/
+  );
+});

--- a/test/git-session-attribution.test.js
+++ b/test/git-session-attribution.test.js
@@ -1,0 +1,60 @@
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var test = require("node:test");
+var { execFileSync } = require("node:child_process");
+var { attachGitSessionAttribution } = require("../lib/git-session-attribution");
+var gitCli = require("../lib/git-cli");
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd: cwd, encoding: "utf8" });
+}
+
+function makeRepository() {
+  var root = fs.mkdtempSync(path.join(os.tmpdir(), "clay-git-session-"));
+  git(root, ["init"]);
+  git(root, ["config", "user.email", "test@example.com"]);
+  git(root, ["config", "user.name", "Clay Test"]);
+  fs.writeFileSync(path.join(root, "app.js"), "var value = 1;\n");
+  git(root, ["add", "app.js"]);
+  git(root, ["commit", "-m", "test: initialize repository"]);
+  return root;
+}
+
+test("session attribution links new working-tree changes and compares their baseline", function () {
+  var root = makeRepository();
+  var tracker = attachGitSessionAttribution({ cwd: root, storageDir: fs.mkdtempSync(path.join(os.tmpdir(), "clay-git-tracking-")) });
+  var session = { localId: 7, cliSessionId: "session-one", title: "Update value", vendor: "codex" };
+
+  tracker.beginTurn(session);
+  fs.writeFileSync(path.join(root, "app.js"), "var value = 2;\n");
+  tracker.finishTurn(session);
+
+  var sessions = new Map([[7, session]]);
+  var status = tracker.decorateStatus(gitCli.getStatus(root), sessions);
+  assert.equal(status.files[0].sessions[0].sessionId, 7);
+  assert.equal(status.files[0].sessions[0].title, "Update value");
+  assert.equal(status.files[0].sessions[0].preExisting, false);
+
+  var comparison = tracker.getSessionBaselineDiff("session-one", "app.js");
+  assert.equal(comparison.oldContent, "var value = 1;\n");
+  assert.equal(comparison.newContent, "var value = 2;\n");
+});
+
+test("session attribution preserves pre-existing uncommitted content as the baseline", function () {
+  var root = makeRepository();
+  var tracker = attachGitSessionAttribution({ cwd: root, storageDir: fs.mkdtempSync(path.join(os.tmpdir(), "clay-git-tracking-")) });
+  var session = { localId: 8, cliSessionId: "session-two", title: "Continue edit", vendor: "claude" };
+  fs.writeFileSync(path.join(root, "app.js"), "var value = 2;\n");
+
+  tracker.beginTurn(session);
+  fs.writeFileSync(path.join(root, "app.js"), "var value = 3;\n");
+  tracker.finishTurn(session);
+
+  var status = tracker.decorateStatus(gitCli.getStatus(root), new Map([[8, session]]));
+  assert.equal(status.files[0].sessions[0].preExisting, true);
+  var comparison = tracker.getSessionBaselineDiff("session-two", "app.js");
+  assert.equal(comparison.oldContent, "var value = 2;\n");
+  assert.equal(comparison.newContent, "var value = 3;\n");
+});

--- a/test/markdown-live-edit.test.js
+++ b/test/markdown-live-edit.test.js
@@ -50,3 +50,44 @@ test("message routing opens Markdown only from the explicit MCP presentation eve
   assert.match(messages, /finishMarkdownTurn\(\)/);
   assert.doesNotMatch(liveEdit, /parseMarkdownEditIntent|cuePattern|turnIntent/);
 });
+
+test("file viewer presentation mode covers the viewport and escapes before closing", function () {
+  var browser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+  var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");
+
+  assert.match(browser, /setFileViewerFullscreen\(!store\.get\('fileViewerFullscreen'\)\)/);
+  assert.match(browser, /if \(store\.get\('fileViewerFullscreen'\)\)[\s\S]*setFileViewerFullscreen\(false\);[\s\S]*return;[\s\S]*closeFileViewer\(\);/);
+  assert.match(css, /#file-viewer\.panel-fullscreen\s*\{[^}]*position:\s*fixed[^}]*inset:\s*0[^}]*z-index:\s*10000/s);
+  assert.match(css, /#file-viewer\.panel-fullscreen \.file-viewer-markdown\s*\{[^}]*width:\s*min\(100%, 1040px\)[^}]*margin:\s*0 auto/s);
+});
+
+test("Markdown H1 headings become navigable presentation slides", function () {
+  var browser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+  var slides = fs.readFileSync(path.join(__dirname, "../lib/public/modules/markdown-slides.js"), "utf8");
+  var html = fs.readFileSync(path.join(__dirname, "../lib/public/index.html"), "utf8");
+  var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");
+
+  assert.ok(html.includes('id="file-viewer-slides"'));
+  assert.ok(html.includes('data-lucide="presentation"'));
+  assert.match(slides, /tagName = "H" \+ normalizedLevel\(level\)/);
+  assert.match(slides, /"ArrowRight"[^\n]*"ArrowDown"[^\n]*"PageDown"/);
+  assert.match(slides, /aria-roledescription", "slide"/);
+  assert.match(browser, /if \(enterMarkdownSlides\(markdownEl, 0\)\) setFileViewerFullscreen\(true\)/);
+  assert.match(css, /\.markdown-slide\.active\s*\{[^}]*display:\s*flex/s);
+  assert.match(css, /\.markdown-slide > \*\s*\{[^}]*flex-shrink:\s*0/s);
+  assert.match(css, /\.markdown-slide > \.mermaid-diagram\s*\{[^}]*overflow:\s*auto/s);
+  assert.match(css, /\.markdown-slide-controls\s*\{[^}]*position:\s*absolute/s);
+});
+
+test("slide breaks support selectable H1 through H3 levels with H2 auto-detection", function () {
+  var slides = fs.readFileSync(path.join(__dirname, "../lib/public/modules/markdown-slides.js"), "utf8");
+  var html = fs.readFileSync(path.join(__dirname, "../lib/public/index.html"), "utf8");
+
+  assert.match(html, /id="file-viewer-slide-level"[^>]*aria-haspopup="menu"/);
+  assert.match(slides, /parsed >= 1 && parsed <= 3/);
+  assert.match(slides, /counts\[1\] === 1 && counts\[2\] > 1\) return 2/);
+  assert.match(slides, /markdown-slide-level-option/);
+  assert.match(slides, /markdown-slide-cover/);
+  assert.match(slides, /headingTag = "H" \+ level/);
+  assert.match(slides, /markdownSlidePreferredLevel/);
+});

--- a/test/markdown-live-edit.test.js
+++ b/test/markdown-live-edit.test.js
@@ -91,3 +91,12 @@ test("slide breaks support selectable H1 through H3 levels with H2 auto-detectio
   assert.match(slides, /headingTag = "H" \+ level/);
   assert.match(slides, /markdownSlidePreferredLevel/);
 });
+
+test("Markdown actions are available before rendered preview is enabled", function () {
+  var browser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+
+  assert.match(browser, /function markdownElementForActions\(\)/);
+  assert.match(browser, /preview\.innerHTML = renderMarkdown\(currentContent\)/);
+  assert.match(browser, /function ensureRenderedMarkdown\(\)[\s\S]*isRendered = true;[\s\S]*renderBody\(\)/);
+  assert.match(browser, /renderBtn\.title = "Render markdown";[\s\S]*pdfBtn\.classList\.remove\("hidden"\);[\s\S]*formattedCopyBtn\.classList\.remove\("hidden"\);[\s\S]*syncMarkdownSlidesButton\(markdownElementForActions\(\)\)/);
+});


### PR DESCRIPTION
## Summary

- add a full-viewport Markdown presentation viewer with configurable H1, H2, or H3 slide boundaries
- keep overflowing slide content and Mermaid diagrams readable through per-slide scrolling
- expose slide, PDF, and formatted-copy actions before Markdown preview mode is enabled
- consolidate email controls into the composer context picker
- add a project Git panel with repository metadata, staging, pull, push, and diff review controls
- connect working-tree changes to the sessions that produced them, distinguish pre-existing changes, and compare files with session-start baselines
- route commit preparation and change review through dedicated agent sessions
- match Git panel interactions and motion to the existing File Browser experience

## Testing

- `node --test --test-concurrency=1 --test-force-exit test/*.test.js` (207 passed before the Git panel additions)
- `node --test test/git-cli.test.js test/git-session-attribution.test.js` (4 passed)
- `node --check lib/git-cli.js`
- `node --check lib/git-session-attribution.js`
- `node --check lib/public/modules/git-panel.js`
- `node --check lib/public/modules/sidebar.js`
- `git diff --check`
