### PR TITLE
[codex] Clarify adapter registration logs

### DIFF
--- a/lib/yoke/index.js
+++ b/lib/yoke/index.js
@@ -346,7 +346,9 @@ function createAdapters(opts) {
   // Claude Code supports multiple auth modes (OAuth, Bedrock, Vertex, API key)
   // that `claude auth status` does not always detect. Runtime auth failures are
   // handled downstream via query-level error detection.
-  var installed = checkInstalled();
+  // Tests can supply a fixed installation snapshot without probing or spawning
+  // vendor binaries; production callers always use the cached host scan.
+  var installed = opts._installed || checkInstalled();
   var auth = { claude: false, codex: false, antigravity: false, opencode: false, kimi: false, grok: false, copilot: false, qwen: false, junie: false, kiro: false };
   var adapters = {};
 
@@ -363,10 +365,10 @@ function createAdapters(opts) {
         // per-project teardown never shuts it down on behalf of one project
         // (see destroy() in lib/project.js).
         _sharedClaudeAdapter.shared = true;
+        console.log("[yoke] Shared adapter created: claude");
       }
       adapters.claude = _sharedClaudeAdapter;
       auth.claude = true;
-      console.log("[yoke] Adapter created: claude");
     } catch (e) {
       console.error("[yoke] Failed to create adapter for claude:", e.message);
     }
@@ -376,7 +378,6 @@ function createAdapters(opts) {
     try {
       adapters.codex = createAdapter({ vendor: "codex", cwd: opts.cwd, slug: opts.slug, osUsers: !!opts.osUsers });
       auth.codex = true;
-      console.log("[yoke] Adapter created: codex");
     } catch (e) {
       console.error("[yoke] Failed to create adapter for codex:", e.message);
     }
@@ -390,7 +391,6 @@ function createAdapters(opts) {
       try {
         adapters[subprocessVendor] = createAdapter({ vendor: subprocessVendor, cwd: opts.cwd, slug: opts.slug });
         auth[subprocessVendor] = true;
-        console.log("[yoke] Adapter created: " + subprocessVendor);
       } catch (e) {
         console.error("[yoke] Failed to create adapter for " + subprocessVendor + ":", e.message);
       }
@@ -404,12 +404,17 @@ function createAdapters(opts) {
     try {
       adapters.kiro = createAdapter({ vendor: "kiro", cwd: opts.cwd, slug: opts.slug });
       auth.kiro = true;
-      console.log("[yoke] Adapter created: kiro");
     } catch (e) {
       console.error("[yoke] Failed to create adapter for kiro:", e.message);
     }
   } else if (installed.kiro && opts.osUsers) {
     console.log("[yoke] " + kiroInfo.displayName + " adapter disabled: OS-user isolation requires per-user spawning");
+  }
+
+  var registeredVendors = Object.keys(adapters);
+  if (registeredVendors.length > 0) {
+    var registrationScope = opts.slug ? " for " + opts.slug : "";
+    console.log("[yoke] Adapters registered" + registrationScope + ": " + registeredVendors.join(", "));
   }
 
   return { adapters: adapters, auth: auth };

--- a/test/yoke-vendor-registry.test.js
+++ b/test/yoke-vendor-registry.test.js
@@ -46,6 +46,50 @@ test("YOKE registry returns null for an unknown vendor", function() {
   assert.strictEqual(yoke.getVendorInfo("nope"), null);
 });
 
+test("adapter startup logs one registration summary instead of creation per vendor", async function() {
+  var originalLog = console.log;
+  var logs = [];
+  console.log = function(message) {
+    logs.push(String(message));
+  };
+  var created;
+  try {
+    created = yoke.createAdapters({
+      cwd: process.cwd(),
+      slug: "log-test",
+      _installed: { codex: true },
+    });
+  } finally {
+    console.log = originalLog;
+  }
+  assert.deepStrictEqual(logs, ["[yoke] Adapters registered for log-test: codex"]);
+  assert.strictEqual(logs.some(function(line) { return line.indexOf("Adapter created: codex") !== -1; }), false);
+  await created.adapters.codex.shutdown();
+});
+
+test("shared Claude creation is logged once across project registrations", function() {
+  var originalLog = console.log;
+  var logs = [];
+  console.log = function(message) {
+    logs.push(String(message));
+  };
+  try {
+    yoke.createAdapters({ cwd: process.cwd(), slug: "shared-a", _installed: { claude: true } });
+    yoke.createAdapters({ cwd: process.cwd(), slug: "shared-b", _installed: { claude: true } });
+  } finally {
+    console.log = originalLog;
+  }
+  assert.strictEqual(logs.filter(function(line) {
+    return line === "[yoke] Shared adapter created: claude";
+  }).length, 1);
+  assert.deepStrictEqual(logs.filter(function(line) {
+    return line.indexOf("[yoke] Adapters registered for shared-") === 0;
+  }), [
+    "[yoke] Adapters registered for shared-a: claude",
+    "[yoke] Adapters registered for shared-b: claude",
+  ]);
+});
+
 test("default vendor follows the declared cross-vendor preference order", function() {
   assert.strictEqual(yoke.resolveDefaultVendor({ kiro: {} }), "kiro");
   assert.strictEqual(yoke.resolveDefaultVendor({ kiro: {}, opencode: {} }), "opencode");


### PR DESCRIPTION
## What changed

- log shared Claude adapter construction only when the singleton is first created
- replace repeated per-vendor creation messages with one registration summary per project
- add regression coverage for project summaries and shared adapter logging

## Why

Startup previously described lightweight adapter registrations as new adapter creation, making it look like every project and Mate spawned three agent processes.

## Impact

Startup logs now reflect the actual lifecycle while preserving useful project-level vendor visibility.

## Validation

- `node --test test/yoke-vendor-registry.test.js test/vendor-installation-state.test.js test/acp-adapter.test.js` (28 passed)
- `git diff --check`
