### PR TITLE
[codex] enforce per-user Codex process isolation

### DIFF
--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -116,7 +116,7 @@ function attachConnection(ctx) {
     if (!_warmedUp) {
       _warmedUp = true;
       if (typeof warmup === "function") {
-        try { warmup(); }
+        try { warmup(wsUser && wsUser.linuxUser ? wsUser.linuxUser : null); }
         catch (e) { console.error("[project-connection] warmup failed for " + slug + ":", e && e.message ? e.message : e); }
       }
     }

--- a/lib/project-debate.js
+++ b/lib/project-debate.js
@@ -604,6 +604,7 @@ function attachDebate(ctx) {
     var _modMate = matesModule.getMate(mateCtx, debate.moderatorId);
     ctx.sdk.createMentionSession({
       vendor: _modMate ? _modMate.vendor : null,
+      linuxUser: mateCtx.linuxUser || undefined,
       claudeMd: claudeMd,
       initialContext: digests,
       initialMessage: quickBriefPrompt,
@@ -799,6 +800,7 @@ function attachDebate(ctx) {
     var _modMate2 = matesModule.getMate(mateCtx, debate.moderatorId);
     ctx.sdk.createMentionSession({
       vendor: _modMate2 ? _modMate2.vendor : null,
+      linuxUser: mateCtx.linuxUser || undefined,
       claudeMd: claudeMd,
       initialContext: moderatorContext,
       initialMessage: "Begin the debate on: " + debate.topic,
@@ -994,6 +996,7 @@ function attachDebate(ctx) {
       var _panMate = matesModule.getMate(debate.mateCtx, mateId);
       ctx.sdk.createMentionSession({
         vendor: _panMate ? _panMate.vendor : null,
+        linuxUser: debate.mateCtx && debate.mateCtx.linuxUser ? debate.mateCtx.linuxUser : undefined,
         claudeMd: claudeMd,
         initialContext: panelistContext + historyContext,
         initialMessage: "The moderator addresses you:\n\n" + moderatorText,
@@ -1530,6 +1533,7 @@ function attachDebate(ctx) {
         var _modMate3 = matesModule.getMate(mateCtx, debate.moderatorId);
         ctx.sdk.createMentionSession({
           vendor: _modMate3 ? _modMate3.vendor : null,
+          linuxUser: mateCtx.linuxUser || undefined,
           claudeMd: claudeMd,
           initialContext: moderatorContext,
           initialMessage: resumePrompt,

--- a/lib/project-mate-interaction.js
+++ b/lib/project-mate-interaction.js
@@ -179,6 +179,7 @@ function attachMateInteraction(ctx) {
   var _digestQueue = [];
   var _digestBusy = false;
   var _digestWorkerTurns = 0;
+  var _digestWorkerLinuxUser = null;
   var DIGEST_WORKER_MAX_TURNS = 20;
 
   function enqueueDigest(job) {
@@ -190,6 +191,13 @@ function attachMateInteraction(ctx) {
     if (_digestQueue.length === 0) { _digestBusy = false; return; }
     _digestBusy = true;
     var job = _digestQueue.shift();
+
+    if (_digestWorker && _digestWorkerLinuxUser !== (job.linuxUser || null)) {
+      try { _digestWorker.close(); } catch (e) {}
+      _digestWorker = null;
+      _digestWorkerTurns = 0;
+      _digestWorkerLinuxUser = null;
+    }
 
     var mateDir = matesModule.getMateDir(job.mateCtx, job.mateId);
     var knowledgeDir = path.join(mateDir, "knowledge");
@@ -315,6 +323,7 @@ function attachMateInteraction(ctx) {
       try { _digestWorker.close(); } catch (e) {}
       _digestWorker = null;
       _digestWorkerTurns = 0;
+      _digestWorkerLinuxUser = null;
     }
 
     var responseText = "";
@@ -328,12 +337,14 @@ function attachMateInteraction(ctx) {
           console.error("[digest-worker] Error:", err);
           _digestWorker = null;
           _digestWorkerTurns = 0;
+          _digestWorkerLinuxUser = null;
           if (job.onError) job.onError(err);
           processDigestQueue();
         },
       });
     } else {
       sdk.createMentionSession({
+        linuxUser: job.linuxUser || undefined,
         claudeMd: "",
         model: "haiku",
         initialContext: "[Digest Worker] You generate memory digests. Respond with ONLY JSON.",
@@ -344,10 +355,15 @@ function attachMateInteraction(ctx) {
         onError: function (err) {
           console.error("[digest-worker] Create error:", err);
           _digestWorker = null;
+          _digestWorkerLinuxUser = null;
           if (job.onError) job.onError(err);
           processDigestQueue();
         },
-      }).then(function (ws) { _digestWorker = ws; _digestWorkerTurns = 1; }).catch(function (err) {
+      }).then(function (ws) {
+        _digestWorker = ws;
+        _digestWorkerTurns = 1;
+        _digestWorkerLinuxUser = job.linuxUser || null;
+      }).catch(function (err) {
         if (job.onError) job.onError(err || new Error("digest worker creation failed"));
         processDigestQueue();
       });
@@ -378,6 +394,7 @@ function attachMateInteraction(ctx) {
 
     enqueueDigest({
       mateCtx: mateCtx,
+      linuxUser: mateCtx.linuxUser || undefined,
       mateId: mateId,
       type: "mention",
       conversationContent: conversationContent,
@@ -473,6 +490,7 @@ function attachMateInteraction(ctx) {
 
     enqueueDigest({
       mateCtx: mateCtx,
+      linuxUser: mateCtx.linuxUser || undefined,
       mateId: mateId,
       type: "dm",
       priorSummary: priorSummary || "",
@@ -716,6 +734,7 @@ function attachMateInteraction(ctx) {
       // Create new persistent mention session
       sdk.createMentionSession({
         vendor: mate.vendor || null,
+        linuxUser: getLinuxUserForSession(session) || undefined,
         claudeMd: claudeMd,
         initialContext: mentionContext,
         initialMessage: mentionFullInput,
@@ -887,6 +906,7 @@ function attachMateInteraction(ctx) {
     ].join("\n");
 
     sdk.createMentionSession({
+      linuxUser: mateCtx.linuxUser || undefined,
       claudeMd: "",
       model: "haiku",
       initialContext: synthesisContext,

--- a/lib/project-memory.js
+++ b/lib/project-memory.js
@@ -339,6 +339,7 @@ function attachMemory(ctx) {
     var gateText = "";
     var _gateSession = null;
     sdk.createMentionSession({
+      linuxUser: mateCtx.linuxUser || undefined,
       claudeMd: "",
       model: "haiku",
       initialContext: gateContext,
@@ -448,6 +449,7 @@ function attachMemory(ctx) {
     var updateText = "";
     var _updateSession = null;
     sdk.createMentionSession({
+      linuxUser: mateCtx.linuxUser || undefined,
       claudeMd: "",
       model: "haiku",
       initialContext: updateContext,
@@ -553,6 +555,7 @@ function attachMemory(ctx) {
     var initText = "";
     var _initSession = null;
     sdk.createMentionSession({
+      linuxUser: mateCtx.linuxUser || undefined,
       claudeMd: "",
       model: "haiku",
       initialContext: initContext,

--- a/lib/project.js
+++ b/lib/project.js
@@ -835,6 +835,7 @@ function createProjectContext(opts) {
     getNotificationsModule: function () { return _notifications; },
     mateDisplayName: opts.mateDisplayName || "",
     isMate: isMate,
+    osUsers: osUsers,
     dangerouslySkipPermissions: dangerouslySkipPermissions,
     mcpServers: getLocalMcpServers,
     getRemoteMcpServers: function () { return _mcp.getMcpServers(); },
@@ -1078,6 +1079,7 @@ function createProjectContext(opts) {
               try {
                 var readyResult = await vendorAdapter.init({
                   cwd: cwd,
+                  linuxUser: modelLinuxUser || undefined,
                   clayPort: serverPort,
                   clayTls: serverTls,
                   clayAuthToken: serverAuthToken,
@@ -1686,8 +1688,8 @@ function createProjectContext(opts) {
     getProject: function () { return project; },
     // Exposed so the first websocket connection can lazily warm up the
     // adapters for this project (see project-connection handleConnection).
-    warmup: function () {
-      sdk.warmup();
+    warmup: function (linuxUser) {
+      sdk.warmup(osUsers ? linuxUser : null);
       sdk.startIdleReaper();
       if (!osUsers && !sessionTitleMigrationScheduled) {
         sessionTitleMigrationScheduled = true;

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -110,6 +110,7 @@ function createSDKBridge(opts) {
   var adapters = opts.adapters || {};
   var mateDisplayName = opts.mateDisplayName || "";
   var isMate = opts.isMate || (slug.indexOf("mate-") === 0);
+  var osUsers = !!opts.osUsers;
   var dangerouslySkipPermissions = opts.dangerouslySkipPermissions || false;
   // mcpServers may be either a static object or a getter function. The
   // getter form lets callers gate individual servers at call time (e.g.
@@ -323,6 +324,14 @@ function createSDKBridge(opts) {
   var mergeSkills = skills.mergeSkills;
 
   // --- Message processing (extracted to sdk-message-processor.js) ---
+  function getSessionLinuxUser(session) {
+    if (!osUsers || !session) return null;
+    if (session.lastLinuxUser) return session.lastLinuxUser;
+    if (!session.ownerId) return null;
+    var owner = usersModule.findUserById(session.ownerId);
+    return owner && owner.linuxUser ? owner.linuxUser : null;
+  }
+
   // Auto-generate a session title via YOKE adapter.generateTitle().
   // Triggered by sdk-message-processor after AUTO_TITLE_TURN_THRESHOLD turns.
   function autoGenerateTitle(session) {
@@ -345,7 +354,10 @@ function createSDKBridge(opts) {
     }
     console.log("[auto-title] Calling adapter.generateTitle with " + userMessages.length + " messages for session " + session.localId);
 
-    sessionAdapter.generateTitle(userMessages, { cwd: cwd }).then(function(title) {
+    sessionAdapter.generateTitle(userMessages, {
+      cwd: cwd,
+      linuxUser: getSessionLinuxUser(session) || undefined,
+    }).then(function(title) {
       if (!title || title.length < 2) return;
       title = title.substring(0, 100);
       if (!session.titleManuallySet) {
@@ -1131,7 +1143,9 @@ function createSDKBridge(opts) {
   async function rollbackConversation(session, numTurns) {
     var sessionAdapter = getAdapterForSession(session);
     if (sessionAdapter && typeof sessionAdapter.rollbackThread === "function") {
-      await sessionAdapter.rollbackThread(session.cliSessionId, numTurns);
+      await sessionAdapter.rollbackThread(session.cliSessionId, numTurns, {
+        linuxUser: getSessionLinuxUser(session) || undefined,
+      });
     }
     // Claude: conversation rollback is handled by rewindFiles + local history trim
   }
@@ -1143,7 +1157,11 @@ function createSDKBridge(opts) {
 
   async function forkSessionUnified(session, uuid) {
     var sessionAdapter = getAdapterForSession(session);
-    var result = await sessionAdapter.forkSession(session.cliSessionId, { upToMessageId: uuid, dir: cwd });
+    var result = await sessionAdapter.forkSession(session.cliSessionId, {
+      upToMessageId: uuid,
+      dir: cwd,
+      linuxUser: getSessionLinuxUser(session) || undefined,
+    });
     if (!result || !result.sessionId) throw new Error("Fork returned no session id");
 
     // Adapters with rollbackThread (e.g. Codex) use local history copy
@@ -1471,6 +1489,7 @@ function createSDKBridge(opts) {
 
     var queryOpts = {
       cwd: cwd,
+      linuxUser: linuxUser || undefined,
       // appendSystemPrompt, NOT systemPrompt: a plain-string systemPrompt
       // REPLACES the entire Claude Code system prompt (sdk.d.ts:2096), which
       // would strip the driver session down to the two-sentence pair preset.

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -2036,7 +2036,7 @@ function createSDKBridge(opts) {
   // Creates a mention session that can be reused across multiple mentions
   // within a conversation flow (session continuity).
   async function createMentionSession(opts) {
-    // opts: { vendor, claudeMd, initialContext, initialMessage, onDelta, onDone, onError, onActivity }
+    // opts: { vendor, linuxUser, claudeMd, initialContext, initialMessage, onDelta, onDone, onError, onActivity }
     var abortController = new AbortController();
 
     // Current response callbacks (swapped on each pushMessage)
@@ -2056,6 +2056,7 @@ function createSDKBridge(opts) {
     try {
       handle = await mentionAdapter.createQuery({
         cwd: cwd,
+        linuxUser: opts.linuxUser || undefined,
         systemPrompt: opts.claudeMd,
         model: opts.model || undefined,
         toolServers: opts.includeMcpServers ? (mergeMcpServers(getMcpServers(), getRemoteMcpServers) || undefined) : undefined,

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -7,6 +7,7 @@ var path = require("path");
 var fs = require("fs");
 var { CodexAppServer } = require("../codex-app-server");
 var skillDiscovery = require("../skill-discovery");
+var { resolveOsUserInfo } = require("../../os-users");
 
 // --- Event flattening ---
 // Converts app-server JSON-RPC notifications into flat objects with a yokeType field.
@@ -1220,6 +1221,13 @@ function createCodexAdapter(opts) {
   var _cwd = (opts && opts.cwd) || process.cwd();
   var _slug = (opts && opts.slug) || "";
   var _defaultInitOpts = Object.assign({}, opts || {});
+  var _runtimeLinuxUser = (opts && opts.runtimeLinuxUser) || null;
+  var _requiresLinuxUser = !!(opts && opts.osUsers) && !_runtimeLinuxUser;
+  var _userRuntimes = Object.create(null);
+  var _resolveOsUserInfo = (opts && opts.resolveOsUserInfo) || resolveOsUserInfo;
+  var _createAppServer = (opts && opts.createAppServer) || function(serverOpts) {
+    return new CodexAppServer(null, serverOpts);
+  };
   // Codex models are a fixed list (the app-server doesn't enumerate them), so
   // model listing must not depend on a successful app-server init — otherwise a
   // slow/failed `initialize` leaves the picker empty and the chip shows the
@@ -1243,6 +1251,45 @@ function createCodexAdapter(opts) {
   var _lastActiveAt = Date.now();
   var _shuttingDown = false;
   var _activeQueries = [];
+
+  function withoutLinuxUser(callOpts) {
+    var cleaned = Object.assign({}, callOpts || {});
+    delete cleaned.linuxUser;
+    return cleaned;
+  }
+
+  function getUserRuntime(linuxUser) {
+    if (!linuxUser) return null;
+    if (_runtimeLinuxUser) {
+      if (_runtimeLinuxUser !== linuxUser) {
+        throw new Error("Codex runtime user mismatch: expected " + _runtimeLinuxUser + ", received " + linuxUser);
+      }
+      return adapter;
+    }
+    if (!_userRuntimes[linuxUser]) {
+      var runtimeOpts = Object.assign({}, _defaultInitOpts, {
+        runtimeLinuxUser: linuxUser,
+      });
+      delete runtimeOpts.linuxUser;
+      _userRuntimes[linuxUser] = createCodexAdapter(runtimeOpts);
+    }
+    return _userRuntimes[linuxUser];
+  }
+
+  function shutdownUserRuntimes(method, idleMs) {
+    var users = Object.keys(_userRuntimes);
+    if (!users.length) return Promise.resolve([]);
+    return Promise.all(users.map(function(linuxUser) {
+      var runtime = _userRuntimes[linuxUser];
+      var result = method === "shutdownIfIdle"
+        ? runtime.shutdownIfIdle(idleMs)
+        : runtime.shutdown();
+      return Promise.resolve(result).then(function(stopped) {
+        if (method === "shutdown" || stopped) delete _userRuntimes[linuxUser];
+        return stopped;
+      });
+    }));
+  }
 
   function updateLastActiveAt() {
     _lastActiveAt = Date.now();
@@ -1396,6 +1443,16 @@ function createCodexAdapter(opts) {
     vendor: "codex",
 
     init: function(initOpts) {
+      var requestedLinuxUser = initOpts && initOpts.linuxUser;
+      if (!_runtimeLinuxUser && requestedLinuxUser) {
+        return getUserRuntime(requestedLinuxUser).init(withoutLinuxUser(initOpts));
+      }
+      if (_requiresLinuxUser) {
+        return Promise.reject(new Error("Codex requires a mapped Linux user while OS-user isolation is enabled"));
+      }
+      if (_runtimeLinuxUser && requestedLinuxUser && requestedLinuxUser !== _runtimeLinuxUser) {
+        return Promise.reject(new Error("Codex runtime user mismatch"));
+      }
       if (_shuttingDown) {
         return Promise.reject(createShutdownError());
       }
@@ -1412,6 +1469,9 @@ function createCodexAdapter(opts) {
 
       _initPromise = (async function() {
         var serverOpts = { cwd: _cwd };
+        if (_runtimeLinuxUser) {
+          serverOpts.osUserInfo = _resolveOsUserInfo(_runtimeLinuxUser);
+        }
 
         // Extract adapter options
         if (effectiveInitOpts && effectiveInitOpts.adapterOptions && effectiveInitOpts.adapterOptions.CODEX) {
@@ -1478,7 +1538,7 @@ function createCodexAdapter(opts) {
         }
 
         // Spawn and initialize app-server
-        _appServer = new CodexAppServer(null, serverOpts);
+        _appServer = _createAppServer(serverOpts);
         await _appServer.start();
 
         await _appServer.send("initialize", {
@@ -1565,6 +1625,16 @@ function createCodexAdapter(opts) {
     },
 
     createQuery: async function(queryOpts) {
+      var requestedLinuxUser = queryOpts && queryOpts.linuxUser;
+      if (!_runtimeLinuxUser && requestedLinuxUser) {
+        return getUserRuntime(requestedLinuxUser).createQuery(withoutLinuxUser(queryOpts));
+      }
+      if (_requiresLinuxUser) {
+        throw new Error("Codex requires a mapped Linux user while OS-user isolation is enabled");
+      }
+      if (_runtimeLinuxUser && requestedLinuxUser && requestedLinuxUser !== _runtimeLinuxUser) {
+        throw new Error("Codex runtime user mismatch");
+      }
       if (_shuttingDown) {
         throw createShutdownError();
       }
@@ -1661,6 +1731,13 @@ function createCodexAdapter(opts) {
 
     // --- Title generation ---
     generateTitle: async function(messages, opts) {
+      var requestedLinuxUser = opts && opts.linuxUser;
+      if (!_runtimeLinuxUser && requestedLinuxUser) {
+        return getUserRuntime(requestedLinuxUser).generateTitle(messages, withoutLinuxUser(opts));
+      }
+      if (_requiresLinuxUser) {
+        throw new Error("Codex requires a mapped Linux user while OS-user isolation is enabled");
+      }
       var systemPrompt = "You are a title generator. Output only a short title (3-8 words). No quotes, no punctuation at the end, no explanation.";
       var prompt = "Below is a conversation between a user and an AI assistant. Generate a short, descriptive title (3-8 words) that captures the main topic. Reply with ONLY the title, nothing else.\n\n";
       for (var i = 0; i < messages.length; i++) {
@@ -1708,6 +1785,11 @@ function createCodexAdapter(opts) {
     listSessions: function() { return Promise.resolve([]); },
     renameSession: function() { return Promise.resolve(); },
     forkSession: function(threadId, opts) {
+      var requestedLinuxUser = opts && opts.linuxUser;
+      if (!_runtimeLinuxUser && requestedLinuxUser) {
+        return getUserRuntime(requestedLinuxUser).forkSession(threadId, withoutLinuxUser(opts));
+      }
+      if (_requiresLinuxUser) return Promise.reject(new Error("Codex requires a mapped Linux user while OS-user isolation is enabled"));
       if (!_appServer || !_appServer.started) return Promise.resolve(null);
       return _appServer.send("thread/fork", { threadId: threadId }, 30000).then(function(result) {
         var newThreadId = (result && result.thread) ? result.thread.id : null;
@@ -1715,17 +1797,30 @@ function createCodexAdapter(opts) {
         return { sessionId: newThreadId };
       });
     },
-    rollbackThread: function(threadId, numTurns) {
+    rollbackThread: function(threadId, numTurns, opts) {
+      var requestedLinuxUser = opts && opts.linuxUser;
+      if (!_runtimeLinuxUser && requestedLinuxUser) {
+        return getUserRuntime(requestedLinuxUser).rollbackThread(threadId, numTurns, withoutLinuxUser(opts));
+      }
+      if (_requiresLinuxUser) return Promise.reject(new Error("Codex requires a mapped Linux user while OS-user isolation is enabled"));
       if (!_appServer || !_appServer.started) return Promise.resolve(null);
       return _appServer.send("thread/rollback", { threadId: threadId, numTurns: numTurns }, 30000);
     },
 
     // Shutdown the app-server process
     shutdown: function() {
-      return beginShutdown(true);
+      return Promise.all([
+        beginShutdown(true),
+        shutdownUserRuntimes("shutdown"),
+      ]).then(function() { return true; });
     },
 
     shutdownIfIdle: function(idleMs) {
+      if (!_runtimeLinuxUser && Object.keys(_userRuntimes).length > 0) {
+        return shutdownUserRuntimes("shutdownIfIdle", idleMs).then(function(results) {
+          return results.some(function(stopped) { return !!stopped; });
+        });
+      }
       if (_shuttingDown || _shutdownPromise) return Promise.resolve(false);
       if (_initPromise) return Promise.resolve(false);
       if (!_appServer) return Promise.resolve(false);

--- a/lib/yoke/codex-app-server.js
+++ b/lib/yoke/codex-app-server.js
@@ -9,6 +9,8 @@ var readline = require("readline");
 var path = require("path");
 var fs = require("fs");
 var { createRequire } = require("module");
+var { buildUserEnv } = require("../build-user-env");
+var { wrapSpawnAsUser } = require("../os-users");
 
 // --- Find the codex binary path ---
 // Mirrors the logic from @openai/codex-sdk findCodexPath()
@@ -120,14 +122,30 @@ function CodexAppServer(executablePath, opts) {
   this._stderrBuf = "";
 }
 
+function buildSpawnSpec(executablePath, args, opts, wrapFn) {
+  opts = opts || {};
+  var osUserInfo = opts.osUserInfo || null;
+  var env = osUserInfo
+    ? Object.assign(buildUserEnv(osUserInfo), opts.env || {})
+    : Object.assign({}, process.env, opts.env || {});
+  var spawnOptions = {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: env,
+    cwd: opts.cwd || process.cwd(),
+  };
+  if (osUserInfo) {
+    spawnOptions.uid = osUserInfo.uid;
+    spawnOptions.gid = osUserInfo.gid;
+  }
+  return (wrapFn || wrapSpawnAsUser)(executablePath, args, spawnOptions);
+}
+
 CodexAppServer.prototype.start = function() {
   var self = this;
 
   return new Promise(function(resolve, reject) {
     try {
       var args = ["app-server"];
-      var env = Object.assign({}, process.env, self.opts.env || {});
-
       // Pass config overrides via --config key=value flags
       if (self.opts.config) {
         var configArgs = serializeConfig(self.opts.config, "");
@@ -136,13 +154,11 @@ CodexAppServer.prototype.start = function() {
         }
       }
 
-      console.log("[codex-app-server] Spawning:", self.executablePath, args.join(" "));
+      var spawnSpec = buildSpawnSpec(self.executablePath, args, self.opts);
+      var userSuffix = self.opts.osUserInfo ? " as " + self.opts.osUserInfo.user : "";
+      console.log("[codex-app-server] Spawning" + userSuffix + ":", spawnSpec.command, spawnSpec.args.join(" "));
 
-      self.proc = spawn(self.executablePath, args, {
-        stdio: ["pipe", "pipe", "pipe"],
-        env: env,
-        cwd: self.opts.cwd || process.cwd(),
-      });
+      self.proc = spawn(spawnSpec.command, spawnSpec.args, spawnSpec.options);
 
       self.proc.on("error", function(err) {
         console.error("[codex-app-server] Process error:", err.message);
@@ -383,4 +399,5 @@ CodexAppServer.prototype.stop = function() {
 module.exports = {
   CodexAppServer: CodexAppServer,
   findCodexPath: findCodexPath,
+  buildSpawnSpec: buildSpawnSpec,
 };

--- a/lib/yoke/index.js
+++ b/lib/yoke/index.js
@@ -350,7 +350,7 @@ function createAdapters(opts) {
 
   if (installed.codex && supportsConfiguredIsolation("codex")) {
     try {
-      adapters.codex = createAdapter({ vendor: "codex", cwd: opts.cwd, slug: opts.slug });
+      adapters.codex = createAdapter({ vendor: "codex", cwd: opts.cwd, slug: opts.slug, osUsers: !!opts.osUsers });
       auth.codex = true;
       console.log("[yoke] Adapter created: codex");
     } catch (e) {
@@ -411,7 +411,12 @@ async function lazyCreateAdapter(adapters, vendor, opts) {
   if (!installed[vendor]) return null;
 
   try {
-    var ad = createAdapter({ vendor: vendor, cwd: opts.cwd, slug: opts.slug });
+    var ad = createAdapter({
+      vendor: vendor,
+      cwd: opts.cwd,
+      slug: opts.slug,
+      osUsers: !!(opts.osUsers || opts.linuxUser),
+    });
     if (typeof ad.init === "function") {
       await ad.init(opts || {});
     }

--- a/test/codex-app-server-routing.test.js
+++ b/test/codex-app-server-routing.test.js
@@ -1,7 +1,7 @@
 var test = require("node:test");
 var assert = require("node:assert");
 
-var { CodexAppServer } = require("../lib/yoke/codex-app-server");
+var { CodexAppServer, buildSpawnSpec } = require("../lib/yoke/codex-app-server");
 
 function makeServer() {
   var server = new CodexAppServer("/nonexistent/codex", {});
@@ -80,4 +80,37 @@ test("rejects an unroutable Codex request instead of dropping it", function() {
   assert.strictEqual(server.written.length, 1);
   assert.strictEqual(server.written[0].id, 7);
   assert.ok(server.written[0].error);
+});
+
+test("builds an OS-user Codex spawn without leaking the daemon environment", function() {
+  var previousSecret = process.env.CLAY_TEST_DAEMON_SECRET;
+  process.env.CLAY_TEST_DAEMON_SECRET = "must-not-leak";
+  var wrappedOptions = null;
+  try {
+    var spec = buildSpawnSpec("/usr/bin/codex", ["app-server"], {
+      cwd: "/workspace",
+      env: { OPENAI_API_KEY: "user-key" },
+      osUserInfo: {
+        uid: 1201,
+        gid: 1202,
+        home: "/home/alice",
+        user: "alice",
+        shell: "/bin/bash",
+      },
+    }, function(command, args, options) {
+      wrappedOptions = options;
+      return { command: command, args: args, options: options };
+    });
+
+    assert.strictEqual(spec.command, "/usr/bin/codex");
+    assert.strictEqual(wrappedOptions.uid, 1201);
+    assert.strictEqual(wrappedOptions.gid, 1202);
+    assert.strictEqual(wrappedOptions.env.HOME, "/home/alice");
+    assert.strictEqual(wrappedOptions.env.USER, "alice");
+    assert.strictEqual(wrappedOptions.env.OPENAI_API_KEY, "user-key");
+    assert.strictEqual(wrappedOptions.env.CLAY_TEST_DAEMON_SECRET, undefined);
+  } finally {
+    if (previousSecret === undefined) delete process.env.CLAY_TEST_DAEMON_SECRET;
+    else process.env.CLAY_TEST_DAEMON_SECRET = previousSecret;
+  }
 });

--- a/test/codex-os-user-isolation.test.js
+++ b/test/codex-os-user-isolation.test.js
@@ -1,0 +1,69 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+var { createCodexAdapter } = require("../lib/yoke/adapters/codex");
+
+function fakeUserInfo(username) {
+  return {
+    uid: username === "alice" ? 1201 : 1202,
+    gid: username === "alice" ? 1301 : 1302,
+    home: "/home/" + username,
+    user: username,
+    shell: "/bin/bash",
+  };
+}
+
+function createFakeServer(options) {
+  return {
+    options: options,
+    started: false,
+    proc: null,
+    start: function() {
+      this.started = true;
+      return Promise.resolve();
+    },
+    send: function(method) {
+      if (method === "skills/list") return Promise.resolve({ data: [] });
+      return Promise.resolve({});
+    },
+    notify: function() {},
+    stop: function() { this.started = false; },
+  };
+}
+
+test("Codex creates and reuses a separate app-server for each mapped Linux user", async function() {
+  var servers = [];
+  var adapter = createCodexAdapter({
+    cwd: process.cwd(),
+    osUsers: true,
+    resolveOsUserInfo: fakeUserInfo,
+    createAppServer: function(options) {
+      var server = createFakeServer(options);
+      servers.push(server);
+      return server;
+    },
+  });
+
+  await adapter.init({ linuxUser: "alice" });
+  await adapter.init({ linuxUser: "alice" });
+  await adapter.init({ linuxUser: "bob" });
+
+  assert.strictEqual(servers.length, 2);
+  assert.strictEqual(servers[0].options.osUserInfo.user, "alice");
+  assert.strictEqual(servers[1].options.osUserInfo.user, "bob");
+  assert.notStrictEqual(servers[0], servers[1]);
+});
+
+test("Codex fails closed when OS-user isolation lacks a mapped Linux user", async function() {
+  var adapter = createCodexAdapter({
+    cwd: process.cwd(),
+    osUsers: true,
+    resolveOsUserInfo: fakeUserInfo,
+    createAppServer: createFakeServer,
+  });
+
+  await assert.rejects(
+    adapter.init({}),
+    /requires a mapped Linux user/
+  );
+});

--- a/test/sdk-bridge-delivery.test.js
+++ b/test/sdk-bridge-delivery.test.js
@@ -54,6 +54,36 @@ test("pushMessage retires a query handle that rejects delivery", function() {
   assert.strictEqual(session.messageQueue, null);
 });
 
+test("mention sessions preserve the mapped Linux user", async function() {
+  var capturedOptions = null;
+  var handle = createEndingHandle([]);
+  var bridge = createSDKBridge({
+    cwd: process.cwd(),
+    sessionManager: {},
+    adapter: {
+      vendor: "codex",
+      createQuery: function(options) {
+        capturedOptions = options;
+        return Promise.resolve(handle);
+      },
+    },
+    send: function() {},
+  });
+
+  var mentionSession = await bridge.createMentionSession({
+    linuxUser: "clay-alice",
+    claudeMd: "",
+    initialContext: "context",
+    initialMessage: "question",
+    onDelta: function() {},
+    onDone: function() {},
+    onError: function() {},
+  });
+
+  assert.ok(mentionSession);
+  assert.strictEqual(capturedOptions.linuxUser, "clay-alice");
+});
+
 test("pushMessage retires a query handle that throws during delivery", function() {
   var bridge = createBridge();
   var query = {


### PR DESCRIPTION
## Summary
- run each Codex app-server under the mapped Linux user's UID, GID, HOME, and credentials
- keep separate Codex runtimes per Linux user instead of sharing one project-level process
- route model warmup, primary queries, titles, forks, rollbacks, mentions, debates, and memory jobs through the owning user's runtime
- recycle shared digest workers before processing a job for another Linux user
- fail closed when OS-user isolation is enabled but no Linux user is mapped
- prevent daemon environment secrets from leaking into isolated Codex processes

## Root cause
Codex was marked as supporting OS-user isolation, but its app-server was spawned directly with the daemon environment and without UID/GID switching. Because the adapter also shared one app-server per project, simply changing the spawn UID would have allowed multiple users to share the first user's process. Auxiliary mention, debate, and memory sessions also lacked user routing.

## Impact
In Linux OS-user mode, all Codex session types now use kernel-enforced user boundaries and per-user credentials as documented. Missing mappings produce an explicit error instead of silently running with daemon privileges.

## Checks
- Node syntax checks for all changed server modules
- targeted Codex isolation, routing, and auxiliary-session tests
- full Node 22 test suite: 47 test files passed
- `git diff --check`
