### PR TITLE
[codex] Allow access to external worktrees

### DIFF
--- a/lib/daemon-projects.js
+++ b/lib/daemon-projects.js
@@ -41,10 +41,10 @@ function scanAndRegisterWorktrees(relay, parentPath, parentSlug, parentIcon, par
       if (worktreeRegistry[parentSlug][j] === wtSlug) { alreadyRegistered = true; break; }
     }
     if (alreadyRegistered) continue;
-    var wtMeta = { parentSlug: parentSlug, branch: wt.branch || wt.dirName, accessible: wt.accessible };
+    var wtMeta = { parentSlug: parentSlug, branch: wt.branch || wt.dirName, external: wt.external };
     relay.addProject(wt.path, wtSlug, wt.branch || wt.dirName, parentIcon, parentOwnerId, wtMeta);
     worktreeRegistry[parentSlug].push(wtSlug);
-    console.log("[daemon] Registered worktree:", wtSlug, "->", wt.path, wt.accessible ? "(accessible)" : "(inaccessible)");
+    console.log("[daemon] Registered worktree:", wtSlug, "->", wt.path, wt.external ? "(external)" : "(inside project folder)");
   }
   daemonSync.register(getWorktreeSyncKey(parentSlug), function () {
     rescanWorktrees(relay, parentPath, parentSlug, parentIcon, parentOwnerId);
@@ -79,7 +79,7 @@ function rescanWorktrees(relay, parentPath, parentSlug, parentIcon, parentOwnerI
         if (existingSlugs[ei] === wtSlug) { found = true; break; }
       }
       if (!found) {
-        var wtMeta = { parentSlug: parentSlug, branch: wt.branch || wt.dirName, accessible: wt.accessible };
+        var wtMeta = { parentSlug: parentSlug, branch: wt.branch || wt.dirName, external: wt.external };
         relay.addProject(wt.path, wtSlug, wt.branch || wt.dirName, parentIcon, parentOwnerId, wtMeta);
         if (!worktreeRegistry[parentSlug]) worktreeRegistry[parentSlug] = [];
         worktreeRegistry[parentSlug].push(wtSlug);

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -978,7 +978,7 @@ var relay = createServer({
     if (!result.ok) return result;
     // Register the new worktree as ephemeral project
     var wtSlug = parentSlug + "--" + dirName;
-    var wtMeta = { parentSlug: parentSlug, branch: branchName, accessible: true };
+    var wtMeta = { parentSlug: parentSlug, branch: branchName, external: false };
     relay.addProject(result.path, wtSlug, branchName, parent.icon, parent.ownerId, wtMeta);
     registerWorktreeSlug(parentSlug, wtSlug);
     console.log("[daemon] Created worktree:", wtSlug, "->", result.path);

--- a/lib/project.js
+++ b/lib/project.js
@@ -163,7 +163,7 @@ function createProjectContext(opts) {
   var updateChannel = opts.updateChannel || "stable";
   var osUsers = opts.osUsers || false;
   var projectOwnerId = opts.projectOwnerId || null;
-  var worktreeMeta = opts.worktreeMeta || null; // { parentSlug, branch, accessible }
+  var worktreeMeta = opts.worktreeMeta || null; // { parentSlug, branch, external }
   var isMate = opts.isMate || false;
   var onCreateWorktree = opts.onCreateWorktree || null;
   var serverPort = opts.port || 2633;
@@ -1815,7 +1815,7 @@ function createProjectContext(opts) {
       status.isWorktree = true;
       status.parentSlug = worktreeMeta.parentSlug;
       status.branch = worktreeMeta.branch;
-      status.worktreeAccessible = worktreeMeta.accessible;
+      status.worktreeExternal = worktreeMeta.external === true;
     }
     if (usersModule.isMultiUser()) {
       var seen = {};

--- a/lib/public/css/command-palette.css
+++ b/lib/public/css/command-palette.css
@@ -434,6 +434,7 @@
    on hover/active, and a 4-direction drop-shadow + white glow on the
    emoji img for readability on either background. */
 .project-switcher-item .cmd-palette-item-icon {
+  position: relative;
   width: 44px;
   height: 44px;
   font-size: 28px;
@@ -446,6 +447,26 @@
   color: var(--text-secondary);
   flex-shrink: 0;
   transition: background 0.15s, color 0.15s;
+}
+.project-switcher-external-badge {
+  position: absolute;
+  right: -5px;
+  bottom: -5px;
+  width: 17px;
+  height: 17px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--bg);
+  border-radius: 50%;
+  background: var(--warning);
+  color: var(--bg);
+  pointer-events: none;
+}
+.project-switcher-item .cmd-palette-item-icon .project-switcher-external-badge .lucide {
+  width: 9px;
+  height: 9px;
+  stroke-width: 2.8;
 }
 .project-switcher-item .cmd-palette-item-icon .lucide {
   width: 22px;
@@ -515,8 +536,7 @@
   letter-spacing: 0.5px;
 }
 
-/* Disabled tile (e.g. worktree with worktreeAccessible: false). Not a
-   valid switch target, so skip highlight, skip click, visually dim. */
+/* Disabled tiles are skipped by keyboard and pointer selection. */
 .project-switcher-item.disabled {
   opacity: 0.35;
   cursor: not-allowed;

--- a/lib/public/css/icon-strip.css
+++ b/lib/public/css/icon-strip.css
@@ -1257,19 +1257,26 @@
   z-index: 1;
 }
 
-/* Disabled/inaccessible worktree */
-.icon-strip-wt-item.wt-disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
+/* Worktree registered outside the main project folder. It remains usable;
+   the badge communicates location without treating it as an error. */
+.worktree-external-badge {
+  position: absolute;
+  right: 5px;
+  bottom: 1px;
+  width: 14px;
+  height: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 2px solid var(--sidebar-bg);
+  background: var(--warning);
+  color: var(--bg);
+  z-index: 3;
+  pointer-events: none;
 }
 
-.icon-strip-wt-item.wt-disabled::after {
-  content: "\1F6AB";
-  position: absolute;
-  font-size: 14px;
-  z-index: 3;
-  filter: grayscale(0.3);
-}
+.worktree-external-badge .lucide { width: 8px; height: 8px; stroke-width: 2.8; }
 
 /* Group add button */
 .icon-strip-group-add {
@@ -1420,10 +1427,19 @@ select.wt-modal-input {
   opacity: 0.85;
 }
 
-.mobile-project-item.wt-disabled {
-  opacity: 0.35;
-  cursor: not-allowed;
+.mobile-worktree-external-badge {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--warning) 14%, transparent);
+  color: var(--warning);
+  flex-shrink: 0;
 }
+
+.mobile-worktree-external-badge .lucide { width: 12px; height: 12px; stroke-width: 2.4; }
 
 .mobile-folder-chevron {
   font-size: 8px;

--- a/lib/public/modules/app-projects.js
+++ b/lib/public/modules/app-projects.js
@@ -322,7 +322,7 @@ export function renderProjectList() {
       isWorktree: p.isWorktree || false,
       parentSlug: p.parentSlug || null,
       branch: p.branch || null,
-      worktreeAccessible: p.worktreeAccessible !== undefined ? p.worktreeAccessible : true,
+      worktreeExternal: p.worktreeExternal === true,
     };
   });
   var st = store.snap();

--- a/lib/public/modules/project-switcher.js
+++ b/lib/public/modules/project-switcher.js
@@ -19,6 +19,7 @@ import { getCachedProjects, switchProject } from './app-projects.js';
 import { openDm } from './app-dm.js';
 import { mateAvatarUrl } from './avatar.js';
 import { parseEmojis } from './markdown.js';
+import { isExternalWorktree, externalWorktreeTooltip, appendExternalWorktreeBadge } from './worktree-location.js';
 
 var _projectMru = [];   // project slugs, most recent first
 var _mateMru = [];      // mate ids (mate_XXX), most recent first
@@ -257,18 +258,16 @@ function buildProjectEntries() {
   // Keep natural (server-provided) order so the list looks the same
   // every time the switcher opens. MRU only drives initial highlight.
   return projects.map(function (p) {
-    // Worktrees can end up "outside project path" (parent workspace
-    // unmounted or moved); those are effectively unreachable from
-    // this session and shouldn't be switchable.
-    var unreachable = p.isWorktree && p.worktreeAccessible === false;
+    var external = isExternalWorktree(p);
     return {
       key: p.slug,
       title: p.title || p.project || p.slug,
       icon: p.icon || null,
       fallbackIcon: 'folder',
       isCurrent: p.slug === store.get('currentSlug'),
-      disabled: unreachable,
-      disabledReason: unreachable ? 'Outside project path' : null,
+      external: external,
+      disabled: false,
+      disabledReason: null,
     };
   });
 }
@@ -336,6 +335,7 @@ function buildEntryNode(entry, index) {
   item.className = 'cmd-palette-item project-switcher-item';
   if (entry.disabled) item.classList.add('disabled');
   if (entry.disabled && entry.disabledReason) item.title = entry.disabledReason;
+  if (entry.external) item.title = externalWorktreeTooltip(entry.title);
   item.dataset.index = String(index);
 
   var iconWrap = document.createElement('div');
@@ -353,6 +353,7 @@ function buildEntryNode(entry, index) {
     fallback.setAttribute('data-lucide', entry.fallbackIcon || 'folder');
     iconWrap.appendChild(fallback);
   }
+  if (entry.external) appendExternalWorktreeBadge(iconWrap, 'project-switcher-external-badge');
   item.appendChild(iconWrap);
 
   var body = document.createElement('div');

--- a/lib/public/modules/sidebar-projects.js
+++ b/lib/public/modules/sidebar-projects.js
@@ -13,6 +13,7 @@ import { showIconTooltip, hideIconTooltip, closeUserCtxMenu, getCurrentDmUserId 
 import { switchProject, openAddProjectModal, getCachedProjects } from './app-projects.js';
 import { showHomeHub } from './app-home-hub.js';
 import { getPendingTuiAttention } from './app-notifications.js';
+import { isExternalWorktree, externalWorktreeTooltip, appendExternalWorktreeBadge } from './worktree-location.js';
 
 // --- Project state ---
 var cachedProjectList = [];
@@ -489,7 +490,7 @@ export function closeProjectCtxMenu() {
   }
 }
 
-function showIconCtxMenu(anchorEl, slug, name) {
+function showIconCtxMenu(anchorEl, slug, name, options) {
   closeProjectCtxMenu();
   if (closeUserCtxMenu) closeUserCtxMenu();
   closeEmojiPicker();
@@ -510,17 +511,19 @@ function showIconCtxMenu(anchorEl, slug, name) {
   menu.appendChild(iconItem);
 
   if (isWorktree) {
-    var removeWtItem = document.createElement("button");
-    removeWtItem.className = "project-ctx-item project-ctx-delete";
-    removeWtItem.innerHTML = iconHtml("trash-2") + " <span>Remove Worktree</span>";
-    removeWtItem.addEventListener("click", function (e) {
-      e.stopPropagation();
-      closeProjectCtxMenu();
-      if (getWs() && store.get('connected')) {
-        getWs().send(JSON.stringify({ type: "remove_project_check", slug: slug, name: name || slug }));
-      }
-    });
-    menu.appendChild(removeWtItem);
+    if (!options || options.canRemoveWorktree !== false) {
+      var removeWtItem = document.createElement("button");
+      removeWtItem.className = "project-ctx-item project-ctx-delete";
+      removeWtItem.innerHTML = iconHtml("trash-2") + " <span>Remove Worktree</span>";
+      removeWtItem.addEventListener("click", function (e) {
+        e.stopPropagation();
+        closeProjectCtxMenu();
+        if (getWs() && store.get('connected')) {
+          getWs().send(JSON.stringify({ type: "remove_project_check", slug: slug, name: name || slug }));
+        }
+      });
+      menu.appendChild(removeWtItem);
+    }
   } else {
     var wtItem = document.createElement("button");
     wtItem.className = "project-ctx-item";
@@ -1253,8 +1256,8 @@ export function renderIconStrip(projects, currentSlug) {
       (function (wt) {
         var wtEl = document.createElement("a");
         var isWtActive = wt.slug === currentSlug && !currentDmUserId;
-        var isAccessible = wt.worktreeAccessible !== false;
-        wtEl.className = "icon-strip-wt-item" + (isWtActive ? " active" : "") + (!isAccessible ? " wt-disabled" : "");
+        var isExternal = isExternalWorktree(wt);
+        wtEl.className = "icon-strip-wt-item" + (isWtActive ? " active" : "") + (isExternal ? " wt-external" : "");
         wtEl.href = "/p/" + wt.slug + "/";
         wtEl.dataset.slug = wt.slug;
 
@@ -1276,42 +1279,28 @@ export function renderIconStrip(projects, currentSlug) {
         if (wt.isProcessing) wtStatus.classList.add("processing");
         wtEl.appendChild(wtStatus);
 
-        var tooltipText = wt.name;
-        if (!isAccessible) {
-          tooltipText += " (outside project path, cannot be accessed)";
-        }
+        if (isExternal) appendExternalWorktreeBadge(wtEl, "worktree-external-badge");
+
+        var tooltipText = isExternal ? externalWorktreeTooltip(wt.name) : wt.name;
         (function (text, elem) {
           elem.addEventListener("mouseenter", function () { showIconTooltip(elem, text); });
           elem.addEventListener("mouseleave", hideIconTooltip);
         })(tooltipText, wtEl);
 
-        if (isAccessible) {
-          (function (slug) {
-            wtEl.addEventListener("click", function (e) {
-              e.preventDefault();
-              if (switchProject) switchProject(slug);
-            });
-          })(wt.slug);
-        } else {
+        (function (slug) {
           wtEl.addEventListener("click", function (e) {
             e.preventDefault();
+            if (switchProject) switchProject(slug);
           });
-        }
+        })(wt.slug);
 
-        if (isAccessible) {
-          (function (slug, name, elem) {
-            elem.addEventListener("contextmenu", function (e) {
-              e.preventDefault();
-              e.stopPropagation();
-              showIconCtxMenu(elem, slug, name);
-            });
-          })(wt.slug, wt.name, wtEl);
-        } else {
-          wtEl.addEventListener("contextmenu", function (e) {
+        (function (slug, name, elem, external) {
+          elem.addEventListener("contextmenu", function (e) {
             e.preventDefault();
             e.stopPropagation();
+            showIconCtxMenu(elem, slug, name, { canRemoveWorktree: !external });
           });
-        }
+        })(wt.slug, wt.name, wtEl, isExternal);
 
         if (!isWtActive && (wt.pendingPermissions > 0 || getPendingTuiAttention(wt.slug) > 0)) {
           wtEl.classList.add("has-pending-perm");
@@ -1360,7 +1349,10 @@ export function renderIconStrip(projects, currentSlug) {
 
   renderProjectList(projects, currentSlug);
 
-  try { lucide.createIcons({ nodes: [container] }); } catch (e) {}
+  var iconNodes = [container];
+  var mobileProjectList = document.getElementById("project-list");
+  if (mobileProjectList) iconNodes.push(mobileProjectList);
+  try { lucide.createIcons({ nodes: iconNodes }); } catch (e) {}
 }
 
 function renderProjectList(projects, currentSlug) {
@@ -1401,11 +1393,10 @@ function renderProjectList(projects, currentSlug) {
     var wtList = document.createElement("div");
     wtList.className = "mobile-folder-items";
     for (var wi = 0; wi < worktrees.length; wi++) {
-      var isAccessible = worktrees[wi].worktreeAccessible !== false;
       var wtItem = createMobileProjectItem(worktrees[wi], currentSlug, true);
-      if (!isAccessible) wtItem.classList.add("wt-disabled");
-      if (!isAccessible) {
-        wtItem.addEventListener("click", function (e) { e.preventDefault(); e.stopPropagation(); });
+      if (isExternalWorktree(worktrees[wi])) {
+        wtItem.classList.add("wt-external");
+        appendExternalWorktreeBadge(wtItem, "mobile-worktree-external-badge");
       }
       wtList.appendChild(wtItem);
     }

--- a/lib/public/modules/worktree-location.js
+++ b/lib/public/modules/worktree-location.js
@@ -1,0 +1,17 @@
+export function isExternalWorktree(project) {
+  return !!(project && project.isWorktree && project.worktreeExternal === true);
+}
+
+export function externalWorktreeTooltip(name) {
+  return name + " — outside the main project folder";
+}
+
+export function appendExternalWorktreeBadge(container, className) {
+  var badge = document.createElement("span");
+  badge.className = className;
+  badge.setAttribute("role", "img");
+  badge.setAttribute("aria-label", "Outside the main project folder");
+  badge.innerHTML = '<i data-lucide="external-link"></i>';
+  container.appendChild(badge);
+  return badge;
+}

--- a/lib/worktree.js
+++ b/lib/worktree.js
@@ -43,9 +43,14 @@ function isWorktree(projectPath) {
   }
 }
 
+function isPathInside(parentPath, candidatePath) {
+  var relative = path.relative(path.resolve(parentPath), path.resolve(candidatePath));
+  return relative !== "" && relative !== ".." && relative.indexOf(".." + path.sep) !== 0 && !path.isAbsolute(relative);
+}
+
 // Scan worktrees for a given project path
-// Returns array of { path, branch, bare, detached, accessible }
-// accessible = true if worktree path is inside parentPath
+// Returns array of { path, branch, bare, detached, external }
+// external = true when Git registered the worktree outside the main project folder
 function scanWorktrees(projectPath) {
   var resolvedParent = path.resolve(projectPath);
   try {
@@ -63,7 +68,7 @@ function scanWorktrees(projectPath) {
       if (wt.bare) continue;
       var resolvedWt = path.resolve(wt.path);
       if (resolvedWt === resolvedParent) continue;
-      wt.accessible = resolvedWt.indexOf(resolvedParent + path.sep) === 0;
+      wt.external = !isPathInside(resolvedParent, resolvedWt);
       wt.dirName = path.basename(wt.path);
       results.push(wt);
     }
@@ -131,4 +136,4 @@ function removeWorktree(projectPath, worktreeDirName) {
   }
 }
 
-module.exports = { scanWorktrees: scanWorktrees, createWorktree: createWorktree, removeWorktree: removeWorktree, isWorktree: isWorktree };
+module.exports = { scanWorktrees: scanWorktrees, createWorktree: createWorktree, removeWorktree: removeWorktree, isWorktree: isWorktree, isPathInside: isPathInside };

--- a/test/worktree-external-access.test.js
+++ b/test/worktree-external-access.test.js
@@ -1,0 +1,46 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+var worktree = require("../lib/worktree");
+
+var root = path.join(__dirname, "..");
+var clientHelpersPromise = null;
+
+function loadClientHelpers() {
+  if (!clientHelpersPromise) {
+    var file = path.join(root, "lib/public/modules/worktree-location.js");
+    var source = fs.readFileSync(file, "utf8");
+    clientHelpersPromise = import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+  }
+  return clientHelpersPromise;
+}
+
+test("worktree paths distinguish nested and external locations", function () {
+  assert.strictEqual(worktree.isPathInside("/projects/clay", "/projects/clay/.worktrees/feature"), true);
+  assert.strictEqual(worktree.isPathInside("/projects/clay", "/projects/clay-feature"), false);
+  assert.strictEqual(worktree.isPathInside("/projects/clay", "/tmp/clay-feature"), false);
+});
+
+test("client worktree metadata treats external location as informational", async function () {
+  var helpers = await loadClientHelpers();
+  var external = { isWorktree: true, worktreeExternal: true };
+
+  assert.strictEqual(helpers.isExternalWorktree(external), true);
+  assert.strictEqual(helpers.isExternalWorktree({ isWorktree: true }), false);
+  assert.match(helpers.externalWorktreeTooltip("Feature"), /outside the main project folder/);
+});
+
+test("external worktrees stay selectable while removal remains restricted", function () {
+  var sidebar = fs.readFileSync(path.join(root, "lib/public/modules/sidebar-projects.js"), "utf8");
+  var switcher = fs.readFileSync(path.join(root, "lib/public/modules/project-switcher.js"), "utf8");
+  var project = fs.readFileSync(path.join(root, "lib/project.js"), "utf8");
+
+  assert.match(project, /status\.worktreeExternal = worktreeMeta\.external === true/);
+  assert.match(sidebar, /appendExternalWorktreeBadge\(wtEl, "worktree-external-badge"\)/);
+  assert.match(sidebar, /if \(switchProject\) switchProject\(slug\)/);
+  assert.match(sidebar, /canRemoveWorktree: !external/);
+  assert.doesNotMatch(sidebar, /worktreeAccessible|wt-disabled/);
+  assert.match(switcher, /external: external,\s*disabled: false/);
+  assert.match(switcher, /project-switcher-external-badge/);
+});


### PR DESCRIPTION
## Summary

- Allow Git-registered worktrees outside the main project folder to open normally.
- Replace the old inaccessible flag with informational external-location metadata.
- Show an amber external-link badge in the desktop icon strip, mobile project list, and project switcher.
- Keep external worktree removal unavailable until removal can safely target the registered absolute path.

## Why

Git commonly places worktrees beside the main checkout. Clay previously treated lexical path containment as an access boundary even though the worktree was registered by the same repository. This prevented valid sibling worktrees from being used.

The new behavior keeps Git registration as the trust boundary and presents the external location as persistent context rather than an error.

## Checks

- `node --check lib/worktree.js`
- `node --check lib/daemon-projects.js`
- `node --check lib/project.js`
- `node --test test/worktree-external-access.test.js test/split-view.test.js test/worker-proposal-ui.test.js test/pane-links.test.js`
- `git diff --check`
