### PR TITLE
feat(yoke): emit background_tasks_changed from codex background terminals

### DIFF
--- a/docs/ongoing/codex-background-tasks-handoff.md
+++ b/docs/ongoing/codex-background-tasks-handoff.md
@@ -1,0 +1,50 @@
+# Codex background_tasks_changed Producer — Handoff
+
+## Context and investigation verdict (2026-08-26)
+
+Follow-up from the background-task indicator (PR #436). The yoke contract (lib/yoke/interface.js) allows adapters to synthesize `background_tasks_changed`. Investigation of the codex app-server protocol concluded:
+
+- Codex emits NO push notification bookending background work. Deriving the event from `item/commandExecution` begin/end would label ordinary foreground shell calls as background tasks and thrash the indicator under REPLACE semantics. DO NOT do that.
+- Codex's genuine background surface is **background terminals**: poll-only requests `thread/backgroundTerminals/list` / `clean` / `terminate` exist in the app-server binary's method table (plus `process/outputDelta` / `process/exited` notifications and the config key `background_terminal_max_timeout`). The interrupt prompt string in the binary confirms processes can outlive a turn.
+- Spawned subagent child threads are a second background surface, but their notifications are dropped at lib/yoke/codex-app-server.js:257 (foreign threadId). Fixing that routing is OUT OF SCOPE here — it is an event-routing change with its own risks. This handoff covers terminals only.
+
+## Design: polled level signal at turn boundaries
+
+Implement `background_tasks_changed` in lib/yoke/adapters/codex.js as a polled signal:
+
+1. **Poll points.** After `turn/completed` and `turn/failed` are flattened (codex.js:152, :208 are the edges), issue `thread/backgroundTerminals/list` for the current thread. The result maps to contract tasks: each live terminal → `{ task_id, task_type: "shell", description }` (use the command line or terminal name the protocol provides; empty string if none).
+2. **Emit only on membership change.** Keep the last emitted set per query handle (state lives in `createEventState`, codex.js:654, instantiated per handle at :694). Compare task_id sets; emit a `background_tasks_changed` event via `pushEvent` (codex.js:715) only when membership changed. This matches the SDK's level-signal semantics and avoids per-turn event spam.
+3. **Reset guarantee.** Emit an empty-set event from the app-server (re)start path (`_createAppServer`/`start()` at codex.js:1542-1549, NOT `adapter.init` entry, which is idempotent-cached at :1464). Consumers must never carry a stale set across a codex process restart.
+4. **Graceful degrade.** If the `thread/backgroundTerminals/list` request errors (older binary, method missing), disable polling for that app-server instance after the first failure and never emit — feature silently absent, zero errors, zero retries per turn.
+5. **task_type vocabulary.** Terminals are `shell`. Nothing else is produced by this implementation.
+
+## Contract test
+
+Add codex to the producer list in test/yoke-adapter-contract.test.js (:87-110). The current fixture shape assumes a pure raw→event normalize function; the codex producer is aggregated/polled, so add the fixture shape the harness needs (e.g. a producer entry that exercises the set-mapping function directly: terminals list in → contract tasks out, with membership-change gating tested separately in a codex-specific test). Do not weaken the claude producer's assertions.
+
+Also add codex-focused tests:
+1. Terminals list response maps to contract-conformant tasks (task_type "shell", ids preserved, description fallback "").
+2. Same membership twice → one emission (level semantics).
+3. Empty list after a non-empty one → empty-set emission (indicator clears).
+4. App-server start emits empty set.
+5. List request failure → no emission and no further polling attempts on that instance.
+
+## Hard requirements
+
+- No synthesis from `item/commandExecution` begin/end events.
+- No new polling timers — poll only at the turn/completed and turn/failed edges plus process start.
+- `var` only, no arrow functions, CommonJS; English strings; no commits.
+- Keep every existing codex adapter behavior unchanged; keep modules under 500 lines (codex.js is large — if the addition pushes limits, extract a small codex-background-tasks.js helper module).
+- Downstream (sdk-message-processor.js:626-633) needs no changes — verify, don't touch.
+
+## Validation
+
+`node --check` on touched files; full `npm test` green on Node 22 (`/Users/chad/.nvm/versions/node/v22.22.1/bin/node`; shell default Node 18 cannot run the suite or import SDK-adjacent modules).
+
+## Acceptance criteria
+
+1. A codex session with no background terminals never emits the event (no indicator, no churn).
+2. The mapping function produces contract-conformant tasks and passes the shared contract assertions.
+3. Membership-change gating and the process-restart empty-set are covered by tests.
+4. A missing/erroring list method degrades silently and permanently for that instance.
+5. Full suite green; claude producer tests unchanged.

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -8,6 +8,7 @@ var fs = require("fs");
 var { CodexAppServer } = require("../codex-app-server");
 var skillDiscovery = require("../skill-discovery");
 var { resolveOsUserInfo } = require("../../os-users");
+var backgroundTasks = require("../codex-background-tasks");
 
 // --- Event flattening ---
 // Converts app-server JSON-RPC notifications into flat objects with a yokeType field.
@@ -672,6 +673,7 @@ function createEventState(model) {
     toolBlocks: {},
     commandInputs: {},
     planTexts: {},
+    backgroundTasks: backgroundTasks.createState(),
   };
 }
 
