### PR TITLE
[codex] Show split notification banner once

### DIFF
--- a/lib/public/css/pane.css
+++ b/lib/public/css/pane.css
@@ -23,6 +23,10 @@ body.pane-mode #sticky-notes-container {
   display: none !important;
 }
 
+body.pane-mode .notif-banner-container {
+  display: none !important;
+}
+
 body.pane-mode #main-area {
   border: 0;
   border-radius: 0;

--- a/test/split-view.test.js
+++ b/test/split-view.test.js
@@ -102,10 +102,12 @@ test("worker delegation notice joins the composer without a gap", function () {
 
 test("split pane clients leave notification banners to the parent shell", function () {
   var notificationsSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-notifications.js"), "utf8");
+  var paneCss = fs.readFileSync(path.join(__dirname, "../lib/public/css/pane.css"), "utf8");
   var initStart = notificationsSource.indexOf("export function initAppNotifications()");
   var initEnd = notificationsSource.indexOf("// ========================================================", initStart);
   var initSource = notificationsSource.slice(initStart, initEnd);
 
   assert.match(initSource, /if \(store\.get\('paneMode'\)\) return;/);
   assert.ok(initSource.indexOf("paneMode") < initSource.indexOf('document.createElement("div")'));
+  assert.match(paneCss, /body\.pane-mode \.notif-banner-container\s*\{[^}]*display:\s*none !important/s);
 });


### PR DESCRIPTION
## Summary

- Suppress notification banners inside pane-mode iframe clients.
- Keep the parent split shell as the single banner surface.
- Add a CSS fallback and regression coverage.

## Why

Each split iframe could render the same global banner, producing duplicate notifications across the screen. Pane clients should leave global notifications to the parent shell.

## Checks

- `node --test test/split-view.test.js`
- `git diff --check`
