### PR TITLE
fix(ui): clear activity dots when tools take over

### DIFF
--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -931,6 +931,7 @@ export function processMessage(msg) {
       case "tool_start":
         removeMatePreThinking();
         stopThinking();
+        setActivity(null);
         markAllToolsDone();
         if (msg.name === "EnterPlanMode") {
           renderPlanBanner("enter");
@@ -1026,6 +1027,7 @@ export function processMessage(msg) {
         break;
 
       case "permission_request":
+        setActivity(null);
         renderPermissionRequest(msg.requestId, msg.toolName, msg.toolInput, msg.decisionReason, msg.mateId, msg.vendor);
         startUrgentBlink();
         break;
@@ -1041,6 +1043,7 @@ export function processMessage(msg) {
         break;
 
       case "permission_request_pending":
+        setActivity(null);
         renderPermissionRequest(msg.requestId, msg.toolName, msg.toolInput, msg.decisionReason, msg.mateId, msg.vendor);
         startUrgentBlink();
         break;

--- a/test/activity-indicator.test.js
+++ b/test/activity-indicator.test.js
@@ -1,0 +1,15 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+
+var source = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-messages.js"), "utf8");
+
+test("tool activity replaces the generic bouncing indicator", function () {
+  assert.match(source, /case "tool_start":\s*removeMatePreThinking\(\);\s*stopThinking\(\);\s*setActivity\(null\);/);
+});
+
+test("permission prompts clear stale bouncing indicators", function () {
+  assert.match(source, /case "permission_request":\s*setActivity\(null\);\s*renderPermissionRequest/);
+  assert.match(source, /case "permission_request_pending":\s*setActivity\(null\);\s*renderPermissionRequest/);
+});


### PR DESCRIPTION
## Summary

- clear the generic bouncing activity indicator when tool UI takes over
- clear stale activity when live or restored permission prompts are shown
- add a focused regression test for both transitions

## Testing

- `node --test test/activity-indicator.test.js` passes
- `npm test` cannot start on the active Node 22 runtime because `--test-force-exit` is unsupported
- running `node --test test/*.test.js` exposes existing runtime incompatibilities (`t.after is not a function`) and an unrelated Codex runtime timeout
