### PR TITLE
fix(mobile): correct PWA chat layout

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -552,6 +552,22 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   var newMsgBtnDefault = "\u2193 Latest";
   var newMsgBtnActivity = "\u2193 New activity";
 
+  // The composer grows for mobile tabs, safe areas, multiline input, and the
+  // keyboard. Keep the jump button immediately above its real height instead
+  // of relying on one fixed bottom offset.
+  function positionNewMsgButton() {
+    var inputArea = $("input-area");
+    if (!inputArea) return;
+    newMsgBtn.style.bottom = (inputArea.offsetHeight + 12) + "px";
+  }
+  var inputAreaForNewMsgBtn = $("input-area");
+  if (inputAreaForNewMsgBtn && window.ResizeObserver) {
+    new ResizeObserver(positionNewMsgButton).observe(inputAreaForNewMsgBtn);
+  } else {
+    window.addEventListener("resize", positionNewMsgButton);
+  }
+  positionNewMsgButton();
+
   messagesEl.addEventListener("scroll", function () {
     // While sticky-bottom is armed (e.g. just after history_done or a "New
     // activity" click), suppress "user scrolled up" detection. Growth-induced
@@ -922,6 +938,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     messagesEl: messagesEl,
     sessionListEl: sessionListEl,
     scrollToBottom: scrollToBottom,
+    forceScrollToBottom: forceScrollToBottom,
     basePath: basePath,
     toggleUsagePanel: toggleUsagePanel,
     toggleStatusPanel: toggleStatusPanel,

--- a/lib/public/css/messages.css
+++ b/lib/public/css/messages.css
@@ -5,10 +5,19 @@
 #messages {
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior-y: contain;
   padding: 20px 0 12px;
   position: relative;
+}
+
+/* Rich message content can contain wide tables, diagrams, or generated HTML.
+   Keep that content inside the chat scroller; nested code blocks still own
+   their intentional horizontal scrolling. */
+#messages > * {
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* --- Remote cursors (Figma-style) --- */

--- a/lib/public/css/pwa-mobile.css
+++ b/lib/public/css/pwa-mobile.css
@@ -1,0 +1,17 @@
+/* In an iOS Home Screen app, a 100%-tall root can be measured against the
+   shortened safe-area viewport. Use the physical viewport for the root while
+   retaining safe-area padding on controls inside the app. */
+@media (max-width: 768px) {
+  html.pwa-standalone,
+  html.pwa-standalone body {
+    height: 100vh;
+  }
+}
+
+@media (max-width: 768px) and (display-mode: standalone),
+       (max-width: 768px) and (display-mode: fullscreen) {
+  html,
+  body {
+    height: 100vh;
+  }
+}

--- a/lib/public/css/title-bar.css
+++ b/lib/public/css/title-bar.css
@@ -324,6 +324,25 @@
     display: none !important;
   }
 
+  .title-bar-content {
+    height: calc(48px + var(--safe-top));
+    padding: var(--safe-top) 16px 0;
+  }
+
+  /* The inline title editor must own the header while the keyboard is open.
+     Leaving the other controls visible made its usable width nearly zero. */
+  .title-bar-content.session-renaming .status,
+  .title-bar-content.session-renaming #header-left > :not(.header-rename-input) {
+    display: none !important;
+  }
+
+  .title-bar-content.session-renaming .header-rename-input {
+    flex: 1 1 100%;
+    width: 100%;
+    min-height: 36px;
+    font-size: 16px;
+  }
+
   #sidebar-column {
     width: 0 !important;
     min-width: 0 !important;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -30,7 +30,7 @@
 (function(){try{var k="clay-theme-vars",v=localStorage.getItem(k),r=document.documentElement;if(v){var o=JSON.parse(v),p;for(p in o)r.style.setProperty(p,o[p]);var vt=localStorage.getItem(k.replace("-vars","-variant"));if(vt==="light"){r.classList.add("light-theme");r.classList.remove("dark-theme")}else{r.classList.add("dark-theme");r.classList.remove("light-theme")}var m=document.querySelector('meta[name="theme-color"]');if(m&&o["--bg"])m.setAttribute("content",o["--bg"])}else{var sl=window.matchMedia&&window.matchMedia("(prefers-color-scheme: light)").matches;if(sl){r.classList.add("light-theme");r.classList.remove("dark-theme")}}}catch(e){}})();
 </script>
 <script>if(window.navigator.standalone||window.matchMedia("(display-mode:standalone)").matches){document.documentElement.classList.add("pwa-standalone")}</script>
