### PR TITLE
feat(sessions): show active background tasks with stop controls

### DIFF
--- a/docs/guides/MODULE_MAP.md
+++ b/docs/guides/MODULE_MAP.md
@@ -155,6 +155,7 @@ Bootstraps UI, initializes store, wires remaining Tier 3 modules. All business l
 | `app-loop-wizard.js` | Ralph Loop wizard: step navigation, mode/authorship selection, data collection |
 | `app-notifications.js` | Notification center panel, badge, rendering, click-to-navigate |
 | `app-debate-ui.js` | Debate sticky banner, floor/conclude/ended modes, bottom bar, hand raise |
+| `background-tasks-ui.js` | Active background-task indicator and task stop controls |
 | `app-skills-install.js` | Skill install dialog, requireSkills, requireClayMateInterview |
 | `app-favicon.js` | Dynamic favicon, IO blink, urgent blink, send button mode, activity indicator |
 | `app-header.js` | Session rename, session info popover, progressive history loading |

--- a/docs/ongoing/background-task-indicator-handoff.md
+++ b/docs/ongoing/background-task-indicator-handoff.md
@@ -1,0 +1,112 @@
+# Background Task Indicator — Handoff
+
+## Problem
+
+When the agent starts a background task (background Bash, Monitor, background subagent) and ends its turn, the Clay UI shows nothing. The user cannot tell "the agent is genuinely waiting on X and will resume" from "the agent just said it is waiting and stopped." The only trace is text the agent chose to write.
+
+The Claude Agent SDK already emits everything we need: a level signal `background_tasks_changed` carrying the full set of live background tasks. Clay currently drops it (falls into the system catch-all in the claude adapter and disappears).
+
+## Verified SDK facts (re-derived from node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts, 2026-08-26)
+
+- `SDKBackgroundTasksChangedMessage` (sdk.d.ts:3131): `{ type: 'system', subtype: 'background_tasks_changed', tasks: [{ task_id, task_type, description }] }`.
+  - REPLACE semantics: swap your set for each payload. Never pair start/finish edges.
+  - Per-process level: nothing is emitted at process startup; consumers MUST reset to empty whenever the session's CLI process (re)starts.
+  - On a repeated `initialize` (reconnect), the SDK sends a snapshot right behind the success response, even when empty.
+  - Payload carries ids only; do not correlate with the edge stream (`task_started`/`task_notification`).
+- `SDKTaskNotificationMessage` (sdk.d.ts:4830): `type: 'system', subtype: 'task_notification'`. The claude adapter matches `raw.type === "task_notification"` (lib/yoke/adapters/claude.js:316), so for the current SDK this is a DEAD PATH — the handler at lib/sdk-message-processor.js:625 never fires from the flattener.
+- `SDKTaskUpdatedMessage` (sdk.d.ts:4904): `type: 'system', subtype: 'task_updated'`. Not flattened at all; lib/sdk-message-processor.js:596 is also a dead path.
+- `stopTask(taskId)` exists on the SDK query object and Clay already plumbs it: `stop_task` WS message → lib/project-sessions.js:934 → lib/sdk-worker.js:123.
+
+## Scope
+
+Server: define `background_tasks_changed` as a vendor-neutral yoke adapter contract event, implement it in the claude adapter, keep it as per-session state, push it to clients, replay on reconnect. Client: render a persistent indicator with per-task stop buttons. Also repair the two dead task event paths in the claude adapter since this feature depends on the same event family.
+
+Out of scope for this PR: codex/kiro adapter implementations (they simply do not emit the event yet and must degrade to "no indicator" with zero errors — the contract explicitly allows them to synthesize it later, see section 1), historical/completed task lists, task output viewing.
+
+## Design principle: this is NOT a claude-only feature
+
+Everything downstream of the yoke layer (processor, session state, WS message, reconnect replay, UI) must depend only on the vendor-neutral `yokeType: "background_tasks_changed"` event, never on claude SDK shapes or vocabulary. The claude adapter is merely the first producer. A future codex or kiro adapter that emits the same contract event must light up the whole feature without touching any downstream file.
+
+## Implementation
+
+### 1. Adapter contract + claude flattening
+
+**Contract (vendor-neutral, applies to every yoke adapter):**
+
+- Event: `yokeType: "background_tasks_changed"`, payload `tasks: [{ task_id, task_type, description }]`.
+- REPLACE semantics: each payload is the full live set; downstream never pairs edges.
+- Reset guarantee: consumers reset to empty on adapter/CLI process (re)start; adapters that can, should emit a snapshot after re-initialization.
+- Emitting the event is OPTIONAL per adapter. An adapter without a native level signal MAY synthesize it from its own edge events (e.g. codex exec begin/end), as long as it upholds REPLACE + reset. Adapters that emit nothing → feature silently absent for that vendor.
+- `task_type` uses a small normalized vocabulary: `shell | agent | monitor | other`. Adapters map their native type strings into it (claude: `local_bash` → `shell`, `local_agent` → `agent`, anything else → `other`). UI must treat `task_type` as a decorative badge only and rely on `description` for meaning.
+
+Document this contract where the other yoke adapter contract expectations live (see test/yoke-adapter-contract.test.js and any adapter contract doc it references).
+
+**Claude adapter implementation** — in `flattenEvent()` where system subtypes are handled (claude.js:172-263):
+
+- Add: `raw.subtype === "background_tasks_changed"` → `base.yokeType = "background_tasks_changed"; base.tasks = raw.tasks;`
+- Add: `raw.subtype === "task_updated"` → `base.yokeType = "task_updated"` (carry `task_id`, `patch`), making lib/sdk-message-processor.js:596 live again.
+- Fix: `task_notification` must also match the system-subtype form. Keep the existing top-level `raw.type === "task_notification"` check (claude.js:316) for older CLIs and add the `raw.type === "system" && raw.subtype === "task_notification"` form. Both produce the same flattened shape.
+
+### 2. Per-session state — lib/sdk-message-processor.js (+ lib/sessions.js)
+
+- New branch for `background_tasks_changed`:
+  - `session.activeBackgroundTasks = ev.tasks` (REPLACE, no merging).
+  - Push to clients: `sendToSession(session, { type: "active_background_tasks", tasks: ev.tasks })`. Use the non-recording send path (like `doSendToSession`, lib/sessions.js:860) — this is level state, it must NOT be written into the transcript/history.
+- Reset rule: on `yokeType === "init"` (new CLI process, handled near lib/sdk-message-processor.js:569 area) set `session.activeBackgroundTasks = []` and push the empty state. This implements the "reset on process (re)start" requirement.
+- Precedent for session-scoped task bookkeeping: `session.taskIdMap` (lib/sdk-message-processor.js:573).
+
+### 3. WS schema — lib/ws-schema.js
+
+Register the new server→client `active_background_tasks` message the same way sibling messages are registered (see `stop_task` at ws-schema.js:149 for the client→server direction; find the server→client registry in the same file).
+
+### 4. Reconnect replay — lib/project-connection.js
+
+At the state-resync point (project-connection.js:282-283, where `status: processing` is replayed for the active session), also send `active_background_tasks` with the current `session.activeBackgroundTasks` (send `[]` explicitly if empty so a stale client indicator clears).
+
+### 5. Session list projection — lib/sessions.js
+
+- `mapSessionForClient` (sessions.js:481): add `backgroundTaskCount: (session.activeBackgroundTasks || []).length`.
+- Call `broadcastSessionList` (sessions.js:529) only when the count changes (0→n or n→0 or different n), not on every identical payload, to avoid list churn.
+
+### 6. Client — new module lib/public/modules/background-tasks-ui.js
+
+- Follow docs/guides/CLIENT_MODULE_DEPS.md: state in store.js, WS via ws-ref.js, direct imports. NO `var _ctx = null` / `initXxx(ctx)` pattern.
+- `app-messages.js`: add `case "active_background_tasks"` → `store.set({ activeBackgroundTasks: msg.tasks })` (near the sibling cases at app-messages.js:1107-1131).
+- The module subscribes to `activeBackgroundTasks` and renders a compact sticky bar above the input (style precedent: app-loop-ui.js / app-debate-ui.js bottom bars):
+  - Collapsed: `⏳ 2 background tasks` (count chip).
+  - Expanded (click): one row per task — `description` text, `task_type` badge, a Stop button that sends `{ type: "stop_task", taskId: task.task_id }` (send precedent: lib/public/modules/tools.js:2400).
+  - Empty set → bar fully removed from DOM.
+- `sidebar-sessions.js`: render a small count badge next to the existing `session-processing` spinner sites (sidebar-sessions.js:977, 1174, 1254, 1324) using the new `backgroundTaskCount` field.
+- All UI strings in English. No `localStorage`. No browser-native dialogs.
+
+### 7. Docs
+
+Add the new module to docs/guides/MODULE_MAP.md.
+
+## Hard requirements (safety rails)
+
+1. REPLACE semantics everywhere. Never increment/decrement from `task_started`/`task_notification` edges — a missed edge must not wedge the indicator.
+2. Reset to empty on CLI process (re)start (init event). A stale "waiting" indicator is worse than none.
+3. `active_background_tasks` is level state: never recorded to transcript, never appears in history replays as a message.
+4. Non-claude vendors: no event → no state → no UI. Zero errors, zero placeholder UI.
+5. Code style: `var` only, no arrow functions; CommonJS on server, ES modules on client; modules under 500 lines; no inline logic in project.js handleMessage.
+6. Do not break the existing subagent card flow in tools.js (task_started/task_progress/subagent_done still work as today).
+
+## Tests
+
+- Extend test/yoke-adapter-contract.test.js (or the closest adapter test): `flattenEvent` maps `{type:'system', subtype:'background_tasks_changed'}` → yokeType + tasks (with `task_type` normalized to the contract vocabulary); maps system-subtype `task_notification` and `task_updated`; top-level legacy `task_notification` still maps. Write the contract-shape assertions vendor-neutrally so a future codex/kiro producer can be added to the same test.
+- Processor test: REPLACE semantics (second payload swaps, does not merge); init event clears state and emits empty push.
+- `node --check` on every touched server file; `npm test` green.
+
+## Acceptance criteria
+
+1. Agent runs a background Bash (`run_in_background: true`) and ends its turn → bar appears with the task description within one WS push; no page reload needed.
+2. Task completes → bar disappears without user action (driven by the next `background_tasks_changed`, not by edge pairing).
+3. Browser refresh while a task is running → bar reappears from the reconnect replay.
+4. Daemon-side CLI process restart while the bar shows → bar clears on the next init.
+5. Stop button ends the task (verifiable by the task's `task_notification` status `stopped` arriving as the usual notification).
+6. Sessions with zero background tasks look exactly as they do today, on all vendors.
+
+## Follow-up (separate PR, not this one)
+
+Codex adapter synthesis: maintain the live set inside lib/yoke/adapters/codex.js from the app-server's exec/task lifecycle events and emit contract-conformant `background_tasks_changed` payloads. Requires a survey of which codex events reliably bookend backgrounded work. Kiro likewise if/when its event stream supports it.

--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -282,6 +282,7 @@ function attachConnection(ctx) {
       if (active.isProcessing) {
         sendTo(ws, { type: "status", status: "processing" });
       }
+      sendTo(ws, { type: "active_background_tasks", tasks: active.activeBackgroundTasks || [] });
       var pendingIds = Object.keys(active.pendingPermissions);
       for (var pi = 0; pi < pendingIds.length; pi++) {
         var p = active.pendingPermissions[pendingIds[pi]];

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -65,6 +65,7 @@ import { initMisc, flushPendingExtMessages, showImageModal as _miscShowImageModa
 import { initSkillInstall, requireSkills as _siRequireSkills, requireClayMateInterview as _siRequireClayMateInterview, handleSkillInstallWs as _siHandleSkillInstallWs } from './modules/app-skills-install.js';
 import { initDebateUi, showDebateConcludeConfirm as _debShowDebateConcludeConfirm, exitDebateConcludeMode as _debExitDebateConcludeMode, handleDebateConcludeSend as _debHandleDebateConcludeSend, showDebateEndedMode as _debShowDebateEndedMode, exitDebateEndedMode as _debExitDebateEndedMode, showDebateUserFloor as _debShowDebateUserFloor, exitDebateFloorMode as _debExitDebateFloorMode, handleDebateFloorSend as _debHandleDebateFloorSend, renderDebateUserFloorDone as _debRenderDebateUserFloorDone, showDebateSticky as _debShowDebateSticky, showDebateBottomBar as _debShowDebateBottomBar, removeDebateBottomBar as _debRemoveDebateBottomBar, sendDebateStickyComment as _debSendDebateStickyComment, updateDebateRound as _debUpdateDebateRound } from './modules/app-debate-ui.js';
 import { initLoopUi, updateLoopInputVisibility as _loopUpdateLoopInputVisibility, updateLoopButton as _loopUpdateLoopButton, showLoopBanner as _loopShowLoopBanner, updateLoopBanner as _loopUpdateLoopBanner, updateRalphBars as _loopUpdateRalphBars, showRalphCraftingBar as _loopShowRalphCraftingBar, showRalphApprovalBar as _loopShowRalphApprovalBar, updateRalphApprovalStatus as _loopUpdateRalphApprovalStatus, openRalphPreviewModal as _loopOpenRalphPreviewModal, showExecModal as _loopShowExecModal, closeExecModal as _loopCloseExecModal, updateExecModalStatus as _loopUpdateExecModalStatus } from './modules/app-loop-ui.js';
+import { initBackgroundTasksUi } from './modules/background-tasks-ui.js';
 import { initLoopWizard, openRalphWizard as _loopOpenRalphWizard, closeRalphWizard as _loopCloseRalphWizard, getWizardSource as _loopGetWizardSource } from './modules/app-loop-wizard.js';
 import { initAppNotifications, handleNotificationsState as _notifHandleState, handleNotificationCreated as _notifHandleCreated, handleNotificationDismissed as _notifHandleDismissed, handleNotificationDismissedAll as _notifHandleDismissedAll } from './modules/app-notifications.js';
 import { initWhatsNew, handleWhatsNewState as _wnHandleState, handleWhatsNewSeenResult as _wnHandleSeenResult } from './modules/whats-new.js';
@@ -296,6 +297,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     slashCommands: [],
     processing: false,
     activeSessionId: null,
+    activeBackgroundTasks: [],
     sessionVendorBound: false,
     cliSessionId: null,
     isHeadlessMode: false,
@@ -649,6 +651,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
   initDebateUi();
 
   initLoopUi();
+  initBackgroundTasksUi();
   initLoopWizard();
 
   // --- Notifications module ---

--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -667,6 +667,50 @@
   position: relative;
 }
 
+.background-tasks-bar {
+  max-width: var(--content-width);
+  margin: 0 auto 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--input-bg);
+  overflow: hidden;
+}
+
+.background-tasks-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.background-tasks-chip, .session-background-task-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.background-tasks-list { padding: 0 10px 8px; }
+.background-task-row { display: flex; align-items: center; gap: 8px; padding: 6px 0; border-top: 1px solid var(--border-subtle); }
+.background-task-description { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.background-task-type { padding: 2px 6px; border-radius: 5px; background: var(--code-bg); color: var(--text-muted); font-size: 11px; }
+.background-task-stop { border: 1px solid var(--border); border-radius: 5px; padding: 3px 7px; background: transparent; color: var(--text-secondary); cursor: pointer; font: inherit; font-size: 12px; }
+.background-task-stop:hover { color: var(--text); border-color: var(--text-muted); }
+
 #input-row {
   display: flex;
   flex-direction: column;

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -1128,6 +1128,10 @@ export function processMessage(msg) {
         updateSubagentTaskStatus(msg.parentToolId, msg.patch);
         break;
 
+      case "active_background_tasks":
+        store.set({ activeBackgroundTasks: Array.isArray(msg.tasks) ? msg.tasks : [] });
+        break;
+
       case "result":
         // Result marks turn end. Drop pre-thinking even if no delta/tool
         // event ever arrived (e.g. tool-only turn whose progress signals

--- a/lib/public/modules/background-tasks-ui.js
+++ b/lib/public/modules/background-tasks-ui.js
@@ -1,0 +1,55 @@
+import { store } from './store.js';
+import { getWs } from './ws-ref.js';
+import { escapeHtml } from './utils.js';
+
+var expanded = false;
+
+export function initBackgroundTasksUi() {
+  store.subscribe(function(state, prev) {
+    if (state.activeBackgroundTasks !== prev.activeBackgroundTasks) renderBackgroundTasks();
+  });
+  renderBackgroundTasks();
+}
+
+function renderBackgroundTasks() {
+  var tasks = store.get('activeBackgroundTasks') || [];
+  var existing = document.getElementById('background-tasks-bar');
+  if (tasks.length === 0) {
+    if (existing) existing.remove();
+    expanded = false;
+    return;
+  }
+  var inputArea = document.getElementById('input-area');
+  if (!inputArea || !inputArea.parentNode) return;
+  var bar = existing || document.createElement('div');
+  bar.id = 'background-tasks-bar';
+  bar.className = 'background-tasks-bar';
+  var taskLabel = tasks.length === 1 ? 'background task' : 'background tasks';
+  var html = '<button type="button" class="background-tasks-toggle" aria-expanded="' + expanded + '">' +
+    '<span aria-hidden="true">⏳</span><span class="background-tasks-chip">' + tasks.length + '</span>' +
+    '<span>' + tasks.length + ' ' + taskLabel + '</span></button>';
+  if (expanded) {
+    html += '<div class="background-tasks-list">';
+    for (var i = 0; i < tasks.length; i++) {
+      var task = tasks[i];
+      html += '<div class="background-task-row"><span class="background-task-description" title="' + escapeHtml(task.description || '') + '">' +
+        escapeHtml(task.description || 'Background task') + '</span><span class="background-task-type">' +
+        escapeHtml(task.task_type || 'other') + '</span><button type="button" class="background-task-stop" data-task-id="' +
+        escapeHtml(task.task_id || '') + '">Stop</button></div>';
+    }
+    html += '</div>';
+  }
+  bar.innerHTML = html;
+  if (!existing) inputArea.parentNode.insertBefore(bar, inputArea);
+  bar.querySelector('.background-tasks-toggle').addEventListener('click', function() {
+    expanded = !expanded;
+    renderBackgroundTasks();
+  });
+  var stopButtons = bar.querySelectorAll('.background-task-stop');
+  for (var j = 0; j < stopButtons.length; j++) {
+    stopButtons[j].addEventListener('click', function() {
+      var ws = getWs();
+      if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'stop_task', taskId: this.dataset.taskId }));
+    });
+  }
+}

--- a/lib/public/modules/sidebar-sessions.js
+++ b/lib/public/modules/sidebar-sessions.js
@@ -977,6 +977,9 @@ function renderLoopChild(s) {
   if (s.isProcessing) {
     textHtml += '<span class="session-processing"></span>';
   }
+  if (s.backgroundTaskCount) {
+    textHtml += '<span class="session-background-task-count">' + s.backgroundTaskCount + '</span>';
+  }
   if (s.loop) {
     var isRalphChild = s.loop.source === "ralph";
     var roleName = s.loop.role === "crafting" ? "Crafting" : s.loop.role === "judge" ? "Judge" : (isRalphChild ? "Coder" : "Run");
@@ -1096,6 +1099,9 @@ function renderLoopGroup(loopId, children, groupKey) {
   if (anyProcessing) {
     textHtml += '<span class="session-processing"></span>';
   }
+  var groupBackgroundTaskCount = 0;
+  for (var bi = 0; bi < children.length; bi++) groupBackgroundTaskCount += children[bi].backgroundTaskCount || 0;
+  if (groupBackgroundTaskCount) textHtml += '<span class="session-background-task-count">' + groupBackgroundTaskCount + '</span>';
   var groupIcon = isDebate ? "mic" : (isRalph ? "repeat" : "calendar-clock");
   var iconClass = isDebate ? " debate" : (isRalph ? "" : " scheduled");
   textHtml += '<span class="session-loop-icon' + iconClass + '">' + iconHtml(groupIcon) + '</span>';
@@ -1205,6 +1211,9 @@ function renderLoopRun(parentGk, startedAtKey, sessions, isRalph) {
   if (anyProcessing) {
     textHtml += '<span class="session-processing"></span>';
   }
+  var runBackgroundTaskCount = 0;
+  for (var bi = 0; bi < sessions.length; bi++) runBackgroundTaskCount += sessions[bi].backgroundTaskCount || 0;
+  if (runBackgroundTaskCount) textHtml += '<span class="session-background-task-count">' + runBackgroundTaskCount + '</span>';
   textHtml += '<span class="session-loop-run-time">' + escapeHtml(timeLabel) + '</span>';
   textHtml += '<span class="session-loop-count' + (isRalph ? "" : " scheduled") + '">' + sessions.length + '</span>';
   textSpan.innerHTML = textHtml;
@@ -1253,6 +1262,9 @@ function renderSessionItem(s) {
     '" alt="" title="' + escapeHtml(VENDOR_NAMES[itemVendor] || itemVendor) + '">';
   if (s.isProcessing) {
     textHtml += '<span class="session-processing"></span>';
+  }
+  if (s.backgroundTaskCount) {
+    textHtml += '<span class="session-background-task-count">' + s.backgroundTaskCount + '</span>';
   }
   if (s.loop && s.loop.source === "debate") {
     textHtml += '<span class="session-debate-icon" title="Debate">' + iconHtml("mic") + '</span>';
@@ -1322,6 +1334,8 @@ function renderSplitGroupItem(group, members) {
   }
   html += "</span>";
   if (members[0].isProcessing || members[1].isProcessing) html += '<span class="session-processing"></span>';
+  var splitBackgroundTaskCount = (members[0].backgroundTaskCount || 0) + (members[1].backgroundTaskCount || 0);
+  if (splitBackgroundTaskCount) html += '<span class="session-background-task-count">' + splitBackgroundTaskCount + '</span>';
   html += '<span class="split-group-name">' + highlightMatch(group.name || "Split", searchQuery) + "</span>";
   text.innerHTML = html;
   el.appendChild(text);

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -175,6 +175,10 @@ function attachMessageProcessor(ctx) {
 
     // Cache slash_commands and model from CLI init message
     if (parsed.yokeType === "init") {
+      var previousBackgroundTaskCount = (session.activeBackgroundTasks || []).length;
+      session.activeBackgroundTasks = [];
+      sendToSession(session, { type: "active_background_tasks", tasks: [] });
+      if (previousBackgroundTaskCount !== 0) sm.broadcastSessionList();
       var fsSkills = discoverSkillDirs();
       sm.skillNames = mergeSkills(parsed.skills, fsSkills);
       if (parsed.slashCommands) {
@@ -610,6 +614,15 @@ function attachMessageProcessor(ctx) {
           taskId: taskId,
           patch: patch,
         });
+      }
+
+    } else if (parsed.yokeType === "background_tasks_changed") {
+      var previousBackgroundTaskCount = (session.activeBackgroundTasks || []).length;
+      var activeBackgroundTasks = Array.isArray(parsed.tasks) ? parsed.tasks : [];
+      session.activeBackgroundTasks = activeBackgroundTasks;
+      sendToSession(session, { type: "active_background_tasks", tasks: activeBackgroundTasks });
+      if (previousBackgroundTaskCount !== activeBackgroundTasks.length) {
+        sm.broadcastSessionList();
       }
 
     } else if (parsed.yokeType === "tool_progress") {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -495,6 +495,7 @@ function createSessionManager(opts) {
       title: s.title || "New Session",
       active: isActive,
       isProcessing: s.isProcessing,
+      backgroundTaskCount: (s.activeBackgroundTasks || []).length,
       lastActivity: s.lastActivity || s.createdAt || 0,
       loop: loop,
       spawn: s.spawn || null,
@@ -717,6 +718,7 @@ function createSessionManager(opts) {
     if (session.isProcessing) {
       _send({ type: "status", status: "processing" });
     }
+    _send({ type: "active_background_tasks", tasks: session.activeBackgroundTasks || [] });
 
     // Re-send any pending permission requests
     var pendingIds = Object.keys(session.pendingPermissions);

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -114,6 +114,7 @@ var schema = {
   "subagent_done":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Subagent task completed" },
   "task_started":             { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Background task started" },
   "task_progress":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Background task progress update" },
+  "active_background_tasks":  { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Current background tasks for the active session (full replacement)" },
   "markdown_edit_present":    { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Open a user-requested Markdown edit with a before snapshot" },
 
   // -----------------------------------------------------------------------

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -197,6 +197,26 @@ function flattenEvent(raw) {
       base.summary = raw.summary || null;
       return base;
     }
+    if (raw.subtype === "background_tasks_changed") {
+      base.yokeType = "background_tasks_changed";
+      base.tasks = normalizeBackgroundTasks(raw.tasks);
+      return base;
+    }
+    if (raw.subtype === "task_updated") {
+      base.yokeType = "task_updated";
+      base.task_id = raw.task_id;
+      base.patch = raw.patch || {};
+      return base;
+    }
+    if (raw.subtype === "task_notification") {
+      base.yokeType = "task_notification";
+      base.parentToolId = raw.parent_tool_use_id;
+      base.taskId = raw.task_id;
+      base.status = raw.status || "completed";
+      base.summary = raw.summary || "";
+      base.usage = raw.usage || null;
+      return base;
+    }
     // Model refusal: the model declined and the CLI either fell back to
     // another model or ended the turn. Translate to a vendor-neutral
     // yokeType so the relay never sees SDK subtype strings.
@@ -341,6 +361,20 @@ function flattenEvent(raw) {
   base.rawType = raw.type;
   base.raw = raw;
   return base;
+}
+
+function normalizeBackgroundTasks(tasks) {
+  if (!Array.isArray(tasks)) return [];
+  return tasks.map(function(task) {
+    var nativeType = task && task.task_type;
+    var taskType = nativeType === "local_bash" ? "shell"
+      : nativeType === "local_agent" ? "agent" : "other";
+    return {
+      task_id: task && task.task_id,
+      task_type: taskType,
+      description: (task && task.description) || "",
+    };
+  });
 }
 
 // --- QueryHandle ---

--- a/lib/yoke/interface.js
+++ b/lib/yoke/interface.js
@@ -9,6 +9,17 @@
 //   2. QueryHandle (returned by adapter.createQuery)
 
 var TOOL_POLICIES = ["ask", "allow-all"];
+var BACKGROUND_TASK_TYPES = ["shell", "agent", "monitor", "other"];
+
+/*
+ * Optional adapter event contract:
+ *   { yokeType: "background_tasks_changed", tasks: [{ task_id, task_type, description }] }
+ *
+ * Each event replaces the complete live set. An adapter that emits this event
+ * must reset it to an empty set when its CLI process restarts. task_type uses
+ * BACKGROUND_TASK_TYPES; adapters without a level signal may synthesize one,
+ * and adapters that emit nothing simply have no background-task indicator.
+ */
 
 /**
  * Validate that an adapter object implements all required methods.
@@ -93,6 +104,7 @@ function validateQueryHandle(handle) {
 
 module.exports = {
   TOOL_POLICIES: TOOL_POLICIES,
+  BACKGROUND_TASK_TYPES: BACKGROUND_TASK_TYPES,
   ADAPTER_METHODS: ADAPTER_METHODS,
   QUERY_HANDLE_METHODS: QUERY_HANDLE_METHODS,
   validateAdapter: validateAdapter,

--- a/test/sdk-bridge-delivery.test.js
+++ b/test/sdk-bridge-delivery.test.js
@@ -225,6 +225,31 @@ test("accepted pushes track turns queued behind the active turn", function() {
   assert.strictEqual(session._queuedTurnCount, 1);
 });
 
+test("background task state replaces the prior set and init clears it", function() {
+  var direct = [];
+  var broadcasts = 0;
+  var bridge = createBridge({
+    sendAndRecord: function() {},
+    sendToSession: function(session, msg) { direct.push(msg); },
+    broadcastSessionList: function() { broadcasts++; },
+  });
+  var session = { localId: 15, activeBackgroundTasks: [{ task_id: "old" }] };
+  var tasks = [{ task_id: "new", task_type: "shell", description: "Waiting" }];
+  bridge.processSDKMessage(session, { yokeType: "background_tasks_changed", tasks: tasks });
+  assert.deepStrictEqual(session.activeBackgroundTasks, tasks);
+  assert.deepStrictEqual(direct[0], { type: "active_background_tasks", tasks: tasks });
+  assert.strictEqual(broadcasts, 0);
+  bridge.processSDKMessage(session, { yokeType: "background_tasks_changed", tasks: [] });
+  assert.deepStrictEqual(session.activeBackgroundTasks, []);
+  assert.deepStrictEqual(direct[1], { type: "active_background_tasks", tasks: [] });
+  assert.strictEqual(broadcasts, 1);
+  session.activeBackgroundTasks = tasks;
+  bridge.processSDKMessage(session, { yokeType: "init" });
+  assert.deepStrictEqual(session.activeBackgroundTasks, []);
+  assert.deepStrictEqual(direct[2], { type: "active_background_tasks", tasks: [] });
+  assert.strictEqual(broadcasts, 2);
+});
+
 test("a result keeps processing active while a queued turn continues", function() {
   var recorded = [];
   var direct = [];

--- a/test/yoke-adapter-contract.test.js
+++ b/test/yoke-adapter-contract.test.js
@@ -75,6 +75,51 @@ test("Claude query handles reject messages after their input queue closes", func
   assert.strictEqual(queue.push({ type: "user" }), false);
 });
 
+function assertBackgroundTaskContract(event, expectedTasks) {
+  var iface = require("../lib/yoke/interface");
+  assert.strictEqual(event.yokeType, "background_tasks_changed");
+  assert.deepStrictEqual(event.tasks, expectedTasks);
+  for (var i = 0; i < event.tasks.length; i++) {
+    assert.ok(iface.BACKGROUND_TASK_TYPES.indexOf(event.tasks[i].task_type) !== -1);
+  }
+}
+
+test("YOKE background-task producers emit the normalized level-state contract", function() {
+  var producers = [{
+    name: "Claude",
+    normalize: require("../lib/yoke/adapters/claude").contractTestKit.normalizeEvent,
+    rawEvent: {
+      type: "system",
+      subtype: "background_tasks_changed",
+      tasks: [
+        { task_id: "bash-1", task_type: "local_bash", description: "Wait for build" },
+        { task_id: "agent-1", task_type: "local_agent", description: "Review changes" },
+        { task_id: "unknown-1", task_type: "native_monitor", description: "Check status" },
+      ],
+    },
+    expectedTasks: [
+      { task_id: "bash-1", task_type: "shell", description: "Wait for build" },
+      { task_id: "agent-1", task_type: "agent", description: "Review changes" },
+      { task_id: "unknown-1", task_type: "other", description: "Check status" },
+    ],
+  }];
+  for (var i = 0; i < producers.length; i++) {
+    var producer = producers[i];
+    assertBackgroundTaskContract(producer.normalize(producer.rawEvent), producer.expectedTasks);
+  }
+});
+
+test("Claude flattens task system events and legacy notifications", function() {
+  var normalize = require("../lib/yoke/adapters/claude").contractTestKit.normalizeEvent;
+  var notification = normalize({ type: "system", subtype: "task_notification", parent_tool_use_id: "tool-1", task_id: "task-1", status: "stopped", summary: "Stopped" });
+  var updated = normalize({ type: "system", subtype: "task_updated", task_id: "task-1", patch: { status: "running" } });
+  var legacy = normalize({ type: "task_notification", parent_tool_use_id: "tool-1", task_id: "task-1", status: "stopped" });
+  assert.deepStrictEqual(notification, { yokeType: "task_notification", parentToolId: "tool-1", taskId: "task-1", status: "stopped", summary: "Stopped", usage: null });
+  assert.deepStrictEqual(updated, { yokeType: "task_updated", task_id: "task-1", patch: { status: "running" } });
+  assert.strictEqual(legacy.yokeType, "task_notification");
+  assert.strictEqual(legacy.taskId, "task-1");
+});
+
 test("Claude worker transport reports closed and failed IPC writes", function() {
   var claudeModule = require("../lib/yoke/adapters/claude");
   var kit = claudeModule.contractTestKit;


### PR DESCRIPTION
## Problem

When the agent starts background work (background Bash, a Monitor, a background subagent) and ends its turn, the UI shows nothing. The user cannot tell "genuinely waiting on X, will resume" from "said it is waiting and stopped." The SDK already emits a level signal (`background_tasks_changed`) carrying the full live task set, but Clay dropped it in the claude adapter's system catch-all.

## What this does

- **Vendor-neutral contract, not a claude-only feature.** `background_tasks_changed` is defined in `lib/yoke/interface.js` as an optional adapter contract event: REPLACE semantics (each payload is the full set, no edge pairing), reset on CLI process restart, and a normalized `task_type` vocabulary (`shell | agent | monitor | other`). Adapters without a native level signal may synthesize it from their own edge events later (codex follow-up is out of scope). Everything downstream depends only on the contract event.
- **Claude adapter** flattens the event and normalizes native task types (`local_bash` → `shell`, `local_agent` → `agent`, else `other`). Also repairs two dead paths: the SDK emits `task_notification` and `task_updated` as system subtypes, which the adapter previously failed to match (legacy top-level `task_notification` still matches).
- **Server** tracks `session.activeBackgroundTasks` (REPLACE, cleared on init), pushes a new non-recorded `active_background_tasks` message, replays it on reconnect and session switch (explicit `[]` so stale indicators clear), and exposes `backgroundTaskCount` in the session list (broadcast only when the count changes).
- **Client** renders a sticky bar above the input: collapsed count chip, expandable rows with description, type badge, and a Stop button wired to the existing `stop_task` path. Sidebar shows count badges for sessions, loop groups, and splits. Empty set removes the bar entirely.
- Vendors that emit nothing get no UI and no errors.

## Testing

- Full suite green on Node 22: 290/290 (`npm test`).
- New contract test in `test/yoke-adapter-contract.test.js` written as a producer list so future codex/kiro adapters join the same assertions.
- New processor test covers REPLACE semantics and init reset.

Spec with verified SDK facts and acceptance criteria: `docs/ongoing/background-task-indicator-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)