### PR TITLE
fix(daemon): create IPC socket before project registration

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -1041,64 +1041,6 @@ function shutdownProjects() {
 
 // Worktree tracking extracted to daemon-projects.js
 
-// --- Register projects ---
-var projects = config.projects || [];
-for (var i = 0; i < projects.length; i++) {
-  var p = projects[i];
-  if (fs.existsSync(p.path)) {
-    console.log("[daemon] Adding project:", p.slug, "→", p.path);
-    relay.addProject(p.path, p.slug, p.title, p.icon, p.ownerId);
-    // Discover and register worktrees for this project
-    scanAndRegisterWorktrees(relay, p.path, p.slug, p.icon, p.ownerId);
-  } else {
-    console.log("[daemon] Skipping missing project:", p.path);
-  }
-}
-
-// Migrate legacy mates storage before registration
-mates.migrateLegacyMates();
-
-// Register existing mates as projects
-if (usersModule.isMultiUser()) {
-  // Multi-user mode: iterate over all users and load each user's mates
-  var allUsers = usersModule.getAllUsers();
-  for (var ui = 0; ui < allUsers.length; ui++) {
-    var mateCtx = mates.buildMateCtx(allUsers[ui].id);
-    var userMates = mates.getAllMates(mateCtx);
-    for (var mi = 0; mi < userMates.length; mi++) {
-      var m = userMates[mi];
-      var mateDir = mates.getMateDir(mateCtx, m.id);
-      var mateSlug = "mate-" + m.id;
-      var mateName = (m.profile && m.profile.displayName) || m.name || "New Mate";
-      if (fs.existsSync(mateDir)) {
-        var mateDef = m.builtinKey ? require("./builtin-mates").getBuiltinByKey(m.builtinKey) : null;
-        var isHost = !!(mateDef && mateDef.hostAgent);
-        console.log("[daemon] Adding mate project:", mateSlug + (isHost ? " (host agent)" : ""));
-        relay.addProject(mateDir, mateSlug, mateName, null, m.createdBy, null, { isMate: true, mateDisplayName: mateName, isHostAgent: isHost });
-      }
-    }
-  }
-} else {
-  // Single-user mode: use null ctx
-  var mateCtx = mates.buildMateCtx(null);
-  var allMates = mates.getAllMates(mateCtx);
-  for (var mi = 0; mi < allMates.length; mi++) {
-    var m = allMates[mi];
-    var mateDir = mates.getMateDir(mateCtx, m.id);
-    var mateSlug = "mate-" + m.id;
-    var mateName = (m.profile && m.profile.displayName) || m.name || "New Mate";
-    if (fs.existsSync(mateDir)) {
-      var mateDef2 = m.builtinKey ? require("./builtin-mates").getBuiltinByKey(m.builtinKey) : null;
-      var isHost2 = !!(mateDef2 && mateDef2.hostAgent);
-      console.log("[daemon] Adding mate project:", mateSlug + (isHost2 ? " (host agent)" : ""));
-      relay.addProject(mateDir, mateSlug, mateName, null, m.createdBy, null, { isMate: true, mateDisplayName: mateName, isHostAgent: isHost2 });
-    }
-  }
-}
-
-// Sync ~/.clayrc on startup
-try { syncClayrc(config.projects); } catch (e) {}
-
 // --- IPC server ---
 // Clean up stale socket/config left by a previously killed daemon
 var existingConfig = loadConfig();
@@ -1333,6 +1275,64 @@ var ipc = createIPCServer(socketPath(), function (msg) {
       return { ok: false, error: "unknown command: " + msg.cmd };
   }
 });
