### PR TITLE
fix(yoke): share one 90s initialize timeout across vendors

### DIFF
--- a/docs/guides/MODULE_MAP.md
+++ b/docs/guides/MODULE_MAP.md
@@ -80,7 +80,7 @@ YOKE is the vendor-agnostic interface layer. Each adapter implements the same co
 | Module | Concern |
 |--------|---------|
 | `yoke/index.js` | Adapter factory, wraps createQuery with project instructions |
-| `yoke/interface.js` | YOKE interface contract definition |
+| `yoke/interface.js` | YOKE interface contract definition, plus vendor-neutral shared constants (`INITIALIZE_TIMEOUT_MS`) |
 | `yoke/adapters/claude.js` | Claude adapter using `@anthropic-ai/claude-agent-sdk`. In-process + worker (OS user isolation) paths |
 | `yoke/adapters/codex.js` | Codex adapter using `codex app-server` JSON-RPC protocol. Handles approval events, skill injection, MCP bridge config |
 | `yoke/codex-app-server.js` | Codex `app-server` child process manager. JSON-RPC 2.0 over stdin/stdout, request ID tracking, event routing |

--- a/lib/yoke/adapters/acp.js
+++ b/lib/yoke/adapters/acp.js
@@ -3,6 +3,7 @@
 // Implements the YOKE Adapter contract once for standard ACP agents.
 
 var AcpProcessManager = require("../acp-process-manager").AcpProcessManager;
+var INITIALIZE_TIMEOUT_MS = require("../interface").INITIALIZE_TIMEOUT_MS;
 var createAcpQueryHandle = require("../acp-query-handle").createAcpQueryHandle;
 var profiles = require("../acp-agent-profiles");
 var driverRuntime = require("../acp-driver-runtime");
@@ -178,7 +179,7 @@ function createAcpAdapter(vendor, opts) {
               session: { configOptions: { boolean: {} } },
             },
           });
-          initResult = await acp.send("initialize", initializeParams, 30000);
+          initResult = await acp.send("initialize", initializeParams, INITIALIZE_TIMEOUT_MS);
           await driverRuntime.callAsync(driver, "onInitialize", context({ acp: acp, initResult: initResult }), function() {});
           if (shuttingDown) throw new Error(driver.displayName + " adapter is shutting down");
         } catch (e) {

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -6,6 +6,7 @@
 var path = require("path");
 var fs = require("fs");
 var { CodexAppServer } = require("../codex-app-server");
+var INITIALIZE_TIMEOUT_MS = require("../interface").INITIALIZE_TIMEOUT_MS;
 var skillDiscovery = require("../skill-discovery");
 var { resolveOsUserInfo } = require("../../os-users");
 var backgroundTasks = require("../codex-background-tasks");
@@ -1577,7 +1578,7 @@ function createCodexAdapter(opts) {
         await _appServer.send("initialize", {
           clientInfo: { name: "clay", title: "Clay", version: "1.0.0" },
           capabilities: { experimentalApi: true },
-        });
+        }, INITIALIZE_TIMEOUT_MS);
         _appServer.notify("initialized", {});
 
         if (_shuttingDown) {

--- a/lib/yoke/adapters/kiro.js
+++ b/lib/yoke/adapters/kiro.js
@@ -14,6 +14,7 @@
 
 var { execFile } = require("child_process");
 var { KiroAcpServer, findKiroPath } = require("../kiro-acp-server");
+var INITIALIZE_TIMEOUT_MS = require("../interface").INITIALIZE_TIMEOUT_MS;
 var skillDiscovery = require("../skill-discovery");
 var { KIRO_DEFAULTS } = require("../../kiro-defaults");
 
@@ -991,9 +992,6 @@ function createKiroAdapter(opts) {
           return _fetchKasToken(_binaryPath, _cwd);
         });
         await _acp.start();
