### PR TITLE
feat(sessions): auto-approve worker proposals when skip permissions is on

### DIFF
--- a/docs/ongoing/worker-proposal-auto-approve-handoff.md
+++ b/docs/ongoing/worker-proposal-auto-approve-handoff.md
@@ -1,0 +1,52 @@
+# Auto-Approve Worker Proposals When Skip Permissions Is On — Handoff
+
+## Goal
+
+When the user has skip permissions toggled on for a session, a `propose_worker` call from the agent should not stop and wait for the user to click approve. The proposal should be auto-approved and the worker should start immediately, exactly as if the user had accepted it. The user has already opted out of per-action gating for that session; making them approve worker creation is friction with no safety benefit.
+
+## What "skip permissions is on" means (verified)
+
+Session-level state, set at session creation (lib/sessions.js:298-299):
+
+- GUI sessions: `session.permissionMode === "bypassPermissions"`
+- TUI sessions: `session.dangerouslySkipPermissions === true`
+
+Treat either as ON. Both are already projected to clients (sessions.js:514, 711), so no new client state is needed for detection.
+
+## Where to change (starting anchors, read the module fully first)
+
+`lib/project-worker-proposal.js` (317 lines) owns the proposal lifecycle:
+
+- Proposal creation around lines 166-184: builds the `worker_proposal` record, `sendAndRecord`s it into history, and waits for a user action message.
+- User action handling around line 243 (`findProposal` + the accept path that calls `runWorker` at ~212).
+- `updateProposal` (line 148) patches the record and broadcasts `worker_proposal_update`.
+
+Implementation shape (adjust to what you find in the module):
+
+1. In the propose flow, after recording the proposal, check the session's skip-permissions state. If ON, mark the proposal accepted with an auto-approval marker (e.g. `autoApproved: true` in the record/patch) and invoke the same code path the user-accept action takes. Do not duplicate the accept logic — call the existing function.
+2. The proposal card must still be recorded and visible in the transcript, updated to its accepted/running state, so the user sees what happened. Add a small "auto-approved" indication to the update payload; client rendering lives in `lib/public/modules/worker-proposal.js` — show it (e.g. "Auto-approved · skip permissions") instead of the approve/reject buttons.
+3. The MCP tool response to the proposing agent currently instructs it to end the turn and wait for the user's decision. When auto-approved, the response must say the worker was auto-approved and started (so the agent does not tell the user to go click a button). Check `lib/session-spawn-mcp-server.js` or wherever the propose_worker tool result text is built.
+4. TUI sessions: if `propose_worker` is not reachable from TUI sessions, the `dangerouslySkipPermissions` check is dead code but harmless — include it anyway for symmetry, do not build anything TUI-specific.
+
+## Hard requirements
+
+- Reuse the existing accept path; no parallel approval logic.
+- No change in behavior when skip permissions is OFF.
+- The auto-approved proposal must remain visible in history with its final state (no silent worker spawns).
+- English-only user-facing strings. `var` only, no arrow functions, CommonJS server / ESM client. No `localStorage`.
+- Do not commit.
+
+## Tests
+
+- Extend the existing worker-proposal tests (find them; if none exist, add a focused test file) with:
+  1. Skip permissions ON → propose call results in an accepted proposal without any action message, and the worker run path is invoked.
+  2. Skip permissions OFF → behavior unchanged: proposal stays pending until an action message arrives.
+  3. The auto-approved record carries the auto-approval marker.
+- `node --check` on touched server files; full `npm test` green on Node 22 (`/Users/chad/.nvm/versions/node/v22.22.1/bin/node` — shell default Node 18 cannot run the suite).
+
+## Acceptance criteria
+
+1. With skip permissions on, an agent's propose_worker starts the worker with zero user interaction, and the transcript shows the proposal card in an auto-approved state.
+2. With skip permissions off, the flow is byte-for-byte the old one.
+3. The proposing agent's tool result tells it the worker already started (no "waiting for user decision" instruction).
+4. Full suite green.

