### PR TITLE
[codex] prefer installed vendors for blank sessions

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -295,6 +295,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     slashCommands: [],
     processing: false,
     activeSessionId: null,
+    sessionVendorBound: false,
     cliSessionId: null,
     isHeadlessMode: false,
     savedMainSlug: null,

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -52,6 +52,7 @@ import { setStatus } from './app-connection.js';
 import { handleWhatsNewState, handleWhatsNewSeenResult, setKnownEntries as setWhatsNewKnownEntries } from './whats-new.js';
 import { closeArticle as closeWhatsNewArticle } from './whats-new-article.js';
 import { resolvePaneSession, resolveSwitchedVendor } from './pane-session.js';
+import { selectDefaultVendorForBlankSession } from './vendor-selection.js';
 import { getModelEffortLevels, accumulateUsage, updateUsagePanel, accumulateContext, updateContextPanel, renderCtxPopover, updateStatusPanel } from './app-panels.js';
 import { updateProjectList, resetClientState, showUpdateAvailable, handleRemoveProjectCheckResult, handleRemoveProjectResult, handleBrowseDirResult, handleAddProjectResult, handleCloneProgress } from './app-projects.js';
 import { updateHistorySentinel, prependOlderHistory } from './app-header.js';
@@ -414,6 +415,15 @@ export function processMessage(msg) {
         break;
 
       case "model_info": {
+        // Installation state applies across vendors. Keep it even when the
+        // model payload itself is stale for the active session.
+        var _vendorState = {};
+        if (msg.availableVendors) _vendorState.availableVendors = msg.availableVendors;
+        if (msg.installedVendors) _vendorState.installedVendors = msg.installedVendors;
+        if (Object.keys(_vendorState).length > 0) {
+          store.set(_vendorState);
+          selectDefaultVendorForBlankSession();
+        }
         // Drop stale model_info from a vendor that doesn't match the active
         // session's vendor. On high-latency connections, the server's default-
         // adapter model_info can arrive after session_switched has already
@@ -447,8 +457,6 @@ export function processMessage(msg) {
           _miUpdate.currentModel = store.get('currentModel');
         }
         if (msg.vendor && !store.get('vendorSelectionLocked')) _miUpdate.currentVendor = msg.vendor;
-        if (msg.availableVendors) _miUpdate.availableVendors = msg.availableVendors;
-        if (msg.installedVendors) _miUpdate.installedVendors = msg.installedVendors;
         if (msg.capabilities) _miUpdate.vendorCapabilities = msg.capabilities;
         store.set(_miUpdate);
         updateSettingsModels(_modelVal, msg.models || []);
@@ -661,7 +669,7 @@ export function processMessage(msg) {
         var _effectiveTerminalId = (typeof msg.runtimeTerminalId === "number")
           ? msg.runtimeTerminalId
           : (typeof msg.terminalId === "number" ? msg.terminalId : null);
-        store.set({ activeSessionId: msg.id, cliSessionId: msg.cliSessionId || null, currentModel: msg.model || store.get('currentModel'), currentEffort: msg.effort || store.get('currentEffort'), vendorCapabilities: msg.capabilities || {}, sessionIsProcessing: !!msg.isProcessing, activeSessionMode: _effectiveMode, activeTerminalId: _effectiveTerminalId, sessionHasHistory: !!msg.hasHistory, sessionFullAccess: msg.permissionMode === "bypassPermissions", currentMode: msg.permissionMode || store.get('currentMode') });
+        store.set({ activeSessionId: msg.id, cliSessionId: msg.cliSessionId || null, currentModel: msg.model || store.get('currentModel'), currentEffort: msg.effort || store.get('currentEffort'), vendorCapabilities: msg.capabilities || {}, sessionIsProcessing: !!msg.isProcessing, activeSessionMode: _effectiveMode, activeTerminalId: _effectiveTerminalId, sessionHasHistory: !!msg.hasHistory, sessionVendorBound: !!msg.vendor || !!msg.hasHistory, sessionFullAccess: msg.permissionMode === "bypassPermissions", currentMode: msg.permissionMode || store.get('currentMode') });
         // TUI sessions swap the chat UI for an embedded xterm running
         // `claude` inside a real PTY. Mount or tear down before the rest of
         // the chat-side bookkeeping runs so we don't waste work on hidden DOM.
@@ -706,7 +714,7 @@ export function processMessage(msg) {
           }
         }
         if (!msg.hasHistory && !msg.vendor) {
-          // Preserve explicit pre-message vendor choice on brand-new sessions.
+          selectDefaultVendorForBlankSession();
         }
         // Vendor toggle visibility + active-vendor indicator next to the
         // model chip.

--- a/lib/public/modules/app-panels.js
+++ b/lib/public/modules/app-panels.js
@@ -474,7 +474,7 @@ export function initPanels() {
     if (vendor === (store.get('currentVendor') || "claude")) return;
     var installed = store.get('installedVendors') || [];
     if (installed.indexOf(vendor) === -1) return;
-    store.set({ currentVendor: vendor, currentModel: "", currentModels: [], vendorSelectionLocked: true });
+    store.set({ currentVendor: vendor, currentModel: "", currentModels: [], vendorSelectionLocked: true, sessionVendorBound: true });
     var ws = getWs();
     if (ws) ws.send(JSON.stringify({ type: "set_vendor", vendor: vendor }));
   }

--- a/lib/public/modules/app-rendering.js
+++ b/lib/public/modules/app-rendering.js
@@ -13,6 +13,7 @@ import { showImageModal, showPasteModal } from './app-misc.js';
 import { sendMessage, hasSendableContent } from './input.js';
 import { getChatLayout } from './theme.js';
 import { getScheduledMsgEl } from './app-rate-limit.js';
+export { VENDOR_ORDER } from './vendor-priority.js';
 
 // Keep these client constants aligned with lib/yoke/vendor-registry.js. The
 // browser cannot import the server's CommonJS registry directly.
@@ -33,7 +34,6 @@ export var VENDOR_NAMES = {
 // Display order for every vendor Clay knows about, installed or not. Pickers
 // render the full list so a missing CLI reads as "not installed yet" rather
 // than "Clay doesn't support it".
-export var VENDOR_ORDER = ["claude", "codex", "antigravity", "opencode", "kiro"];
 // Where to send the user when they pick a vendor whose CLI isn't installed.
 export var VENDOR_HOMEPAGES = {
   claude: "https://claude.com/product/claude-code",

--- a/lib/public/modules/sidebar-sessions.js
+++ b/lib/public/modules/sidebar-sessions.js
@@ -299,13 +299,10 @@ function appendSessionCloseButton(el, session) {
   el.appendChild(closeBtn);
 }
 
-// Resolve the vendor the "New session" button should launch: the project's
-// last-used vendor when its CLI is still installed, else the first installed
-// vendor, else Claude (so the button always has a sane label to render).
+// Resolve the vendor the "New session" button should launch from the stable
+// installed-vendor priority (Claude, then Codex, then the remaining vendors).
 export function resolveDefaultVendor() {
   var installed = store.get('installedVendors') || [];
-  var last = store.get('lastVendor') || "";
-  if (last && installed.indexOf(last) !== -1) return last;
   for (var i = 0; i < VENDOR_ORDER.length; i++) {
     if (installed.indexOf(VENDOR_ORDER[i]) !== -1) return VENDOR_ORDER[i];
   }
@@ -330,6 +327,7 @@ export function startNewSession(vendor, extra) {
     currentModel: "",
     currentModels: [],
     vendorSelectionLocked: true,
+    sessionVendorBound: true,
   });
 }
 

--- a/lib/public/modules/vendor-priority.js
+++ b/lib/public/modules/vendor-priority.js
@@ -1,0 +1,9 @@
+export var VENDOR_ORDER = ["claude", "codex", "antigravity", "opencode", "kiro"];
+
+export function firstInstalledVendor(installedVendors) {
+  var installed = Array.isArray(installedVendors) ? installedVendors : [];
+  for (var i = 0; i < VENDOR_ORDER.length; i++) {
+    if (installed.indexOf(VENDOR_ORDER[i]) !== -1) return VENDOR_ORDER[i];
+  }
+  return "";
+}

--- a/lib/public/modules/vendor-selection.js
+++ b/lib/public/modules/vendor-selection.js
@@ -1,0 +1,20 @@
+import { store } from './store.js';
+import { firstInstalledVendor } from './vendor-priority.js';
+
+export function selectDefaultVendorForBlankSession() {
+  var state = store.snap();
+  if (!state.activeSessionId || state.sessionHasHistory || state.sessionVendorBound || state.dmMode) return "";
+  var vendor = firstInstalledVendor(state.installedVendors);
+  if (!vendor) return "";
+  if (vendor === state.currentVendor) {
+    if (state.vendorSelectionLocked) store.set({ vendorSelectionLocked: false });
+    return vendor;
+  }
+  store.set({
+    currentVendor: vendor,
+    currentModel: "",
+    currentModels: [],
+    vendorSelectionLocked: false,
+  });
+  return vendor;
+}

--- a/test/vendor-priority.test.js
+++ b/test/vendor-priority.test.js
@@ -1,0 +1,26 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+function loadVendorPriority() {
+  var file = path.join(__dirname, "../lib/public/modules/vendor-priority.js");
+  var source = fs.readFileSync(file, "utf8");
+  return import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+}
+
+test("installed vendor selection prefers Claude over Codex", async function () {
+  var vendorPriority = await loadVendorPriority();
+  assert.strictEqual(vendorPriority.firstInstalledVendor(["codex", "claude", "kiro"]), "claude");
+});
+
+test("installed vendor selection falls back to Codex", async function () {
+  var vendorPriority = await loadVendorPriority();
+  assert.strictEqual(vendorPriority.firstInstalledVendor(["kiro", "codex"]), "codex");
+});
+
+test("installed vendor selection follows remaining priority and handles none", async function () {
+  var vendorPriority = await loadVendorPriority();
+  assert.strictEqual(vendorPriority.firstInstalledVendor(["kiro", "opencode"]), "opencode");
+  assert.strictEqual(vendorPriority.firstInstalledVendor([]), "");
+});


### PR DESCRIPTION
## Summary

- automatically select installed vendors for blank sessions in a stable Claude → Codex → remaining-vendors order
- keep installation metadata even when a stale model response is ignored
- preserve explicit manual vendor selections and bound session vendors

## Why

A new project could inherit stale client-side vendor state and show Codex even when Claude was installed. Installation metadata was also discarded together with stale model payloads, preventing the blank session from correcting itself.

## Impact

New and unbound sessions now start with Claude when available, fall back to Codex, and then use the remaining supported vendors in priority order. The existing composer and mobile experience are unchanged.

## Validation

- `node --test test/vendor-priority.test.js`
- ES module syntax checks for all changed client modules
- `git diff --check`

The repository-wide test command could not run normally in the local Node 18 environment because the project script uses `--test-force-exit`, and several existing tests require newer `node:test` APIs.