-        // kiro-cli boots the KAS server, MCP subsystem and SQLite before it
-        // answers initialize, which measures ~20s cold. 30s left no margin and
-        // timed out under load, so allow a wide window here.
         await _acp.send("initialize", {
           protocolVersion: 1,
           clientInfo: { name: "clay", version: "1.0.0" },
@@ -1003,7 +1001,7 @@ function createKiroAdapter(opts) {
           // calls, so implementing them later means bypassing canUseTool and
           // needs explicit cwd confinement first.
           clientCapabilities: { fs: { readTextFile: false, writeTextFile: false } },
-        }, 90000);
+        }, INITIALIZE_TIMEOUT_MS);
         _initialized = true;
 
         if (_shuttingDown) throw createShutdownError();

--- a/lib/yoke/interface.js
+++ b/lib/yoke/interface.js
@@ -11,6 +11,14 @@
 var TOOL_POLICIES = ["ask", "allow-all"];
 var BACKGROUND_TASK_TYPES = ["shell", "agent", "monitor", "other"];
 
+// Shared budget for the initialize handshake every vendor process manager
+// performs. Agents do their cold start before answering it: kiro-cli boots the
+// KAS server, MCP subsystem and SQLite first, which measures ~20s, and Codex
+// launches its configured MCP servers. The cost is asymmetric, since too short
+// a window makes a working agent unusable while too long a one only delays the
+// error for an agent that is already broken, so keep it generous.
+var INITIALIZE_TIMEOUT_MS = 90000;
+
 /*
  * Optional adapter event contract:
  *   { yokeType: "background_tasks_changed", tasks: [{ task_id, task_type, description }] }
@@ -104,6 +112,7 @@ function validateQueryHandle(handle) {
 
 module.exports = {
   TOOL_POLICIES: TOOL_POLICIES,
+  INITIALIZE_TIMEOUT_MS: INITIALIZE_TIMEOUT_MS,
   BACKGROUND_TASK_TYPES: BACKGROUND_TASK_TYPES,
   ADAPTER_METHODS: ADAPTER_METHODS,
   QUERY_HANDLE_METHODS: QUERY_HANDLE_METHODS,


### PR DESCRIPTION
Follow-up to #446, which raised Kiro's initialize timeout to 90s but left the same 30s value in place for every other vendor.

## Scope

Grouping the 11 adapters by exposure to this handshake:

| Group | Vendors | Before |
|---|---|---|
| Profile-driven ACP, one shared call site (`acp.js:181`) | copilot, grok, junie, kimi, opencode, qwen | 30s hardcoded |
| Codex app-server (`codex.js:1577`, no explicit timeout) | codex | 30s via `CodexAppServer.send` default |
| Dedicated ACP adapter | kiro | 90s (#446) |
| No handshake | claude, claude-worker, antigravity | n/a |

`claude` / `claude-worker` are SDK-based. `antigravity` (`antigravity.js:355`) spawns per query with no resident process, so its `init` only fetches models.

## Change

Add `INITIALIZE_TIMEOUT_MS = 90000` to `yoke/interface.js`, which already holds the vendor-neutral shared constants (`TOOL_POLICIES`, `BACKGROUND_TASK_TYPES`) and carries no runtime logic. `acp.js`, `kiro.js` and `codex.js` now read it instead of three separate literals.

Rationale for 90s: agents do their cold start before answering initialize. Measured for kiro-cli 2.19.0, spawn to `initialize` response is ~20s (KAS server + MCP subsystem + SQLite). Codex launches its configured MCP servers in the same window. The cost is asymmetric, since too short a window makes a working agent unusable while too long a one only delays the error for an agent that is already broken.

## Honest limitation

The six profile-driven vendor binaries are not installed on the machine this was developed on, so their real boot times were not measured. This PR is not claiming a reproduced failure for them; it removes a confirmed structural inconsistency (one hardcoded literal per adapter, already drifted 30s vs 90s) and applies the timeout that Kiro empirically needed.

## Testing

`node --test` over the 15 yoke/vendor/acp/codex/kiro test files - 99 passing.