### PR TITLE
fix(debate): prevent proposal failures from stopping daemon

### DIFF
--- a/lib/debate-mcp-server.js
+++ b/lib/debate-mcp-server.js
@@ -42,6 +42,7 @@ function getToolDefs(onPropose) {
       format: { type: "string", description: "Debate format, e.g. free_discussion (default)" },
       context: { type: "string", description: "Key context from the conversation that panelists should know" },
       specialRequests: { type: "string", description: "Special instructions for the debate, or empty" },
+      moderatorId: { type: "string", description: "Mate ID for the moderator. Required when proposing from a normal project; Mate sessions moderate their own proposals." },
       panelists: { type: "string", description: "JSON array of panelist objects: [{\"mateId\": \"<UUID>\", \"role\": \"perspective\", \"brief\": \"guidance\"}]" },
     }, ["topic", "panelists"]),
     handler: function (args) {
@@ -51,6 +52,13 @@ function getToolDefs(onPropose) {
       } catch (e) {
         return Promise.resolve({
           content: [{ type: "text", text: "Error: panelists must be a valid JSON array. Got: " + (args.panelists || "").substring(0, 100) }],
+          isError: true,
+        });
+      }
+      if (!Array.isArray(panelists)) {
+        return Promise.resolve({
+          content: [{ type: "text", text: "Error: panelists must be a JSON array." }],
+          isError: true,
         });
       }
 
@@ -59,12 +67,19 @@ function getToolDefs(onPropose) {
         format: args.format || "free_discussion",
         context: args.context || "",
         specialRequests: args.specialRequests || null,
+        moderatorId: args.moderatorId || null,
         panelists: panelists,
       };
 
       return onPropose(briefData).then(function (result) {
         if (result && result.action === "start") {
           return { content: [{ type: "text", text: "Debate approved and started. Topic: " + briefData.topic }] };
+        }
+        if (result && result.action === "error") {
+          return {
+            content: [{ type: "text", text: "Error: " + (result.error || "The debate could not be started.") }],
+            isError: true,
+          };
         }
         return { content: [{ type: "text", text: "Debate proposal was cancelled by the user." }] };
       });

--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -6,6 +6,22 @@ var emailAccounts = require("./email-accounts");
 var { getCodexConfig } = require("./codex-defaults");
 var yoke = require("./yoke");
 
+function dispatchMessageSafely(handleMessage, sendTo, slug, ws, msg) {
+  try {
+    handleMessage(ws, msg);
+    return true;
+  } catch (err) {
+    var detail = err && err.stack ? err.stack : (err && err.message ? err.message : String(err));
+    console.error("[project-connection] Message handler failed for " + slug + "/" + (msg.type || "unknown") + ":", detail);
+    try {
+      sendTo(ws, { type: "error", text: "The request could not be completed. Check the server logs for details." });
+    } catch (sendErr) {
+      console.error("[project-connection] Failed to send message error for " + slug + ":", sendErr && sendErr.message ? sendErr.message : sendErr);
+    }
+    return false;
+  }
+}
+
 /**
  * Attach connection/disconnection handlers to a project context.
  *
@@ -286,7 +302,7 @@ function attachConnection(ctx) {
     ws.on("message", function (raw) {
       var msg;
       try { msg = JSON.parse(raw.toString()); } catch (e) { return; }
-      handleMessage(ws, msg);
+      dispatchMessageSafely(handleMessage, sendTo, slug, ws, msg);
     });
 
     ws.on("close", function () {
@@ -317,4 +333,4 @@ function attachConnection(ctx) {
   };
 }
 
-module.exports = { attachConnection: attachConnection };
+module.exports = { attachConnection: attachConnection, dispatchMessageSafely: dispatchMessageSafely };

--- a/lib/project-debate-proposal.js
+++ b/lib/project-debate-proposal.js
@@ -1,0 +1,138 @@
+var path = require("path");
+var debateMcp = require("./debate-mcp-server");
+
+function attachDebateProposal(ctx) {
+  var pendingProposals = {};
+
+  function createMcpServer(adapter, boundSession) {
+    var toolDefs = debateMcp.getToolDefs(function onPropose(briefData) {
+      if (!boundSession) {
+        return Promise.resolve({
+          action: "error",
+          error: "Debate proposals require an active Clay session.",
+        });
+      }
+
+      return new Promise(function (resolve) {
+        var proposalId = "dp_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8);
+        briefData.proposalId = proposalId;
+        pendingProposals[proposalId] = {
+          resolve: resolve,
+          briefData: briefData,
+          session: boundSession,
+        };
+      });
+    });
+
+    return adapter.createToolServer({
+      name: "clay-debate",
+      version: "1.0.0",
+      tools: toolDefs,
+    });
+  }
+
+  function findPendingProposal(ws, msg) {
+    var keys = Object.keys(pendingProposals);
+    if (keys.length === 0) return null;
+    var key = msg.proposalId || null;
+    if (!key && ws && Number.isInteger(ws._clayActiveSession)) {
+      for (var i = keys.length - 1; i >= 0; i--) {
+        var candidate = pendingProposals[keys[i]];
+        if (candidate.session && candidate.session.localId === ws._clayActiveSession) {
+          key = keys[i];
+          break;
+        }
+      }
+    }
+    if (!key) key = keys[keys.length - 1];
+    var pending = pendingProposals[key];
+    if (!pending) return null;
+    delete pendingProposals[key];
+    return pending;
+  }
+
+  function rejectProposal(ws, pending, error) {
+    try {
+      ctx.sendTo(ws, { type: "debate_error", error: error });
+    } catch (sendErr) {
+      console.error("[debate] Failed to send proposal error:", sendErr && sendErr.message ? sendErr.message : sendErr);
+    }
+    pending.resolve({ action: "error", error: error });
+  }
+
+  function validateProposal(ws, pending) {
+    var briefData = pending.briefData;
+    var moderatorId = ctx.isMate ? path.basename(ctx.cwd) : briefData.moderatorId;
+    if (!moderatorId || typeof moderatorId !== "string") {
+      return { error: "A valid Mate moderator is required to start this debate." };
+    }
+
+    var userId = ws && ws._clayUser
+      ? ws._clayUser.id
+      : (pending.session.ownerId || ctx.getProjectOwnerId() || null);
+    var mateCtx = ctx.buildMateCtx(userId);
+    if (!ctx.getMate(mateCtx, moderatorId)) {
+      return { error: "The selected debate moderator is unavailable." };
+    }
+
+    var panelists = briefData.panelists;
+    if (!Array.isArray(panelists) || panelists.length === 0) {
+      return { error: "At least one valid panelist is required to start this debate." };
+    }
+
+    var seen = {};
+    for (var i = 0; i < panelists.length; i++) {
+      var panelistId = panelists[i] && panelists[i].mateId;
+      if (!panelistId || typeof panelistId !== "string" || !ctx.getMate(mateCtx, panelistId)) {
+        return { error: "One or more selected debate panelists are unavailable." };
+      }
+      if (panelistId === moderatorId) {
+        return { error: "The debate moderator cannot also be a panelist." };
+      }
+      if (seen[panelistId]) {
+        return { error: "The same Mate cannot be added to a debate more than once." };
+      }
+      seen[panelistId] = true;
+    }
+
+    return { moderatorId: moderatorId };
+  }
+
+  function handleMessage(ws, msg) {
+    if (msg.type !== "debate_proposal_response") return false;
+
+    var pending = findPendingProposal(ws, msg);
+    if (!pending) return true;
+    if (msg.action !== "start") {
+      pending.resolve({ action: "cancel" });
+      return true;
+    }
+
+    var validated = validateProposal(ws, pending);
+    if (validated.error) {
+      rejectProposal(ws, pending, validated.error);
+      return true;
+    }
+
+    try {
+      var result = ctx.startDebate(pending.session, pending.briefData, validated.moderatorId, ws);
+      if (result && result.error) {
+        rejectProposal(ws, pending, result.error);
+        return true;
+      }
+      pending.resolve({ action: "start" });
+    } catch (err) {
+      var detail = err && err.message ? err.message : String(err);
+      console.error("[debate] Failed to start approved proposal:", detail);
+      rejectProposal(ws, pending, "The debate could not be started. Check the server logs for details.");
+    }
+    return true;
+  }
+
+  return {
+    createMcpServer: createMcpServer,
+    handleMessage: handleMessage,
+  };
+}
+
+module.exports = { attachDebateProposal: attachDebateProposal };

--- a/lib/project-debate.js
+++ b/lib/project-debate.js
@@ -1742,6 +1742,7 @@ function attachDebate(ctx) {
 
     console.log("[debate] MCP debate approved. Topic:", debate.topic, "debateId:", debateId);
     startDebateLive(session);
+    return { ok: true };
   }
 
   // --- Public API ---

--- a/lib/project.js
+++ b/lib/project.js
@@ -16,6 +16,7 @@ var matesModule = require("./mates");
 var sessionSearch = require("./session-search");
 var userPresence = require("./user-presence");
 var { attachDebate } = require("./project-debate");
+var { attachDebateProposal } = require("./project-debate-proposal");
 var { attachMemory } = require("./project-memory");
 var { attachMateInteraction } = require("./project-mate-interaction");
 var { attachUserMention } = require("./project-user-mention");
@@ -247,7 +248,6 @@ function createProjectContext(opts) {
   var clients = new Set();
 
   // --- Browser extension state (shared mutable object) ---
-  var _pendingDebateProposals = {}; // proposalId -> { resolve, briefData }
   var _extToken = crypto.randomUUID(); // Auth token for MCP server bridge
   var browserState = {
     _browserTabList: {},
@@ -568,6 +568,19 @@ function createProjectContext(opts) {
     getLinuxUserForSession: getLinuxUserForSession,
     getPairToolDefs: function (boundSession) { return _sessionPair.getToolDefs(boundSession); },
   });
+  var _debate = null;
+  var _debateProposal = attachDebateProposal({
+    cwd: cwd,
+    isMate: isMate,
+    sendTo: sendTo,
+    buildMateCtx: matesModule.buildMateCtx,
+    getMate: matesModule.getMate,
+    getProjectOwnerId: function () { return projectOwnerId; },
+    startDebate: function (session, briefData, moderatorId, ws) {
+      if (!_debate) return { error: "The debate engine is unavailable." };
+      return _debate.handleMcpDebateApproval(session, briefData, moderatorId, ws);
+    },
+  });
 
   // --- MCP tool servers (created via YOKE adapter) ---
   var mcpServers = (function () {
@@ -605,20 +618,7 @@ function createProjectContext(opts) {
 
     // Debate MCP server (available to both mates and main project)
     try {
-      var debateMcp = require("./debate-mcp-server");
-      var debateToolDefs = debateMcp.getToolDefs(function onPropose(briefData) {
-        return new Promise(function (resolve) {
-          var proposalId = "dp_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8);
-          briefData.proposalId = proposalId;
-          _pendingDebateProposals[proposalId] = {
-            resolve: resolve,
-            briefData: briefData,
-          };
-          // The SDK sends tool_executing with briefData as input.
-          // Client renders the debate brief card when it sees propose_debate.
-        });
-      });
-      var debateMcpConfig = adapter.createToolServer({ name: "clay-debate", version: "1.0.0", tools: debateToolDefs });
+      var debateMcpConfig = _debateProposal.createMcpServer(adapter, null);
       if (debateMcpConfig) servers[debateMcpConfig.name || "clay-debate"] = debateMcpConfig;
     } catch (e) {
       console.error("[project] Failed to create debate MCP server:", e.message);
@@ -804,6 +804,15 @@ function createProjectContext(opts) {
           if (boundDocuments) { filtered[name] = boundDocuments; hasAny = true; }
         } catch (e) {
           console.error("[project] Failed to bind session document MCP server:", e.message);
+        }
+        continue;
+      }
+      if (name === "clay-debate" && forSession) {
+        try {
+          var boundDebate = _debateProposal.createMcpServer(adapter, forSession);
+          if (boundDebate) { filtered[name] = boundDebate; hasAny = true; }
+        } catch (e) {
+          console.error("[project] Failed to bind debate MCP server:", e.message);
         }
         continue;
       }
@@ -1139,28 +1148,7 @@ function createProjectContext(opts) {
       handleDebateConfirmBrief(ws);
       return;
     }
-    if (msg.type === "debate_proposal_response") {
-      // Match the most recent pending proposal (proposalId may not be
-      // available on the client since it's not part of the tool input)
-      var _dpKeys = Object.keys(_pendingDebateProposals);
-      if (_dpKeys.length === 0) return;
-      var _dpKey = msg.proposalId || _dpKeys[_dpKeys.length - 1];
-      var pending = _pendingDebateProposals[_dpKey];
-      if (!pending) return;
-      delete _pendingDebateProposals[_dpKey];
-      if (msg.action === "start") {
-        // Set up debate state on the session, then transition to live
-        var _dpSession = getSessionForWs(ws);
-        if (_dpSession) {
-          var _dpMateId = isMate ? path.basename(cwd) : null;
-          handleMcpDebateApproval(_dpSession, pending.briefData, _dpMateId, ws);
-        }
-        pending.resolve({ action: "start" });
-      } else {
-        pending.resolve({ action: "cancel" });
-      }
-      return;
-    }
+    if (_debateProposal.handleMessage(ws, msg)) return;
     if (msg.type === "debate_user_floor_response") {
       handleDebateUserFloorResponse(ws, msg);
       return;
@@ -1268,7 +1256,7 @@ function createProjectContext(opts) {
   var handleUserMention = _userMention.handleUserMention;
 
   // --- Debate engine (delegated to project-debate.js) ---
-  var _debate = attachDebate({
+  _debate = attachDebate({
     cwd: cwd,
     slug: slug,
     isMate: isMate,
@@ -1297,7 +1285,6 @@ function createProjectContext(opts) {
   var handleDebateUserFloorResponse = _debate.handleDebateUserFloorResponse;
   var restoreDebateState = _debate.restoreDebateState;
   var checkForDmDebateBrief = _debate.checkForDmDebateBrief;
-  var handleMcpDebateApproval = _debate.handleMcpDebateApproval;
 
   // --- Session presence (who is viewing which session) ---
   function broadcastPresence() {
@@ -1547,7 +1534,7 @@ function createProjectContext(opts) {
         // In-app MCP servers (debate, browser, email).
         // Use getLocalMcpServers() so clay-browser is hidden unless the
         // Chrome extension is currently connected (see issue #325).
-        var localMcp = getLocalMcpServers();
+        var localMcp = getLocalMcpServers(boundSession);
         if (localMcp) {
           var inAppNames = Object.keys(localMcp);
           for (var i = 0; i < inAppNames.length; i++) {
@@ -1599,7 +1586,7 @@ function createProjectContext(opts) {
         }
         if (sessionOnly) return Promise.reject(new Error("Session tool not found: " + serverName + "/" + toolName));
         // Try in-app servers first (gated by extension connectivity for clay-browser).
-        var localMcp = getLocalMcpServers();
+        var localMcp = getLocalMcpServers(boundSession);
         if (localMcp && localMcp[serverName]) {
           var server = localMcp[serverName];
           if (server.instance && server.instance._registeredTools && server.instance._registeredTools[toolName]) {

--- a/test/debate-proposal.test.js
+++ b/test/debate-proposal.test.js
@@ -1,0 +1,161 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var { attachDebateProposal } = require("../lib/project-debate-proposal");
+var { dispatchMessageSafely } = require("../lib/project-connection");
+
+function createHarness(options) {
+  var sent = [];
+  var starts = [];
+  var mates = options.mates || {};
+  var proposal = attachDebateProposal({
+    cwd: options.cwd || "/projects/example",
+    isMate: !!options.isMate,
+    sendTo: function (ws, msg) { sent.push(msg); },
+    buildMateCtx: function (userId) { return { userId: userId }; },
+    getMate: function (mateCtx, mateId) { return mates[mateId] || null; },
+    getProjectOwnerId: function () { return "project-owner"; },
+    startDebate: function (session, briefData, moderatorId, ws) {
+      starts.push({ session: session, briefData: briefData, moderatorId: moderatorId, ws: ws });
+      if (options.startError) throw options.startError;
+      return { ok: true };
+    },
+  });
+  var adapter = {
+    createToolServer: function (definition) {
+      return { name: definition.name, definition: definition };
+    },
+  };
+  var session = { localId: 7, ownerId: "session-owner" };
+  var server = proposal.createMcpServer(adapter, session);
+  return {
+    proposal: proposal,
+    tool: server.definition.tools[0],
+    session: session,
+    sent: sent,
+    starts: starts,
+  };
+}
+
+function proposalArgs(overrides) {
+  return Object.assign({
+    topic: "Test debate",
+    panelists: JSON.stringify([{ mateId: "mate_panel", role: "Reviewer", brief: "Review the proposal" }]),
+  }, overrides || {});
+}
+
+test("normal project proposals fail safely when no moderator is provided", async function () {
+  var harness = createHarness({ mates: { mate_panel: { id: "mate_panel" } } });
+  var resultPromise = harness.tool.handler(proposalArgs());
+
+  assert.equal(harness.proposal.handleMessage({}, { type: "debate_proposal_response", action: "start" }), true);
+  var result = await resultPromise;
+
+  assert.equal(harness.starts.length, 0);
+  assert.equal(harness.sent[0].type, "debate_error");
+  assert.match(harness.sent[0].error, /moderator/i);
+  assert.equal(result.isError, true);
+});
+
+test("normal project proposals use an explicit moderator and their bound session", async function () {
+  var harness = createHarness({
+    mates: {
+      mate_mod: { id: "mate_mod" },
+      mate_panel: { id: "mate_panel" },
+    },
+  });
+  var resultPromise = harness.tool.handler(proposalArgs({ moderatorId: "mate_mod" }));
+  var ws = { _clayUser: { id: "user-1" } };
+
+  harness.proposal.handleMessage(ws, { type: "debate_proposal_response", action: "start" });
+  var result = await resultPromise;
+
+  assert.equal(harness.starts.length, 1);
+  assert.equal(harness.starts[0].session, harness.session);
+  assert.equal(harness.starts[0].moderatorId, "mate_mod");
+  assert.match(result.content[0].text, /approved and started/i);
+});
+
+test("Mate project proposals use the current Mate as moderator", async function () {
+  var harness = createHarness({
+    cwd: "/mates/mate_self",
+    isMate: true,
+    mates: {
+      mate_self: { id: "mate_self" },
+      mate_panel: { id: "mate_panel" },
+    },
+  });
+  var resultPromise = harness.tool.handler(proposalArgs());
+
+  harness.proposal.handleMessage({}, { type: "debate_proposal_response", action: "start" });
+  await resultPromise;
+
+  assert.equal(harness.starts[0].moderatorId, "mate_self");
+});
+
+test("invalid panelist payloads are rejected before creating a proposal", async function () {
+  var harness = createHarness({ mates: {} });
+  var result = await harness.tool.handler(proposalArgs({ panelists: "{}" }));
+
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /JSON array/i);
+});
+
+test("debate startup exceptions become proposal errors", async function () {
+  var harness = createHarness({
+    mates: {
+      mate_mod: { id: "mate_mod" },
+      mate_panel: { id: "mate_panel" },
+    },
+    startError: new TypeError("The path argument must be of type string"),
+  });
+  var originalError = console.error;
+  console.error = function () {};
+  try {
+    var resultPromise = harness.tool.handler(proposalArgs({ moderatorId: "mate_mod" }));
+    assert.doesNotThrow(function () {
+      harness.proposal.handleMessage({}, { type: "debate_proposal_response", action: "start" });
+    });
+    var result = await resultPromise;
+    assert.equal(result.isError, true);
+    assert.equal(harness.sent[0].type, "debate_error");
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test("project message exceptions are isolated from the daemon", function () {
+  var sent = [];
+  var originalError = console.error;
+  console.error = function () {};
+  try {
+    var handled = dispatchMessageSafely(function () {
+      throw new Error("message failed");
+    }, function (ws, msg) {
+      sent.push(msg);
+    }, "example", {}, { type: "debate_proposal_response" });
+
+    assert.equal(handled, false);
+    assert.deepEqual(sent, [{
+      type: "error",
+      text: "The request could not be completed. Check the server logs for details.",
+    }]);
+  } finally {
+    console.error = originalError;
+  }
+});
+
+test("a closed WebSocket cannot escape the project message boundary", function () {
+  var originalError = console.error;
+  console.error = function () {};
+  try {
+    assert.doesNotThrow(function () {
+      dispatchMessageSafely(function () {
+        throw new Error("message failed");
+      }, function () {
+        throw new Error("socket closed");
+      }, "example", {}, { type: "debate_proposal_response" });
+    });
+  } finally {
+    console.error = originalError;
+  }
+});


### PR DESCRIPTION
## Summary

- bind MCP debate proposals to the session that created them
- require and validate a Mate moderator before starting from a normal project
- validate panelists and return `debate_error` instead of allowing startup exceptions to escape
- isolate synchronous project WebSocket message failures from the daemon process

Fixes #413

## Validation

- `node --test test/debate-proposal.test.js` — 7/7 passed
- `node scripts/check-client-imports.js` — passed
- `npm test` on Node 22 — 217/219 passed; the two failures are the existing `project-file-watch.test.js` timing timeouts
