### PR TITLE
fix(release): align alias package provenance

### DIFF
--- a/scripts/publish-alias.js
+++ b/scripts/publish-alias.js
@@ -17,11 +17,11 @@ var pkg = {
   name: "claude-relay",
   version: version,
   description: "Alias for clay-server — Web UI for Claude Code.",
-  bin: { "claude-relay": "./bin/cli.js" },
+  bin: { "claude-relay": "bin/cli.js" },
   dependencies: { "clay-server": version },
   keywords: ["claude", "claude-code", "cli", "mobile", "remote", "relay", "web-ui", "tailscale"],
-  repository: { type: "git", url: "git+https://github.com/chadbyte/claude-relay.git" },
-  homepage: "https://github.com/chadbyte/claude-relay#readme",
+  repository: { type: "git", url: "git+https://github.com/chadbyte/clay.git" },
+  homepage: "https://github.com/chadbyte/clay#readme",
   author: "Chad",
   license: "MIT"
 }


### PR DESCRIPTION
## Summary

- point the generated `claude-relay` package metadata at `chadbyte/clay`, matching the GitHub Actions OIDC provenance
- normalize the alias bin path so current npm keeps the `claude-relay` executable
- unblock tokenless alias publishing after `clay-server@3.3.0` was published successfully

## Testing

- `NPM_CONFIG_DRY_RUN=true node scripts/publish-alias.js 9.9.9-test.0`
- `node --check scripts/publish-alias.js`
- `git diff --check`

## Release recovery

After merging, verify the automatic beta release publishes both `clay-server` and `claude-relay`. Then promote the resulting patch release to stable so both packages converge on the same version.