+
+// --- Register projects ---
+var projects = config.projects || [];
+for (var i = 0; i < projects.length; i++) {
+  var p = projects[i];
+  if (fs.existsSync(p.path)) {
+    console.log("[daemon] Adding project:", p.slug, "→", p.path);
+    relay.addProject(p.path, p.slug, p.title, p.icon, p.ownerId);
+    // Discover and register worktrees for this project
+    scanAndRegisterWorktrees(relay, p.path, p.slug, p.icon, p.ownerId);
+  } else {
+    console.log("[daemon] Skipping missing project:", p.path);
+  }
+}
+
+// Migrate legacy mates storage before registration
+mates.migrateLegacyMates();
+
+// Register existing mates as projects
+if (usersModule.isMultiUser()) {
+  // Multi-user mode: iterate over all users and load each user's mates
+  var allUsers = usersModule.getAllUsers();
+  for (var ui = 0; ui < allUsers.length; ui++) {
+    var mateCtx = mates.buildMateCtx(allUsers[ui].id);
+    var userMates = mates.getAllMates(mateCtx);
+    for (var mi = 0; mi < userMates.length; mi++) {
+      var m = userMates[mi];
+      var mateDir = mates.getMateDir(mateCtx, m.id);
+      var mateSlug = "mate-" + m.id;
+      var mateName = (m.profile && m.profile.displayName) || m.name || "New Mate";
+      if (fs.existsSync(mateDir)) {
+        var mateDef = m.builtinKey ? require("./builtin-mates").getBuiltinByKey(m.builtinKey) : null;
+        var isHost = !!(mateDef && mateDef.hostAgent);
+        console.log("[daemon] Adding mate project:", mateSlug + (isHost ? " (host agent)" : ""));
+        relay.addProject(mateDir, mateSlug, mateName, null, m.createdBy, null, { isMate: true, mateDisplayName: mateName, isHostAgent: isHost });
+      }
+    }
+  }
+} else {
+  // Single-user mode: use null ctx
+  var mateCtx = mates.buildMateCtx(null);
+  var allMates = mates.getAllMates(mateCtx);
+  for (var mi = 0; mi < allMates.length; mi++) {
+    var m = allMates[mi];
+    var mateDir = mates.getMateDir(mateCtx, m.id);
+    var mateSlug = "mate-" + m.id;
+    var mateName = (m.profile && m.profile.displayName) || m.name || "New Mate";
+    if (fs.existsSync(mateDir)) {
+      var mateDef2 = m.builtinKey ? require("./builtin-mates").getBuiltinByKey(m.builtinKey) : null;
+      var isHost2 = !!(mateDef2 && mateDef2.hostAgent);
+      console.log("[daemon] Adding mate project:", mateSlug + (isHost2 ? " (host agent)" : ""));
+      relay.addProject(mateDir, mateSlug, mateName, null, m.createdBy, null, { isMate: true, mateDisplayName: mateName, isHostAgent: isHost2 });
+    }
+  }
+}
+
+// Sync ~/.clayrc on startup
+try { syncClayrc(config.projects); } catch (e) {}
 
 // --- Cleanup stale SDK warmup CLI session files ---
 //


### PR DESCRIPTION
## Problem

Restarting the daemon intermittently printed `Failed to start daemon. Check logs:` even though the daemon actually started fine. The CLI health check (`isDaemonAliveAsync`) polls the IPC unix socket for only 5 seconds after spawn, but the daemon created that socket only after registering every project and mate project (~45 entries in this case, plus TUI hook install). When startup exceeded the window, the CLI declared failure and cleared the live daemon's PID from config.

## Fix

Move the IPC server block ahead of project registration in `lib/daemon.js` (pure move, no code changes). The socket now accepts connections as soon as the daemon boots, so the health check passes regardless of how long project loading takes.

## Safety

- IPC handlers cannot run before registration finishes: registration is synchronous top-level code, so the event loop only processes connections afterwards.
- No socket unlink race with the old daemon: `gracefulShutdown()` calls `ipc.close()` (which unlinks the socket) at its start, before the slow project teardown and before the new daemon spawns.

## Testing

- `node --check lib/daemon.js`
- `node --test test/daemon-sync.test.js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)