### PR TITLE
fix(ui): show connecting wording and quiet pane connection overlay

### DIFF
--- a/lib/public/css/pane.css
+++ b/lib/public/css/pane.css
@@ -25,6 +25,10 @@ body.pane-mode #sticky-notes-container {
 
 body.pane-mode #file-viewer { display: none !important; }
 
+body.pane-mode #connect-overlay { background: var(--bg); }
+body.pane-mode #connect-overlay #ascii-logo-canvas { display: none; }
+body.pane-mode #connect-overlay-msg { color: var(--text-dimmer); }
+
 body.pane-mode .notif-banner-container {
   display: none !important;
 }

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -403,7 +403,7 @@
       <div id="app">
         <div id="connect-overlay">
       <canvas id="ascii-logo-canvas"></canvas>
-      <p id="connect-overlay-msg">Reconnecting to server…</p>
+      <p id="connect-overlay-msg">Connecting…</p>
     </div>
     <div id="sticky-notes-container" class="hidden"></div>
     <div id="debate-info-float" class="hidden"></div>

--- a/lib/public/modules/app-connection.js
+++ b/lib/public/modules/app-connection.js
@@ -17,6 +17,7 @@ var reconnectTimer = null;
 var reconnectDelay = 1000;
 var connectTimeoutId = null;
 var connectOverlay = null;
+var hasConnectedOnce = false;
 
 export function initConnection() {
   connectOverlay = document.getElementById("connect-overlay");
@@ -39,6 +40,7 @@ export function initConnection() {
     if (state.connected !== prev.connected) {
       var sendBtn = getSendBtn();
       if (state.connected) {
+        hasConnectedOnce = true;
         if (sendBtn) sendBtn.disabled = false;
         if (connectOverlay) connectOverlay.classList.add("hidden");
         var updPill = document.getElementById("update-pill-wrap");
@@ -46,6 +48,10 @@ export function initConnection() {
         stopLogoAnimation();
       } else {
         if (sendBtn) sendBtn.disabled = true;
+        if (hasConnectedOnce && connectOverlay) {
+          var overlayMessage = document.getElementById("connect-overlay-msg");
+          if (overlayMessage) overlayMessage.textContent = "Reconnecting to server…";
+        }
         if (connectOverlay) connectOverlay.classList.remove("hidden");
         startLogoAnimation();
       }

--- a/test/connect-overlay-ui.test.js
+++ b/test/connect-overlay-ui.test.js
@@ -1,0 +1,27 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+
+function source(file) {
+  return fs.readFileSync(path.join(__dirname, "../", file), "utf8");
+}
+
+test("connection overlay starts with connecting wording", function() {
+  var html = source("lib/public/index.html");
+  assert.match(html, /id="connect-overlay-msg">Connecting…</);
+  assert.doesNotMatch(html, /id="connect-overlay-msg">Reconnecting/);
+});
+
+test("reconnect wording is only set after a prior connection", function() {
+  var connection = source("lib/public/modules/app-connection.js");
+  assert.match(connection, /var hasConnectedOnce = false/);
+  assert.match(connection, /if \(hasConnectedOnce && connectOverlay\)[\s\S]*Reconnecting to server…/);
+});
+
+test("pane overlays use a quiet themed loading state", function() {
+  var css = source("lib/public/css/pane.css");
+  assert.match(css, /body\.pane-mode #connect-overlay \{ background: var\(--bg\); \}/);
+  assert.match(css, /body\.pane-mode #connect-overlay #ascii-logo-canvas \{ display: none; \}/);
+  assert.match(css, /body\.pane-mode #connect-overlay-msg \{ color: var\(--text-dimmer\); \}/);
+});


### PR DESCRIPTION
## Problem

The connection overlay (`#connect-overlay`) is visible by default with hardcoded "Reconnecting to server…" and `position: fixed; inset: 0; background: #000`. Every fresh load therefore claims to be *re*connecting, and since each split pane is a full app instance in an iframe, opening a split flashed full-black "Reconnecting to server…" takeovers in every pane until their sockets connected (screenshot report, 2026-08-27).

## Fix

- Initial markup says "Connecting…". A `hasConnectedOnce` flag in `app-connection.js` switches the text to "Reconnecting to server…" only when a previously-established connection drops.
- Pane mode (`body.pane-mode`): the overlay uses `var(--bg)` instead of black, hides the ASCII logo canvas, and renders only the dim status text — a brief quiet flash instead of a black takeover.
- The main window's boot branding (black + ASCII logo) is unchanged.

## Testing

Source-level regression tests (`test/connect-overlay-ui.test.js`) for the initial wording, the flag-guarded reconnect text, and the pane-mode overrides. Full suite green on Node 22: 319/319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)