@@ -698,6 +700,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
   var eventWaiting = null;
   var iteratorDone = false;
   var finishedNotified = false;
+  var removeBackgroundTaskReset = null;
 
   function notifyFinished() {
     if (finishedNotified) return;
@@ -722,12 +725,22 @@ function createCodexQueryHandle(appServer, queryOpts) {
     }
   }
 
+  if (typeof queryOpts.registerBackgroundTaskReset === "function") {
+    removeBackgroundTaskReset = queryOpts.registerBackgroundTaskReset(function() {
+      backgroundTasks.emitReset(state.backgroundTasks, pushEvent);
+    });
+  }
+
   function endIterator() {
     iteratorDone = true;
     if (eventWaiting) {
       var resolve = eventWaiting;
       eventWaiting = null;
       resolve({ value: undefined, done: true });
+    }
+    if (removeBackgroundTaskReset) {
+      removeBackgroundTaskReset();
+      removeBackgroundTaskReset = null;
     }
     notifyFinished();
   }
@@ -932,6 +945,10 @@ function createCodexQueryHandle(appServer, queryOpts) {
     var yokeEvents = flattenEvent(msg, state);
     for (var i = 0; i < yokeEvents.length; i++) {
       pushEvent(yokeEvents[i]);
+    }
+
+    if (method === "turn/completed" || method === "turn/failed") {
+      backgroundTasks.poll(appServer, state.threadId, state.backgroundTasks, pushEvent).catch(function() {});
     }
 
     // Resolve turn promise when turn ends
@@ -1246,6 +1263,20 @@ function createCodexAdapter(opts) {
   ];
   var _cachedModels = CODEX_MODELS.slice();
   var _appServer = null;
+  var _backgroundTaskResetListeners = [];
+
+  function registerBackgroundTaskReset(listener) {
+    _backgroundTaskResetListeners.push(listener);
+    return function() {
+      var index = _backgroundTaskResetListeners.indexOf(listener);
+      if (index !== -1) _backgroundTaskResetListeners.splice(index, 1);
+    };
+  }
+
+  function emitBackgroundTaskReset() {
+    var listeners = _backgroundTaskResetListeners.slice();
+    for (var i = 0; i < listeners.length; i++) listeners[i]();
+  }
   var _initPromise = null;
   var _shutdownPromise = null;
   var _refCount = 0;
@@ -1541,6 +1572,7 @@ function createCodexAdapter(opts) {
         // Spawn and initialize app-server
         _appServer = _createAppServer(serverOpts);
         await _appServer.start();
+        emitBackgroundTaskReset();
 
         await _appServer.send("initialize", {
           clientInfo: { name: "clay", title: "Clay", version: "1.0.0" },
@@ -1676,6 +1708,7 @@ function createCodexAdapter(opts) {
         canUseTool: queryOpts.canUseTool || null,
         onElicitation: queryOpts.onElicitation || null,
         resumeSessionId: queryOpts.resumeSessionId || null,
+        registerBackgroundTaskReset: registerBackgroundTaskReset,
       };
 
       // Reasoning effort

--- a/lib/yoke/codex-background-tasks.js
+++ b/lib/yoke/codex-background-tasks.js
@@ -1,0 +1,84 @@
+function terminalList(result) {
+  if (Array.isArray(result)) return result;
+  if (!result || typeof result !== "object") return [];
+  if (Array.isArray(result.terminals)) return result.terminals;
+  if (Array.isArray(result.backgroundTerminals)) return result.backgroundTerminals;
+  if (Array.isArray(result.items)) return result.items;
+  return [];
+}
+
+function isLiveTerminal(terminal) {
+  var status = String((terminal && (terminal.status || terminal.state)) || "").toLowerCase();
+  return status !== "exited" && status !== "terminated" && status !== "completed" && status !== "failed";
+}
+
+function mapTerminals(result) {
+  var terminals = terminalList(result);
+  var tasks = [];
+  for (var i = 0; i < terminals.length; i++) {
+    var terminal = terminals[i] || {};
+    var taskId = terminal.id || terminal.terminalId || terminal.taskId || "";
+    if (!taskId || !isLiveTerminal(terminal)) continue;
+    tasks.push({
+      task_id: String(taskId),
+      task_type: "shell",
+      description: terminal.commandLine || terminal.command || terminal.name || "",
+    });
+  }
+  return tasks;
+}
+
+function taskIds(tasks) {
+  var ids = {};
+  for (var i = 0; i < tasks.length; i++) ids[tasks[i].task_id] = true;
+  return ids;
+}
+
+function sameMembership(first, second) {
+  var firstKeys = Object.keys(first || {});
+  var secondKeys = Object.keys(second || {});
+  if (firstKeys.length !== secondKeys.length) return false;
+  for (var i = 0; i < firstKeys.length; i++) {
+    if (!second[firstKeys[i]]) return false;
+  }
+  return true;
+}
+
+function createState() {
+  return { taskIds: null };
+}
+
+function emitIfChanged(state, tasks, pushEvent) {
+  var ids = taskIds(tasks);
+  if (state.taskIds === null && tasks.length === 0) {
+    state.taskIds = ids;
+    return false;
+  }
+  if (state.taskIds && sameMembership(state.taskIds, ids)) return false;
+  state.taskIds = ids;
+  pushEvent({ yokeType: "background_tasks_changed", tasks: tasks });
+  return true;
+}
+
+function poll(appServer, threadId, state, pushEvent) {
+  if (!appServer || !threadId || appServer._clayBackgroundTasksPollingDisabled) return Promise.resolve(false);
+  return appServer.send("thread/backgroundTerminals/list", { threadId: threadId }).then(function(result) {
+    return emitIfChanged(state, mapTerminals(result), pushEvent);
+  }).catch(function() {
+    appServer._clayBackgroundTasksPollingDisabled = true;
+    return false;
+  });
+}
+
+function emitReset(state, pushEvent) {
+  state.taskIds = {};
+  pushEvent({ yokeType: "background_tasks_changed", tasks: [] });
+}
+
+module.exports = {
+  createState: createState,
+  mapTerminals: mapTerminals,
+  emitIfChanged: emitIfChanged,
+  poll: poll,
+  emitReset: emitReset,
+};

--- a/test/codex-background-tasks.test.js
+++ b/test/codex-background-tasks.test.js
@@ -1,0 +1,57 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var backgroundTasks = require("../lib/yoke/codex-background-tasks");
+
+test("Codex maps live background terminals to shell tasks", function() {
+  var tasks = backgroundTasks.mapTerminals({ terminals: [
+    { id: "term-1", command: "npm test" },
+    { terminalId: "term-2", name: "Build watch" },
+    { id: "term-3", status: "exited", command: "old" },
+    { id: "term-4" },
+  ] });
+  assert.deepStrictEqual(tasks, [
+    { task_id: "term-1", task_type: "shell", description: "npm test" },
+    { task_id: "term-2", task_type: "shell", description: "Build watch" },
+    { task_id: "term-4", task_type: "shell", description: "" },
+  ]);
+});
+
+test("Codex emits only when background terminal membership changes", function() {
+  var state = backgroundTasks.createState();
+  var events = [];
+  var task = [{ task_id: "term-1", task_type: "shell", description: "npm test" }];
+  assert.strictEqual(backgroundTasks.emitIfChanged(state, task, function(event) { events.push(event); }), true);
+  assert.strictEqual(backgroundTasks.emitIfChanged(state, task, function(event) { events.push(event); }), false);
+  assert.strictEqual(events.length, 1);
+});
+
+test("Codex emits an empty set when a background terminal set clears", function() {
+  var state = backgroundTasks.createState();
+  var events = [];
+  backgroundTasks.emitIfChanged(state, [{ task_id: "term-1", task_type: "shell", description: "npm test" }], function(event) { events.push(event); });
+  backgroundTasks.emitIfChanged(state, [], function(event) { events.push(event); });
+  assert.deepStrictEqual(events[1], { yokeType: "background_tasks_changed", tasks: [] });
+});
+
+test("Codex app-server restart emits an empty background-task set", function() {
+  var state = backgroundTasks.createState();
+  var events = [];
+  backgroundTasks.emitReset(state, function(event) { events.push(event); });
+  assert.deepStrictEqual(events, [{ yokeType: "background_tasks_changed", tasks: [] }]);
+});
+
+test("Codex permanently disables background terminal polling after a list failure", async function() {
+  var calls = 0;
+  var server = {
+    send: function() {
+      calls++;
+      return Promise.reject(new Error("method not found"));
+    },
+  };
+  var state = backgroundTasks.createState();
+  var events = [];
+  await backgroundTasks.poll(server, "thread-1", state, function(event) { events.push(event); });
+  await backgroundTasks.poll(server, "thread-1", state, function(event) { events.push(event); });
+  assert.strictEqual(calls, 1);
+  assert.deepStrictEqual(events, []);
+});

--- a/test/yoke-adapter-contract.test.js
+++ b/test/yoke-adapter-contract.test.js
@@ -102,10 +102,20 @@ test("YOKE background-task producers emit the normalized level-state contract", 
       { task_id: "agent-1", task_type: "agent", description: "Review changes" },
       { task_id: "unknown-1", task_type: "other", description: "Check status" },
     ],
+  }, {
+    name: "Codex",
+    produce: require("../lib/yoke/codex-background-tasks").mapTerminals,
+    rawEvent: {
+      terminals: [{ id: "terminal-1", commandLine: "npm test" }],
+    },
+    expectedTasks: [
+      { task_id: "terminal-1", task_type: "shell", description: "npm test" },
+    ],
   }];
   for (var i = 0; i < producers.length; i++) {
     var producer = producers[i];
-    assertBackgroundTaskContract(producer.normalize(producer.rawEvent), producer.expectedTasks);
+    if (producer.normalize) assertBackgroundTaskContract(producer.normalize(producer.rawEvent), producer.expectedTasks);
+    else assertBackgroundTaskContract({ yokeType: "background_tasks_changed", tasks: producer.produce(producer.rawEvent) }, producer.expectedTasks);
   }
 });
 


