### PR TITLE
fix(sessions): report interrupted worker turns as interrupted

### DIFF
--- a/docs/ongoing/worker-interrupt-status-handoff.md
+++ b/docs/ongoing/worker-interrupt-status-handoff.md
@@ -1,0 +1,59 @@
+# Worker Interruption Reported as Normal Completion — Handoff
+
+## Symptom (observed live, 2026-08-26)
+
+The user interrupted a Worker mid-implementation. The Driver session then received "[Worker execution completed] ... Review and verify the Worker's result" with no indication of interruption, so the Driver treated partial, unverified work as finished. `read_partner` and `check_spawned_sessions` have the same blind spot.
+
+## Root cause (verified with file:line)
+
+Both pair pollers infer the Worker's outcome from `partner.isProcessing` + `errorSince()`:
+
+- Wait path: lib/project-session-pair.js:153-183 — resolves `{ status: failure ? "error" : "complete" }` at :167-172.
+- Detached path: lib/project-session-pair.js:185-194 → `handleTurnDone` :136-151 sets `token.response` / `token.failure`; push text built at :99-104.
+- `errorSince()` (lib/project-session-pair.js:27-32) matches only `history[i].type === "error"`.
+
+A user interrupt produces NO error record: the result-less stream end paths (lib/sdk-bridge.js:883-899 task-stop, :918-932 AbortError) record `thinking_stop`, an `{type:"info", text:"Interrupted · ..."}` message, and `{type:"done", code:0}`, then clear `isProcessing`. The poller sees an idle worker with output and no error → `"complete"`.
+
+Additional traps:
+- `session.taskStopRequested` is reset in the query `finally` (lib/sdk-bridge.js:1028-1029) before the next 500ms poll tick, so it cannot be read from the poller. A durable flag is required.
+- The interrupt path never fires `onTurnDone` (normal completion routes via lib/sdk-message-processor.js:568-570 → lib/project.js:859-862); detached delivery relies purely on the poll, so the signal must live on the session object.
+- Same bug class in the spawn tool: lib/project-session-spawn.js:316-325 reports `done` for interrupted sessions because `hasSessionError()` (:125-131) only checks `type === "error"` or `done` with code 1, and interrupts emit `done` with code 0.
+
+## Fix
+
+1. **Capture a durable flag.** In lib/sdk-bridge.js set `session._lastTurnInterrupted = true` in both result-less interrupt paths (:887-899 alongside the existing interrupt feedback, :918-932 in the AbortError branch — only when the cause is taskStopRequested/abort, not adapter errors). Clear it when a new query/turn starts (where `taskStopRequested` resets at :1028-1029 is NOT the right place to clear — that runs at the end of the same stream; clear at query/turn START so the flag survives until the next turn begins).
+2. **Detect in the pair pollers.** lib/project-session-pair.js: add the interrupted check next to `errorSince()` usage in both paths.
+   - Wait path :164-173: resolve `status: "interrupted"` (still include the partial `response` text) when the flag is set and no error record exists.
+   - Detached path :147-148: set `token.interrupted = true`; `resumeDriverWithResult` :99-104 gets a distinct text for the interrupted case, e.g. "[Worker execution interrupted] The user interrupted the Worker mid-turn. Its work is PARTIAL and unverified — do not treat it as finished. Review what was done and decide next steps with the user." Keep the completed/failed texts unchanged.
+3. **Thread through the proposal flow.** lib/project-worker-proposal.js: `parsePartnerResult` (:232-238) passes the new status through; `runWorker` (:240-257) gets an `interrupted` branch before the failure `else` — proposal record status "interrupted", driver resume text as above, and the proposal card should not read "Completed". Client: lib/public/modules/worker-proposal.js statusLabel gets an "Interrupted" label.
+4. **Status surfaces.** lib/project-session-pair.js:263 `read_partner` reports `status: "interrupted"`; lib/project-session-spawn.js:322 `check_spawned_sessions` likewise (treat a trailing interrupted turn as `interrupted`, not `done`).
+5. **Driver guidance.** The pair system prompt (lib/project-session-pair.js:386 area) mentions the interrupted outcome so Drivers know it exists.
+
+## Tests
+
+Extend test/session-pair.test.js (fixture at :29-48 currently fakes turns with error/delta + `handleTurnDone`):
+1. Teach the fixture to emulate an interrupted turn: `info` ("Interrupted ...") + `done` code 0 + the durable `_lastTurnInterrupted` flag + `isProcessing = false`, WITHOUT `handleTurnDone` (interrupts never fire it — the detached monitor poll must catch it).
+2. Wait path returns `status: "interrupted"` with the partial response.
+3. Detached push text contains "interrupted" and "PARTIAL", not "completed".
+4. A normal completion after an interrupted turn (flag cleared at next query start) still reports "complete" — the flag must not stick across turns.
+5. worker-proposal: an interrupted worker run produces the interrupted resume text and proposal status (mirror test/worker-proposal.test.js:197-218 which asserts /Worker execution completed/).
+6. spawn tool: an interrupted spawned session reports `interrupted`, not `done`.
+
+Existing assertions must remain unweakened.
+
+## Hard requirements
+
+- `var` only, no arrow functions; CommonJS server / ESM client; English strings; no commits.
+- Do not change the completed/failed flows or their texts.
+- The durable flag must be interrupt-specific: adapter errors keep reporting `error`, normal ends keep reporting `complete`.
+
+## Validation
+
+`node --check` on touched files; full `npm test` green on Node 22 (`/Users/chad/.nvm/versions/node/v22.22.1/bin/node`; shell default Node 18 cannot run the suite).
+
+## Acceptance criteria
+
+1. Interrupting a Worker mid-turn → Driver push says interrupted/partial, never "completed".
+2. `read_partner` on an interrupted Worker returns `interrupted`, not `idle`.
+3. `check_spawned_sessions` on an interrupted spawned session returns `interrupted`, not `done`.
+4. Normal completion, failure, and still-running flows unchanged; full suite green.