--- a/lib/project-worker-proposal.js
+++ b/lib/project-worker-proposal.js
@@ -154,6 +154,18 @@ function attachWorkerProposal(ctx) {
     }, patch));
   }
 
+  function skipPermissionsEnabled(session) {
+    return !!session && (session.permissionMode === "bypassPermissions" || session.dangerouslySkipPermissions === true);
+  }
+
+  function autoApprovalWs(session) {
+    return {
+      _clayActiveSession: session.localId,
+      _clayUser: session.ownerId ? { id: session.ownerId } : null,
+      _autoApproval: true,
+    };
+  }
+
   async function propose(args, session) {
     if (!isEligible(session)) return toolResult({ error: "Worker suggestions are only available in an unpaired Fable session." });
     if (hasPendingProposal(session)) return toolResult({ error: "A Worker suggestion is already awaiting a decision." });
@@ -166,6 +178,7 @@ function attachWorkerProposal(ctx) {
     var options = proposalOptions();
     if (options.installedVendors.length === 0) return toolResult({ error: "No coding agent is installed for a Worker session." });
     var recommendation = chooseRecommendation(args, session, options);
+    var autoApprove = skipPermissionsEnabled(session);
     var proposal = {
       type: "worker_proposal",
       proposalId: "worker_" + crypto.randomUUID(),
@@ -178,7 +191,22 @@ function attachWorkerProposal(ctx) {
       recommendedEffort: recommendation.effort,
       options: options,
     };
+    if (autoApprove) proposal.autoApproved = true;
     sm.sendAndRecord(session, proposal);
+    if (autoApprove) {
+      var accepted = await acceptProposal(session, proposal, {
+        vendor: recommendation.vendor,
+        model: recommendation.model,
+        effort: recommendation.effort,
+        autoApproved: true,
+      }, autoApprovalWs(session));
+      if (!accepted.ok) return toolResult({ error: accepted.error || "Could not start the Worker." });
+      return toolResult({
+        status: "running",
+        proposalId: proposal.proposalId,
+        instruction: "The Worker was auto-approved and started because skip permissions is enabled. Its result will return for review.",
+      });
+    }
     return toolResult({
       status: "posted",
       proposalId: proposal.proposalId,
@@ -238,6 +266,35 @@ function attachWorkerProposal(ctx) {
     return session;
   }
 
+  async function acceptProposal(session, proposal, msg, ws) {
+    var options = proposal.options || proposalOptions();
+    var vendor = msg.vendor || proposal.recommendedVendor;
+    var model = msg.model || "";
+    if (options.installedVendors.indexOf(vendor) === -1) throw new Error("Selected Worker vendor is not installed");
+    if (!modelIsAvailable(options, vendor, model)) throw new Error("Selected Worker model is unavailable");
+    var effort = yoke.clampEffort(vendor, msg.effort || proposal.recommendedEffort || "medium") || "";
+    var startingPatch = { status: "starting", selectedVendor: vendor, selectedModel: model, selectedEffort: effort };
+    if (msg.autoApproved) startingPatch.autoApproved = true;
+    updateProposal(session, proposal, startingPatch);
+    try {
+      var created = ctx.createPairRecord(ws, {
+        driver: { sessionId: session.localId },
+        worker: { vendor: vendor, model: model, effort: effort },
+      });
+      updateProposal(session, proposal, { status: "running", groupId: created.group.id, workerId: created.worker.localId });
+      if (ws._autoApproval) sm.sendToSession(session, { type: "pair_session_created", ok: true, group: created.group });
+      else ctx.sendTo(ws, { type: "pair_session_created", ok: true, group: created.group });
+      runWorker(session, proposal).catch(function (err) {
+        updateProposal(session, proposal, { status: "error", error: err.message || String(err) });
+        resumeDriver(session, "[Worker execution failed]\n" + (err.message || String(err))).catch(function () {});
+      });
+      return { ok: true, status: "running", group: created.group };
+    } catch (err) {
+      updateProposal(session, proposal, { status: "pending", error: err.message || String(err) });
+      return { ok: false, status: "pending", error: err.message || String(err) };
+    }
+  }
+
   async function respondToProposal(ws, msg) {
     var session = sessionForResponse(ws);
     var proposal = findProposal(session, msg.proposalId);
@@ -248,29 +305,7 @@ function attachWorkerProposal(ctx) {
       await resumeDriver(session, "[Worker suggestion declined]\nContinue this task in the current session using the plan you already prepared.");
       return { ok: true, status: "declined" };
     }
-    var options = proposal.options || proposalOptions();
-    var vendor = msg.vendor || proposal.recommendedVendor;
-    var model = msg.model || "";
-    if (options.installedVendors.indexOf(vendor) === -1) throw new Error("Selected Worker vendor is not installed");
-    if (!modelIsAvailable(options, vendor, model)) throw new Error("Selected Worker model is unavailable");
-    var effort = yoke.clampEffort(vendor, msg.effort || proposal.recommendedEffort || "medium") || "";
-    updateProposal(session, proposal, { status: "starting", selectedVendor: vendor, selectedModel: model, selectedEffort: effort });
-    try {
-      var created = ctx.createPairRecord(ws, {
-        driver: { sessionId: session.localId },
-        worker: { vendor: vendor, model: model, effort: effort },
-      });
-      updateProposal(session, proposal, { status: "running", groupId: created.group.id, workerId: created.worker.localId });
-      ctx.sendTo(ws, { type: "pair_session_created", ok: true, group: created.group });
-      runWorker(session, proposal).catch(function (err) {
-        updateProposal(session, proposal, { status: "error", error: err.message || String(err) });
-        resumeDriver(session, "[Worker execution failed]\n" + (err.message || String(err))).catch(function () {});
-      });
-      return { ok: true, status: "running", group: created.group };
-    } catch (err) {
-      updateProposal(session, proposal, { status: "pending", error: err.message || String(err) });
-      return { ok: false, status: "pending", error: err.message || String(err) };
-    }
+    return acceptProposal(session, proposal, msg, ws);
   }
 
   function handleMessage(ws, msg) {

--- a/lib/public/modules/worker-proposal.js
+++ b/lib/public/modules/worker-proposal.js
@@ -103,8 +103,10 @@ function statusLabel(status) {
 function applyState(card, msg) {
   var status = msg.status || "pending";
   card.dataset.status = status;
+  if (msg.autoApproved) card.dataset.autoApproved = "true";
+  var autoApproved = card.dataset.autoApproved === "true";
   var badge = card.querySelector(".worker-proposal-status");
-  if (badge) badge.textContent = statusLabel(status);
+  if (badge) badge.textContent = statusLabel(status) + (autoApproved ? " · auto-approved" : "");
   var error = card.querySelector(".worker-proposal-error");
   if (error) {
     error.textContent = msg.error || "";
@@ -116,6 +118,8 @@ function applyState(card, msg) {
     preview.classList.remove("hidden");
   }
   setControlsDisabled(card, status !== "pending");
+  var actions = card.querySelector(".worker-proposal-actions");
+  if (actions) actions.classList.toggle("hidden", autoApproved);
 }
 
 function sendDecision(card, accepted) {

--- a/test/worker-proposal-ui.test.js
+++ b/test/worker-proposal-ui.test.js
@@ -12,6 +12,8 @@ test("Worker proposal card exposes runtime controls and sends one decision messa
   assert.match(source, /worker-proposal-effort-btn/);
   assert.match(source, /type: "worker_proposal_response"/);
   assert.match(source, /Run with Worker/);
+  assert.match(source, /status === "completed"\) return "Completed"/);
+  assert.match(source, /statusLabel\(status\) \+ \(autoApproved \? " · auto-approved" : ""\)/);
 });
 
 test("message routing renders and updates Worker proposal lifecycle events", function () {

--- a/test/worker-proposal.test.js
+++ b/test/worker-proposal.test.js
@@ -148,6 +148,52 @@ test("a same-vendor fallback recommends a non-Fable execution model", async func
   assert.strictEqual(proposal.recommendedModel, "claude-sonnet-4-6");
 });
 
+test("skip permissions auto-approves and starts a Worker", async function () {
+  var f = fixture();
+  f.session.permissionMode = "bypassPermissions";
+  var tool = f.attached.getToolDefs(f.session)[0];
+  var result = parseToolResult(await tool.handler({
+    summary: "The implementation is large enough to benefit from a dedicated Worker.",
+    plan: "1. Inspect the current flow\n2. Implement the change\n3. Run focused tests",
+    message: "Implement the approved change and run focused tests.",
+    recommendedVendor: "codex",
+    recommendedModel: "gpt-5.6-sol",
+    recommendedEffort: "high",
+  }));
+  var proposal = f.session.history.filter(function (item) { return item.type === "worker_proposal"; })[0];
+
+  assert.strictEqual(result.status, "running");
+  assert.match(result.instruction, /auto-approved and started/);
+  assert.strictEqual(proposal.autoApproved, true);
+  assert.ok(proposal.status === "running" || proposal.status === "completed");
+  assert.strictEqual(f.pairs.length, 1);
+  assert.ok(f.updates.some(function (message) { return message.autoApproved === true; }));
+});
+
+test("skip permissions off leaves a Worker proposal pending", async function () {
+  var f = fixture();
+  var proposal = await postProposal(f);
+
+  assert.strictEqual(proposal.status, "pending");
+  assert.strictEqual(proposal.autoApproved, undefined);
+  assert.strictEqual(f.pairs.length, 0);
+  assert.strictEqual(f.delegations.length, 0);
+});
+
+test("auto-approved proposal updates carry the auto-approval marker", async function () {
+  var f = fixture();
+  f.session.dangerouslySkipPermissions = true;
+  var tool = f.attached.getToolDefs(f.session)[0];
+  await tool.handler({
+    summary: "The implementation is large enough to benefit from a dedicated Worker.",
+    plan: "1. Inspect the current flow\n2. Implement the change\n3. Run focused tests",
+    message: "Implement the approved change and run focused tests.",
+  });
+
+  var starting = f.updates.find(function (message) { return message.status === "starting"; });
+  assert.strictEqual(starting.autoApproved, true);
+});
+
 test("accepting a Worker suggestion creates the split, delegates, and returns the result", async function () {
   var f = fixture();
   var proposal = await postProposal(f);


### PR DESCRIPTION
## What

When the session has skip permissions toggled on (`permissionMode: "bypassPermissions"` on GUI sessions, `dangerouslySkipPermissions` on TUI sessions), a `propose_worker` call no longer waits for the user to click approve — the proposal is auto-approved and the Worker starts immediately.

## How

- The manual accept path in `lib/project-worker-proposal.js` is extracted into `acceptProposal` and reused for auto-approval, so validation, pair creation, worker dispatch, and lifecycle updates are byte-for-byte the same code as a user click. No parallel approval logic.
- The proposal card is still recorded in history and advances through starting/running with an `autoApproved` marker — no silent worker spawns. `pair_session_created` is delivered through the session path since there is no initiating socket.
- Client: approve/reject controls are hidden for auto-approved cards and the lifecycle badge gets an auto-approved suffix ("Worker running · auto-approved", "Completed · auto-approved") so terminal states stay visible.
- The MCP tool result tells the proposing agent the worker was auto-approved and already started, instead of instructing it to end the turn and wait.
- With skip permissions off, the flow is unchanged (covered by a regression test asserting the proposal stays pending with zero pairs created).

## Testing

- Three new server tests (auto-approve on bypassPermissions, unchanged pending flow when off, autoApproved marker on updates) and a UI test for the auto-approved completed badge.
- Full suite green on Node 22: 296/296.

Spec: `docs/ongoing/worker-proposal-auto-approve-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)