-<link rel="stylesheet" href="style.css?v=20260407">
+<link rel="stylesheet" href="style.css?v=20260824f">
 <style>
 @media(max-width:768px){
   /* User messages: vertical stack, avatar on top, right-aligned */
@@ -2325,7 +2325,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0/lib/addon-fit.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0/lib/addon-web-links.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-webgl@0/lib/addon-webgl.min.js"></script>
-<script type="module" src="app.js"></script>
+<script type="module" src="app.js?v=20260824g"></script>
 <div id="pwa-install-modal" class="pwa-modal hidden">
   <div class="pwa-modal-backdrop"></div>
   <div class="pwa-modal-card">

--- a/lib/public/modules/app-header.js
+++ b/lib/public/modules/app-header.js
@@ -93,6 +93,8 @@ export function initHeader() {
       input.type = "text";
       input.className = "header-rename-input";
       input.value = currentText;
+      var titleBar = headerTitleEl.closest(".title-bar-content");
+      if (titleBar) titleBar.classList.add("session-renaming");
       headerTitleEl.style.display = "none";
       headerRenameBtn.style.display = "none";
       headerTitleEl.parentNode.insertBefore(input, headerTitleEl.nextSibling);
@@ -117,6 +119,7 @@ export function initHeader() {
           }
         }
         input.remove();
+        if (titleBar) titleBar.classList.remove("session-renaming");
         headerTitleEl.style.display = "";
         headerRenameBtn.style.display = "";
       }
@@ -126,6 +129,7 @@ export function initHeader() {
         if (e.key === "Escape") {
           e.preventDefault();
           input.remove();
+          if (titleBar) titleBar.classList.remove("session-renaming");
           headerTitleEl.style.display = "";
           headerRenameBtn.style.display = "";
         }

--- a/lib/public/modules/notifications.js
+++ b/lib/public/modules/notifications.js
@@ -72,6 +72,7 @@ export function initNotifications(_ctx) {
   if (window.visualViewport) {
     var layout = $("layout");
     var mobileTabBar = document.getElementById("mobile-tab-bar");
+    var keyboardWasOpen = false;
     // Capture initial viewport height before any keyboard interaction.
     // In iOS PWA standalone mode, window.innerHeight shrinks when the
     // keyboard opens, so we need a stable baseline for comparison.
@@ -86,7 +87,12 @@ export function initNotifications(_ctx) {
       // Toggle class so CSS can remove the tab-bar bottom padding while keyboard is up
       var keyboardOpen = vv.height < stableViewportHeight - 100;
       document.body.classList.toggle("keyboard-open", keyboardOpen);
-      if (!keyboardOpen) ctx.scrollToBottom();
+      if (keyboardOpen && !keyboardWasOpen && ctx.forceScrollToBottom) {
+        requestAnimationFrame(function() { ctx.forceScrollToBottom(); });
+      } else if (!keyboardOpen) {
+        ctx.scrollToBottom();
+      }
+      keyboardWasOpen = keyboardOpen;
       // Hide tab bar when software keyboard is open
       if (mobileTabBar) {
         if (keyboardOpen) {

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -1,12 +1,12 @@
 @import url("css/base.css");
 @import url("css/icon-strip.css");
-@import url("css/title-bar.css");
+@import url("css/title-bar.css?v=20260824");
 @import url("css/pane.css");
 @import url("css/worker-proposal.css");
 @import url("css/sidebar.css");
 @import url("css/overlays.css");
 @import url("css/menus.css");
-@import url("css/messages.css?v=20260407");
+@import url("css/messages.css?v=20260824");
 @import url("css/rewind.css");
 @import url("css/input.css");
 @import url("css/filebrowser.css");
@@ -35,3 +35,4 @@
 @import url("css/debate.css");
 @import url("css/notifications-center.css");
 @import url("css/tui-attention.css");
+@import url("css/pwa-mobile.css?v=20260824f");


### PR DESCRIPTION
## Summary
- prevent horizontal overflow from rich chat content
- size the iOS Home Screen PWA root to the physical viewport
- keep mobile session rename input usable
- scroll to the latest message when the keyboard opens
- position the Latest button above the measured composer height

## Verification
- npm test (211 passing)
- node scripts/check-client-imports.js
- node --check for changed client modules
- tested in an iOS Home Screen PWA