### PR TITLE
[codex] Open pane web links in new tabs

### DIFF
--- a/lib/public/modules/pane-bridge.js
+++ b/lib/public/modules/pane-bridge.js
@@ -5,6 +5,7 @@
 
 import { store } from './store.js';
 import { applyContextView, getContextView } from './app-panels.js';
+import { forceExternalLinkToNewTab } from './pane-links.js';
 
 var panelOpen = false;
 
@@ -29,9 +30,19 @@ function togglePaneContextPanel() {
   applyContextView(panelOpen ? "panel" : "off");
 }
 
+function preparePaneLink(event) {
+  var target = event.target;
+  if (!target || typeof target.closest !== "function") return;
+  var anchor = target.closest("a[href]");
+  if (!anchor || anchor.hasAttribute("download")) return;
+  forceExternalLinkToNewTab(anchor, window.location.href);
+}
+
 export function initPaneBridge() {
   if (!store.get('paneMode')) return;
   panelOpen = getContextView() === "panel";
+  document.addEventListener("click", preparePaneLink, true);
+  document.addEventListener("auxclick", preparePaneLink, true);
   window.addEventListener("message", function (event) {
     if (event.origin !== window.location.origin) return;
     var msg = event.data;

--- a/lib/public/modules/pane-links.js
+++ b/lib/public/modules/pane-links.js
@@ -1,0 +1,23 @@
+export function isExternalWebLink(href, currentHref) {
+  if (!href) return false;
+  try {
+    var url = new URL(href, currentHref);
+    var currentUrl = new URL(currentHref);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    return url.origin !== currentUrl.origin;
+  } catch (err) {
+    return false;
+  }
+}
+
+export function forceExternalLinkToNewTab(anchor, currentHref) {
+  if (!anchor || !isExternalWebLink(anchor.href, currentHref)) return false;
+
+  var rel = (anchor.getAttribute("rel") || "").split(/\s+/).filter(Boolean);
+  if (rel.indexOf("noopener") === -1) rel.push("noopener");
+  if (rel.indexOf("noreferrer") === -1) rel.push("noreferrer");
+
+  anchor.setAttribute("target", "_blank");
+  anchor.setAttribute("rel", rel.join(" "));
+  return true;
+}

--- a/test/pane-links.test.js
+++ b/test/pane-links.test.js
@@ -1,0 +1,48 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var helpersPromise = null;
+function loadHelpers() {
+  if (!helpersPromise) {
+    var file = path.join(__dirname, "../lib/public/modules/pane-links.js");
+    var source = fs.readFileSync(file, "utf8");
+    helpersPromise = import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+  }
+  return helpersPromise;
+}
+
+function fakeAnchor(href, rel) {
+  var attributes = { rel: rel || "" };
+  return {
+    href: href,
+    attributes: attributes,
+    getAttribute: function (name) { return attributes[name] || null; },
+    setAttribute: function (name, value) { attributes[name] = value; },
+  };
+}
+
+test("pane links force external web destinations into a new tab", async function () {
+  var helpers = await loadHelpers();
+  var anchor = fakeAnchor("https://example.com/docs", "nofollow");
+
+  assert.strictEqual(helpers.forceExternalLinkToNewTab(anchor, "https://clay.test/p/project"), true);
+  assert.strictEqual(anchor.attributes.target, "_blank");
+  assert.strictEqual(anchor.attributes.rel, "nofollow noopener noreferrer");
+});
+
+test("pane links preserve same-origin app navigation", async function () {
+  var helpers = await loadHelpers();
+  var anchor = fakeAnchor("https://clay.test/p/another-project");
+
+  assert.strictEqual(helpers.forceExternalLinkToNewTab(anchor, "https://clay.test/p/project"), false);
+  assert.strictEqual(anchor.attributes.target, undefined);
+});
+
+test("pane links ignore non-web protocols", async function () {
+  var helpers = await loadHelpers();
+
+  assert.strictEqual(helpers.isExternalWebLink("mailto:hello@example.com", "https://clay.test/p/project"), false);
+  assert.strictEqual(helpers.isExternalWebLink("javascript:void(0)", "https://clay.test/p/project"), false);
+});

--- a/test/split-view.test.js
+++ b/test/split-view.test.js
@@ -109,3 +109,11 @@ test("split pane clients leave notification banners to the parent shell", functi
   assert.match(initSource, /if \(store\.get\('paneMode'\)\) return;/);
   assert.ok(initSource.indexOf("paneMode") < initSource.indexOf('document.createElement("div")'));
 });
+
+test("split pane clients prepare web links before browser navigation", function () {
+  var bridgeSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/pane-bridge.js"), "utf8");
+
+  assert.match(bridgeSource, /document\.addEventListener\("click", preparePaneLink, true\)/);
+  assert.match(bridgeSource, /document\.addEventListener\("auxclick", preparePaneLink, true\)/);
+  assert.match(bridgeSource, /forceExternalLinkToNewTab\(anchor, window\.location\.href\)/);
+});


### PR DESCRIPTION
## Summary

- Force external HTTP(S) links clicked inside pane iframes to use a new browser tab.
- Apply `noopener noreferrer` without discarding existing link relations.
- Preserve same-origin Clay navigation, downloads, and non-web protocols.
- Cover normal and auxiliary click preparation with regression tests.

## Why

Some links created inside a pane bypassed Markdown's static target handling and navigated the iframe itself. Sites that disallow framing then failed to render. Capturing pane link clicks ensures external destinations leave the iframe.

## Checks

- `node --test test/pane-links.test.js test/split-view.test.js`
- `git diff --check`
