### PR TITLE
fix(mobile): recalibrate keyboard viewport after rotation

### DIFF
--- a/lib/public/modules/notifications.js
+++ b/lib/public/modules/notifications.js
@@ -98,6 +98,14 @@ export function initNotifications(_ctx) {
     }
     window.visualViewport.addEventListener("resize", onViewportChange);
     window.visualViewport.addEventListener("scroll", onViewportChange);
+    window.addEventListener("orientationchange", function() {
+      // A portrait baseline makes a short landscape viewport look like a
+      // keyboard. Wait for the browser to finish rotating before recalibrating.
+      setTimeout(function() {
+        stableViewportHeight = window.innerHeight;
+        onViewportChange();
+      }, 0);
+    });
   }
 
   // --- Update pill badge ---


### PR DESCRIPTION
## Summary
- recalibrate the mobile keyboard viewport baseline after device rotation
- prevent landscape height from hiding the tab bar or mis-spacing the composer

## Verification
- `node --check lib/public/modules/notifications.js`
- `node scripts/check-client-imports.js`
- `npm test`