--- a/lib/project-session-pair.js
+++ b/lib/project-session-pair.js
@@ -98,10 +98,15 @@ function attachSessionPair(ctx) {
     token.delivered = true;
     var failure = token.failure || null;
     var response = token.response || "";
-    var text = "A Worker task delegated through send_to_partner has finished.\n\n" +
-      "Original task:\n" + token.message + "\n\n" +
-      (failure ? "Worker error:\n" + failure : "Worker result:\n" + (response || "(No text response was recorded.)")) +
-      "\n\nReview the result, verify it as needed, and continue the task.";
+    var text;
+    if (token.interrupted) {
+      text = "[Worker execution interrupted] The user interrupted the Worker mid-turn. Its work is PARTIAL and unverified — do not treat it as finished. Review what was done and decide next steps with the user.";
+    } else {
+      text = "A Worker task delegated through send_to_partner has finished.\n\n" +
+        "Original task:\n" + token.message + "\n\n" +
+        (failure ? "Worker error:\n" + failure : "Worker result:\n" + (response || "(No text response was recorded.)")) +
+        "\n\nReview the result, verify it as needed, and continue the task.";
+    }
     sm.sendAndRecord(caller, {
       type: "user_message",
       text: text,
@@ -146,6 +151,7 @@ function attachSessionPair(ctx) {
     }
     token.response = responseText(partner.history || [], token.startIndex);
     token.failure = errorSince(partner.history || [], token.startIndex);
+    token.interrupted = !token.failure && !!partner._lastTurnInterrupted;
     finishDelegation(group, caller, partner, token);
     return resumeDriverWithResult(caller, partner, token);
   }
@@ -165,8 +171,9 @@ function attachSessionPair(ctx) {
           clearInterval(timer);
           finishDelegation(group, caller, partner, token);
           var failure = errorSince(partner.history || [], token.startIndex);
+          var interrupted = !failure && !!partner._lastTurnInterrupted;
           resolve({
-            status: failure ? "error" : "complete",
+            status: failure ? "error" : (interrupted ? "interrupted" : "complete"),
             response: responseText(partner.history || [], token.startIndex),
             error: failure || undefined,
           });
@@ -260,7 +267,7 @@ function attachSessionPair(ctx) {
       var count = Number.isFinite(args.lastTurns) ? Math.floor(args.lastTurns) : 1;
       count = Math.max(1, Math.min(5, count));
       return toolResult({
-        status: resolved.partner.isProcessing ? "running" : "idle",
+        status: resolved.partner.isProcessing ? "running" : (resolved.partner._lastTurnInterrupted ? "interrupted" : "idle"),
         partnerId: resolved.partner.localId,
         title: resolved.partner.title || "New Session",
         turns: recentTurns(resolved.partner, count),
@@ -383,7 +390,7 @@ function attachSessionPair(ctx) {
     var group = store.groupForMember(session.localId);
     var pairPrompt = "";
     if (group && group.pair && group.pair.driverId === session.localId) {
-      pairPrompt = "You are the Driver in a two-agent pair. The tools send_to_partner and read_partner are provided directly to you. Use send_to_partner to delegate concrete bounded work to the Worker. A completed Worker turn leaves the Worker session available for more work. If review or user feedback requires corrections to the Worker's implementation, delegate a follow-up turn to that Worker instead of editing the Worker-owned files yourself. If send_to_partner reports that the Worker is no longer available, create a replacement with spawn_sessions and delegate the remaining implementation rather than taking it over. If a non-waiting delegation finishes later, Clay pushes the result back and resumes you automatically; use read_partner only when you need an interim status check. Integrate and verify the final outcome. Do not search the project for implementations of these tools, and do not delegate work that must be performed sequentially in this same session.";
+      pairPrompt = "You are the Driver in a two-agent pair. The tools send_to_partner and read_partner are provided directly to you. Use send_to_partner to delegate concrete bounded work to the Worker. A completed Worker turn leaves the Worker session available for more work. If a Worker turn is interrupted, its work is partial and unverified; review it and decide next steps with the user. If review or user feedback requires corrections to the Worker's implementation, delegate a follow-up turn to that Worker instead of editing the Worker-owned files yourself. If send_to_partner reports that the Worker is no longer available, create a replacement with spawn_sessions and delegate the remaining implementation rather than taking it over. If a non-waiting delegation finishes later, Clay pushes the result back and resumes you automatically; use read_partner only when you need an interim status check. Integrate and verify the final outcome. Do not search the project for implementations of these tools, and do not delegate work that must be performed sequentially in this same session.";
     }
     return [pairPrompt, workerProposal.getSystemPrompt(session)].filter(Boolean).join("\n\n");
   }

--- a/lib/project-session-spawn.js
+++ b/lib/project-session-spawn.js
@@ -319,7 +319,7 @@ function attachSessionSpawn(ctx) {
         statuses.push({
           localId: session.localId,
           title: session.title || "New Session",
-          status: session.isProcessing ? "running" : (hasSessionError(session) ? "error" : "done"),
+          status: session.isProcessing ? "running" : (session._lastTurnInterrupted ? "interrupted" : (hasSessionError(session) ? "error" : "done")),
           turnCount: session.turnCount || 0,
           lastActivity: session.lastActivity || session.createdAt || 0,
         });

--- a/lib/project-worker-proposal.js
+++ b/lib/project-worker-proposal.js
@@ -248,6 +248,8 @@ function attachWorkerProposal(ctx) {
     var followup;
     if (result.status === "complete") {
       followup = "[Worker execution completed]\nReview and verify the Worker's result. The Worker session remains available: if the implementation needs corrections or additional edits, send a follow-up with send_to_partner instead of taking over the Worker-owned files yourself. If that Worker is no longer available, create a replacement with spawn_sessions for the remaining implementation.\n\n" + (result.response || "The Worker completed without a text summary.");
+    } else if (result.status === "interrupted") {
+      followup = "[Worker execution interrupted]\nThe user interrupted the Worker mid-turn. Its work is PARTIAL and unverified — do not treat it as finished. Review what was done and decide next steps with the user.";
     } else if (result.status === "running") {
       followup = "[Worker execution is still running]\nUse read_partner to inspect progress before completing the task.";
     } else {

--- a/lib/public/modules/worker-proposal.js
+++ b/lib/public/modules/worker-proposal.js
@@ -95,6 +95,7 @@ function statusLabel(status) {
   if (status === "starting") return "Starting Worker";
   if (status === "running") return "Worker running";
   if (status === "completed") return "Completed";
+  if (status === "interrupted") return "Interrupted";
   if (status === "declined") return "Continuing here";
   if (status === "error") return "Needs attention";
   return "Suggested by Fable";

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -885,6 +885,7 @@ function createSDKBridge(opts) {
       console.log("[sdk-bridge] processQueryStream ended: isProcessing=" + session.isProcessing + " taskStopRequested=" + session.taskStopRequested);
       var stillOwnsRuntime = session.queryInstance === myQueryInstance;
       if (session.isProcessing && session.taskStopRequested && stillOwnsRuntime) {
+        session._lastTurnInterrupted = true;
         session.isProcessing = false;
         session._awaitingTurnResult = false;
         session._queuedTurnCount = 0;
@@ -922,6 +923,7 @@ function createSDKBridge(opts) {
         session._queuedTurnCount = 0;
         onProcessingChanged();
         if (err.name === "AbortError" || (myAbortController && myAbortController.signal.aborted) || session.taskStopRequested) {
+          session._lastTurnInterrupted = true;
           if (!session.destroying) {
             sendAndRecord(session, { type: "thinking_stop" });
             var interruptMsg2 = (session.vendor && session.vendor !== "claude")
@@ -1189,6 +1191,7 @@ function createSDKBridge(opts) {
   // Wrapper: marks the boot window so pushMessage can buffer instead of
   // dropping messages that arrive while createQuery is still awaiting.
   async function startQuery(session, text, images, linuxUser) {
+    delete session._lastTurnInterrupted;
     session._queryStarting = true;
     try {
       return await startQueryInner(session, text, images, linuxUser);
@@ -1707,6 +1710,7 @@ function createSDKBridge(opts) {
         console.error("[sdk-bridge] QueryHandle rejected message for session " + session.localId + ":", e.message || e);
       }
       if (delivered) {
+        delete session._lastTurnInterrupted;
         if (session._awaitingTurnResult) {
           session._queuedTurnCount = (session._queuedTurnCount || 0) + 1;
         } else {

--- a/test/session-pair.test.js
+++ b/test/session-pair.test.js
@@ -37,11 +37,20 @@ function fixture(configured, options) {
     startQuery: function (session, text) {
       starts.push({ session: session, text: text });
       if (session !== worker) return Promise.resolve();
+      delete session._lastTurnInterrupted;
       setTimeout(function () {
-        if (options.workerError) session.history.push({ type: "error", text: options.workerError });
-        else session.history.push({ type: "delta", text: "Partner result" });
+        if (options.workerError) {
+          session.history.push({ type: "error", text: options.workerError });
+        } else if (options.workerInterrupted) {
+          session.history.push({ type: "delta", text: "Partial implementation" });
+          session.history.push({ type: "info", text: "Interrupted · What should Claude do instead?" });
+          session.history.push({ type: "done", code: 0 });
+          session._lastTurnInterrupted = true;
+        } else {
+          session.history.push({ type: "delta", text: "Partner result" });
+        }
         session.isProcessing = false;
-        if (options.autoTurnDone !== false) attached.handleTurnDone(session);
+        if (options.autoTurnDone !== false && !options.workerInterrupted) attached.handleTurnDone(session);
       }, options.workerDelay || 20);
       return Promise.resolve();
     },
@@ -125,6 +134,34 @@ test("the detached monitor delivers failures even when no normal turn-done event
   assert.strictEqual(f.driverPushes.length, 1);
   assert.match(f.driverPushes[0], /Worker error:\nWorker crashed/);
   assert.strictEqual(f.worker._pairDelegation, undefined);
+});
+
+test("waiting for an interrupted Worker returns its partial response and interrupted status", async function () {
+  var f = fixture(true, { workerInterrupted: true });
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  var result = parseToolResult(await tool.handler({ message: "Inspect the tests", timeoutSeconds: 2 }));
+  assert.deepStrictEqual(result, { status: "interrupted", response: "Partial implementation" });
+  assert.deepStrictEqual(f.driverPushes, []);
+});
+
+test("the detached monitor reports interruption as partial, not completion", async function () {
+  var f = fixture(true, { workerInterrupted: true });
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  await tool.handler({ message: "Inspect the tests", wait: false });
+  await new Promise(function (resolve) { setTimeout(resolve, 550); });
+
+  assert.strictEqual(f.driverPushes.length, 1);
+  assert.match(f.driverPushes[0], /Worker execution interrupted/);
+  assert.match(f.driverPushes[0], /PARTIAL/);
+  assert.doesNotMatch(f.driverPushes[0], /completed/);
+});
+
+test("a new Worker turn clears an earlier interrupted state", async function () {
+  var f = fixture(true);
+  f.worker._lastTurnInterrupted = true;
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  var result = parseToolResult(await tool.handler({ message: "Inspect the tests", timeoutSeconds: 2 }));
+  assert.deepStrictEqual(result, { status: "complete", response: "Partner result" });
 });
 
 test("a user-started Worker turn never pushes to the Driver", function () {

--- a/test/session-spawn.test.js
+++ b/test/session-spawn.test.js
@@ -77,6 +77,7 @@ function createForkFixture(options) {
   });
   var server = attached.createMcpServer(fakeAdapter, parent);
   var spawnTool = server.tools.filter(function(tool) { return tool.name === "spawn_sessions"; })[0];
+  var checkTool = server.tools.filter(function(tool) { return tool.name === "check_spawned_sessions"; })[0];
   return {
     parent: parent,
     sessions: sessions,
@@ -84,6 +85,7 @@ function createForkFixture(options) {
     forks: forks,
     get broadcasts() { return broadcasts; },
     spawn: function(args) { return spawnTool.handler(args); },
+    check: function(args) { return checkTool.handler(args || {}); },
   };
 }
 
@@ -122,6 +124,20 @@ test("spawned sessions cannot create grandchildren", function() {
   assert.throws(function() {
     spawnModule.assertSpawnAllowed({ localId: 7, spawn: { parentId: 2 } }, [], 1);
   }, { message: "spawned sessions cannot spawn further sessions" });
+});
+
+test("check_spawned_sessions reports an interrupted child distinctly", async function() {
+  var f = createForkFixture();
+  var response = await f.spawn({ sessions: JSON.stringify([{ title: "Worker", prompt: "Implement it" }]) });
+  var spawned = JSON.parse(response.content[0].text).spawned[0];
+  var child = f.sessions.get(spawned.localId);
+  child.isProcessing = false;
+  child._lastTurnInterrupted = true;
+  child.history.push({ type: "info", text: "Interrupted · What should Claude do instead?" });
+  child.history.push({ type: "done", code: 0 });
+
+  var checked = JSON.parse((await f.check()).content[0].text);
+  assert.strictEqual(checked[0].status, "interrupted");
 });
 
 test("twentieth child is allowed and twenty-first is rejected", function() {

--- a/test/worker-proposal.test.js
+++ b/test/worker-proposal.test.js
@@ -222,3 +222,26 @@ test("accepting a Worker suggestion creates the split, delegates, and returns th
   assert.ok(f.updates.some(function (message) { return message.status === "running"; }));
   assert.ok(f.updates.some(function (message) { return message.status === "completed"; }));
 });
+
+test("an interrupted Worker proposal stays interrupted and warns the Driver", async function () {
+  var f = fixture();
+  f.attached = proposalModule.attachWorkerProposal({
+    sm: f.sm,
+    isMate: false,
+    splitStore: { groupForMember: function () { return null; } },
+    getSdk: function () { return { pushMessage: function () { return false; }, startQuery: function (target, text) { f.starts.push({ session: target, text: text }); return Promise.resolve(); } }; },
+    sendTo: function (ws, message) { f.directEvents.push(message); },
+    usersModule: { isMultiUser: function () { return false; } },
+    getLinuxUserForSession: function () { return null; },
+    onProcessingChanged: function () {},
+    adapters: {},
+    createPairRecord: function () { return { worker: { localId: 2 }, group: { id: "sg_worker", members: [1, 2] } }; },
+    sendToPartner: function () { return Promise.resolve({ content: [{ type: "text", text: JSON.stringify({ status: "interrupted", response: "Partial implementation" }) }] }); },
+  });
+  var proposal = await postProposal(f);
+  await f.attached.respondToProposal(f.ws, { proposalId: proposal.proposalId, accepted: true, vendor: "codex", model: "gpt-5.6-sol", effort: "high" });
+  await nextTurn();
+  assert.strictEqual(proposal.status, "interrupted");
+  assert.match(f.starts[0].text, /Worker execution interrupted/);
+  assert.match(f.starts[0].text, /PARTIAL/);
+});


### PR DESCRIPTION
## Problem

Interrupting a Worker mid-turn produced a "[Worker execution completed] ... Review and verify the Worker's result" push to the Driver with no hint of interruption (observed live 2026-08-26), so Drivers treated partial, unverified work as finished. `read_partner` reported `idle` and `check_spawned_sessions` reported `done` for the same reason.

Root cause: both pair pollers classify outcomes via `isProcessing` + `errorSince()` only, and user interrupts leave no error record — they end result-less with `info` + `done code 0`. `taskStopRequested` resets before the 500ms pollers tick, and interrupts never fire `onTurnDone`, so no durable signal existed.

## Fix

- Durable `session._lastTurnInterrupted` set on both user-interrupt terminal paths in `lib/sdk-bridge.js`, cleared when the next query starts or the next turn is delivered.
- Pair wait path resolves `status: "interrupted"` (with the partial response); the detached push text says the work is **PARTIAL and unverified** instead of the completed wording.
- Worker proposals thread the state through (`parsePartnerResult`, interrupted branch in `runWorker`, "Interrupted" badge on the client card).
- `read_partner` → `interrupted` instead of `idle`; `check_spawned_sessions` → `interrupted` instead of `done`.
- The Driver pair system prompt documents the interrupted outcome.
- Completed, failed, and running flows and texts are byte-for-byte unchanged (existing assertions unweakened).

## Testing

Five new regression tests across `test/session-pair.test.js` (fixture taught the interrupted-turn shape that never fires `handleTurnDone`, so the poll path is what's exercised), `test/worker-proposal.test.js`, and `test/session-spawn.test.js` — including flag reset on the next normal turn. Full suite green on Node 22: 306/306.

Spec: `docs/ongoing/worker-interrupt-status-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)