### PR DESCRIPTION
## What

Adds a codex producer for the vendor-neutral `background_tasks_changed` yoke contract event, completing the follow-up from #436 (the background-task indicator was claude-only at the producer level).

## Design (investigation-driven)

A protocol survey concluded codex emits no push notification bookending background work — synthesizing from `item/commandExecution` begin/end would mislabel ordinary foreground shell calls and thrash the indicator under REPLACE semantics, so that approach is explicitly rejected. Codex's genuine background surface is **background terminals** (`thread/backgroundTerminals/list`, poll-only).

- New `lib/yoke/codex-background-tasks.js` (84 lines, keeps the oversized codex.js from growing): maps live terminals to `{ task_id, task_type: "shell", description }`, tracks the last emitted membership per query handle, and emits only on membership change (level-signal semantics — no per-turn spam).
- Polling happens only at the `turn/completed` / `turn/failed` edges; no timers.
- App-server (re)start emits an empty set to active query handles, so consumers never carry stale state across a codex process restart.
- The first `list` request failure disables polling for that app-server instance permanently — older binaries without the method degrade silently with zero errors.
- Subagent child-thread routing (a second potential background surface, currently dropped at `codex-app-server.js:257`) is explicitly out of scope; documented in the spec.

## Testing

- Codex joins the shared producer contract test in `test/yoke-adapter-contract.test.js` (claude entry unweakened).
- New `test/codex-background-tasks.test.js`: mapping, membership gating, clear-on-empty, restart reset, failure degrade.
- Full suite green on Node 22: 311/311. Downstream processor unchanged (verified consumer is already vendor-neutral).

Spec: `docs/ongoing/codex-background-tasks-handoff.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)