### PR TITLE
fix(kiro): widen ACP initialize timeout to 90s

### DIFF
--- a/lib/yoke/adapters/kiro.js
+++ b/lib/yoke/adapters/kiro.js
@@ -991,6 +991,9 @@ function createKiroAdapter(opts) {
           return _fetchKasToken(_binaryPath, _cwd);
         });
         await _acp.start();
+        // kiro-cli boots the KAS server, MCP subsystem and SQLite before it
+        // answers initialize, which measures ~20s cold. 30s left no margin and
+        // timed out under load, so allow a wide window here.
         await _acp.send("initialize", {
           protocolVersion: 1,
           clientInfo: { name: "clay", version: "1.0.0" },
@@ -1000,7 +1003,7 @@ function createKiroAdapter(opts) {
           // calls, so implementing them later means bypassing canUseTool and
           // needs explicit cwd confinement first.
           clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
-        }, 30000);
+        }, 90000);
         _initialized = true;
 
         if (_shuttingDown) throw createShutdownError();


### PR DESCRIPTION
## Problem

Kiro model loading failed with:

```
[kiro-acp-server] stdout closed
[kiro-acp-server] Process exited: code=null signal=SIGTERM
[project-models] kiro init failed: Request timeout: initialize (id=1)
```

The SIGTERM is a consequence, not the cause: the failure path in `createKiroAdapter` calls `stopAcp()` after the handshake rejects. The four identical log lines are four `get_vendor_models` callers sharing one rejected `_initPromise`, so only one handshake actually ran.

## Cause

`kiro-cli acp` boots the KAS server, MCP subsystem and SQLite before it answers `initialize`. Measured locally (kiro-cli 2.19.0):

| step | duration |
|---|---|
| `kiro-cli chat --list-models --format json` | 12.8s |
| `kiro-cli chat _ get-kas-token` | 7.4s |
| `kiro-cli acp` spawn to `initialize` response | ~20s |

A 20s cold handshake against a 30s timeout leaves no margin. The catalog fetch runs sequentially just before the spawn, and kiro requests `_kiro/auth/getAccessToken` mid-boot (which re-runs kiro-cli for ~7s), so under load the 30s window is exceeded.

## Change

Raise the `initialize` timeout from 30s to 90s and record why.

## Testing

`node --test test/kiro-adapter-init.test.js test/kiro-acp-routing.test.js test/kiro-adapter-query.test.js` - 21 passing.

## Follow-up (not in this PR)

Running the model catalog fetch in parallel with the handshake would cut ~13s off first load, but it moves that work *into* the initialize window, so it depends on this timeout increase landing first. Caching the KAS token would remove the ~7s mid-boot CLI re-run.