### PR TITLE
build(deps): update Claude Agent SDK to 0.3.241

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.233",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.241",
         "@lydell/node-pty": "^1.2.0-beta.3",
         "@openai/codex": "^0.147.0",
         "imapflow": "^1.3.1",
@@ -83,22 +83,21 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.233.tgz",
-      "integrity": "sha512-Dy+YqhggwtbezDy3Ap2pb1sK3bOqnI+sLNnsVjB3AUWvR0QlGnjjrjORXY03Y50I+B1eFRNEcYPAZKRYlCkSLQ==",
-      "license": "SEE LICENSE IN README.md",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.241.tgz",
+      "integrity": "sha512-pIHdCSTywFe30H0oWDCKZzC4ipBLtF5YMDRKjf6PHyARg57O4l/72v3b6QKnnefwtKKMe6uWJ1Y9lUJg/sKWyA==",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.233",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.233",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.233",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.233",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.233",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.233",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.233",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.233"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.241",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.241"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -107,104 +106,96 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.233.tgz",
-      "integrity": "sha512-4WDiBZgcrmvTDJjS8RNZwoxGgMz/0EpOM+sYa6EtyjwHTd6It1H/+k5zBckCmBajbgS5/ASCJqdwZzi7dwBl0Q==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.241.tgz",
+      "integrity": "sha512-v26ta54lKFMFEZzbOE+6p3YhKERWnDiEA6OmkSAg+3fAQHOa1+aLTKw222cfgzxgiVixwFtHMk8c63zsDd8aXQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.233.tgz",
-      "integrity": "sha512-RaaEfNrbqSh77H5NdVF9cJQ0xhAUO92aOv71LSKSdAYModMeUvJN0k22Q7gvmx0TlmqJ+aVyCG8J8gVfgSL9mg==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.241.tgz",
+      "integrity": "sha512-5jweT0vft1ZCaGSoxZHF9vJlHbx8Yxx4+x5aHAIXTd4lx7ZbT4o5buEF8kpmTeHUB+Fw9jtFIm4QDsRiBXgf+Q==",
       "cpu": [
         "x64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.233.tgz",
-      "integrity": "sha512-Az9HjQthYQqRjJCacBtDIAHX3TRGK9WlACNb/UOGAK3JndNzZMprM2mK/t6YmP2cRLJsGyorxL7HZmR9R9HYaw==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.241.tgz",
+      "integrity": "sha512-SxszQGffXiLzMEnAv+pJXEmQbA8haijKyRjjH/jOt1CLeMIfpjKcO9WQDv8dEA8nREWS3zJ103zjgecAF7oOQQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.233.tgz",
-      "integrity": "sha512-Z3uZdzt6xgJ3f4NIgO6lzBYSELULKSq6AL4OsNLBzuaEpVW0iYs1kUCaD9rcMlMrf3cV+Dk/GA/lTCGMgbucjQ==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.241.tgz",
+      "integrity": "sha512-GslvPvSzehfCZyzOaJAt4lgodznm5zpl/LMXN8ygD12z5qnpM+I9/eFnmAaISJ0L8/vyohtlAP1jjaeR2jz1AQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.233.tgz",
-      "integrity": "sha512-jpbhV+n9PnxLiyheQ/HjtHIg/E5/jVsk2Vdu132BSoL/3bsObSmMqKgsqoMutzwRZvtpqRs2RPVcjsC8G4A9Zw==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.241.tgz",
+      "integrity": "sha512-gJRa922Qcm7loumHcXMDFEFg//tz1aOi7Nx0sQa9I9lC1JSN8yL6i7/idzOU5Hp193tEDFOgqIMFL/yRiXg+rw==",
       "cpu": [
         "x64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.233.tgz",
-      "integrity": "sha512-kYBIAQCu2f1YITcGbpUN2jfrkAzs59TVAragAhE2z+GrkIcxcpZwmaRY6heMBtaSY8SuyrwgqbCW9hJALYFnEg==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.241.tgz",
+      "integrity": "sha512-kZigJ5Ug2I2G/n7Cunmwy4TGr0lOGnWrz6TkzyWiDcUmJOodoTH6GZECNarWAtETfN03AAeLfrpiz8z3hOEDqA==",
       "cpu": [
         "x64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.233.tgz",
-      "integrity": "sha512-aO2MaNdmQofyPLKszE4s+Ope/sLJPeI/ZlGdCcjYp7qhji2hgZ4bRWWsOrx5eKjz0gFK5CFFltILkFcNcxCsVg==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.241.tgz",
+      "integrity": "sha512-/3yA9jQuCvHDVlILzhtslH6kFYOvydXyMZiKwnzqM8ZfvFTNO41w8TpiFpBLseyM+4A4E8QMeTKu3L01Xyb5IQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.233",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.233.tgz",
-      "integrity": "sha512-TcAYyWPXS5mREZGUksuCZsLIRQjbo/Vriur2PqIhAmgZ1oiqBZO27a90sX60EUczD7yV8wpwOVhVLhUxO0kAEg==",
+      "version": "0.3.241",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.241.tgz",
+      "integrity": "sha512-cHYdAgORl9kynujMeYXyV1uj/hbmsBjRw9dRVkIW4/4sF7S6L4u/qDSzn1/wiNP7g2yWSJ4KbsvHDH2WWDnCBQ==",
       "cpu": [
         "x64"
       ],
-      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/chadbyte/clay#readme",
   "author": "Chad",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.233",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.241",
     "@lydell/node-pty": "^1.2.0-beta.3",
     "@openai/codex": "^0.147.0",
     "imapflow": "^1.3.1",


### PR DESCRIPTION
## Summary

- update `@anthropic-ai/claude-agent-sdk` from 0.3.233 to 0.3.241
- refresh platform-specific SDK packages in the lockfile

## Validation

- Claude adapter contract and runtime dependency tests pass on Node 22
- SDK bridge delivery tests pass on Node 22
- full suite: 210/213 passed locally; two existing file-watch timeouts and one transient Codex startup timeout, which passed in isolation
