### PR TITLE
[codex] fix installed vendor state in new projects

### DIFF
--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -22,6 +22,17 @@ function dispatchMessageSafely(handleMessage, sendTo, slug, ws, msg) {
   }
 }
 
+function buildInitialModelInfo(sm, initialVendor, initialModel, initialModels) {
+  return {
+    type: "model_info",
+    model: initialModel || "",
+    models: initialModels || [],
+    vendor: initialVendor,
+    availableVendors: sm.availableVendors || [],
+    installedVendors: sm.installedVendors || [],
+  };
+}
+
 /**
  * Attach connection/disconnection handlers to a project context.
  *
@@ -167,9 +178,9 @@ function attachConnection(ctx) {
       sendTo(ws, { type: "slash_commands", commands: sm.slashCommands });
     }
     var initialModel = (restoredActive && restoredActive.model) || sm.currentModel || "";
-    if (initialModel) {
-      sendTo(ws, { type: "model_info", model: initialModel, models: initialModels, vendor: initialVendor, availableVendors: sm.availableVendors || [], installedVendors: sm.installedVendors || [] });
-    }
+    // Vendor installation state is needed even before a new project has a
+    // model. Always send it so reconnects cannot fall back to "Not installed."
+    sendTo(ws, buildInitialModelInfo(sm, initialVendor, initialModel, initialModels));
     sendTo(ws, { type: "config_state", model: initialModel, mode: sm.currentPermissionMode || "default", effort: initialEffort || "medium", betas: sm.currentBetas || [], thinking: sm.currentThinking || "adaptive", thinkingBudget: sm.currentThinkingBudget || 10000 });
     sendTo(ws, { type: "last_vendor", vendor: sm.lastVendor || "" });
     sendTo(ws, Object.assign({ type: "codex_config" }, getCodexConfig(sm)));
@@ -333,4 +344,8 @@ function attachConnection(ctx) {
   };
 }
 
-module.exports = { attachConnection: attachConnection, dispatchMessageSafely: dispatchMessageSafely };
+module.exports = {
+  attachConnection: attachConnection,
+  buildInitialModelInfo: buildInitialModelInfo,
+  dispatchMessageSafely: dispatchMessageSafely,
+};

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -1859,6 +1859,13 @@ function createSDKBridge(opts) {
     var defaultVendor = adapter ? adapter.vendor : "claude";
     sm.defaultVendor = defaultVendor;
 
+    // Installation detection is independent of adapter initialization. Publish
+    // it before warmup so a new project does not render the initial empty state
+    // as if every CLI were missing while the default adapter starts up.
+    sm.installedVendors = detectInstalledVendors(linuxUser);
+    sm.availableVendors = getAvailableVendors(linuxUser);
+    sendModelInfoForVendor(defaultVendor, sm.currentModel || "");
+
     // Initialize default adapter first (provides skills, slash commands, etc.)
     if (adapter) {
       try {
@@ -1910,19 +1917,8 @@ function createSDKBridge(opts) {
     //     actually issues a query with it.
     sm.modelsByVendor = sm.modelsByVendor || {};
 
-    // Detect installed vendors per-user (binary existence check)
-    sm.installedVendors = detectInstalledVendors(linuxUser);
-    sm.availableVendors = getAvailableVendors(linuxUser);
-
-    // Send initial state to client
-    send({
-      type: "model_info",
-      model: sm.currentModel || "",
-      models: getModelsForVendor(defaultVendor),
-      vendor: defaultVendor,
-      availableVendors: sm.availableVendors,
-      installedVendors: sm.installedVendors,
-    });
+    // Send the fully initialized state to the client.
+    sendModelInfoForVendor(defaultVendor, sm.currentModel || "");
   }
 
   async function setModel(session, model) {

--- a/test/vendor-installation-state.test.js
+++ b/test/vendor-installation-state.test.js
@@ -1,0 +1,58 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var { createSDKBridge } = require("../lib/sdk-bridge");
+var { buildInitialModelInfo } = require("../lib/project-connection");
+
+test("new project publishes installed vendors before adapter warmup completes", async function () {
+  var finishWarmup;
+  var warmupResult = new Promise(function (resolve) {
+    finishWarmup = resolve;
+  });
+  var adapter = {
+    vendor: "claude",
+    init: function () { return warmupResult; },
+  };
+  var sent = [];
+  var sm = {
+    availableModels: [],
+    modelsByVendor: {},
+    sessions: new Map(),
+    setSlashCommandsForVendor: function () {},
+  };
+  var bridge = createSDKBridge({
+    cwd: process.cwd(),
+    slug: "new-project",
+    sessionManager: sm,
+    send: function (msg) { sent.push(msg); },
+    adapter: adapter,
+    adapters: { claude: adapter },
+  });
+
+  var pendingWarmup = bridge.warmup(null);
+
+  assert.ok(Array.isArray(sm.installedVendors));
+  assert.strictEqual(sent.length, 1);
+  assert.strictEqual(sent[0].type, "model_info");
+  assert.deepStrictEqual(sent[0].installedVendors, sm.installedVendors);
+
+  finishWarmup({
+    models: [],
+    defaultModel: "",
+    skills: [],
+    slashCommands: [],
+    capabilities: {},
+  });
+  await pendingWarmup;
+});
+
+test("project connection includes vendor state when the model is empty", function () {
+  var msg = buildInitialModelInfo({
+    availableVendors: ["claude", "codex", "kiro"],
+    installedVendors: ["claude", "codex", "kiro"],
+  }, "claude", "", []);
+
+  assert.strictEqual(msg.type, "model_info");
+  assert.strictEqual(msg.model, "");
+  assert.deepStrictEqual(msg.installedVendors, ["claude", "codex", "kiro"]);
+  assert.deepStrictEqual(msg.availableVendors, ["claude", "codex", "kiro"]);
+});


### PR DESCRIPTION
## What changed

- publish installed vendor state before the default adapter warmup starts
- include vendor state on every project connection, even when no model exists yet
- add regression coverage for new-project warmup and empty-model reconnects

## Why

New projects rendered the vendor picker before installation detection completed. The client interpreted the missing state as an empty installed-vendor list, so installed CLIs appeared as `Not installed`. Reconnecting could preserve the incorrect state when the project had no initial model.

## Impact

Claude Code, Codex, Kiro, and other detected vendors now appear as installed immediately in new projects without waiting for adapter initialization.

## Verification

- Node 22 full test suite: 250 passed, 0 failed
- client import validation: 92 modules passed
- syntax checks for changed server files
- `git diff --check`
