### PR TITLE
fix(ui): match delegation notice border to input focus state

### DIFF
--- a/lib/public/css/pane.css
+++ b/lib/public/css/pane.css
@@ -203,15 +203,18 @@ button.split-pair-role:hover { filter: brightness(1.25); }
   max-width: var(--content-width);
   margin: 0 auto;
   padding: 4px 10px;
-  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
-  border-bottom: 0;
   border-radius: 8px 8px 0 0;
   background: color-mix(in srgb, var(--accent) 8%, var(--bg));
   color: var(--text-secondary);
   font-size: 11px;
   line-height: 1.4;
+  transition: box-shadow 0.2s;
 }
 .pane-delegation-notice.visible { display: flex; }
+.pane-delegation-notice.visible:has(+ #input-wrapper #input-row:focus-within) {
+  box-shadow: 0 0 0 1px var(--border);
+  clip-path: inset(-1px -1px 0 -1px);
+}
 .pane-delegation-notice.visible + #input-wrapper #input-row {
   border-radius: 0 0 8px 8px;
 }


### PR DESCRIPTION
## Problem

The worker-pane delegation notice banner ("Following an instruction from ... join the same turn") always draws a 1px border, while the chat input below it has no border until focus, when it gains a 1px outer `box-shadow` ring. Unfocused they align; focused, the input reads 1px wider on each side and the banner looks shrunken and misaligned.

## Fix (CSS only, `lib/public/css/pane.css`)

- Remove the banner's permanent accent border. Unfocused, both banner and input are borderless and identically sized.
- While the adjacent `#input-row` has focus (`:has(+ #input-wrapper #input-row:focus-within)`), the banner gets the input's exact ring (`box-shadow: 0 0 0 1px var(--border)`) with the same 0.2s transition, so both light up together as one unit.
- The banner's bottom shadow edge is clipped (`clip-path: inset(-1px -1px 0 -1px)`) to avoid a doubled seam at the banner/input junction.

## Testing

Full suite green on Node 22 (301/301); static DOM check confirms the sibling structure the selector relies on (`split-pair-ui.js` inserts the notice directly before `#input-wrapper`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)