### PR TITLE
feat(session): add handoff source history tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,10 @@
 - Server-side: CommonJS (`require`). Client-side: ES modules (`import`).
 - Never commit, create PRs, merge, or comment on issues automatically. Only do these when explicitly asked.
 - All user-facing messages, code comments, and commit messages must be in English only.
-- Commit messages must follow Angular Commit Convention (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `perf:`, `test:`, `style:`, `ci:`, `build:`). Use `!` or `BREAKING CHANGE:` footer for breaking changes. Always use the `angular-commit` skill when committing.
+- Every commit must strictly follow the Angular Commit Convention. This requirement is mandatory with no exceptions, including small fixes, generated changes, and follow-up commits.
+- When the user explicitly requests a commit, always invoke and follow the `angular-commit` skill before staging or committing. Never run `git commit` without using that skill.
+- Commit subjects must use either `<type>: <summary>` or `<type>(<scope>): <summary>`, where `type` is one of `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `style`, `ci`, or `build`. Do not use vague or non-conforming subjects such as `update`, `changes`, `fix stuff`, or bare prose.
+- Breaking changes must use `!` after the type or scope, or include a `BREAKING CHANGE:` footer. Commit messages must remain in English and must never include `Co-Authored-By` lines.
 - Never use browser-native `alert()`, `confirm()`, or `prompt()`. Always use custom JS dialogs/modals instead.
 - When rebuilding daemon config (e.g. `restartDaemonFromConfig()`), always use `Object.assign({}, lastConfig, overrides)` to preserve all existing settings. Never reconstruct config by manually listing fields.
 - Before adding new code, read [docs/guides/MODULE_MAP.md](docs/guides/MODULE_MAP.md) to find the right file. Never add inline logic to `project.js` handleMessage. Keep modules under 500 lines.

--- a/docs/guides/MODULE_MAP.md
+++ b/docs/guides/MODULE_MAP.md
@@ -53,6 +53,7 @@ Wires all modules, sets up session manager and SDK bridge, dispatches messages.
 | `project-models.js` | Vendor model discovery, loading/error responses, model matching, and selection acknowledgements |
 | `project-worker-proposal.js` | Fable-triggered inline Worker suggestions, approval routing, and execution handoff |
 | `session-spawn-mcp-server.js` | SDK-free `clay-sessions` MCP tool definitions for spawning and checking sessions |
+| `session-handoff-mcp-server.js` | SDK-free `clay-handoff` MCP tool definition for reading a session's handoff source chain |
 | `project-session-document.js` + `session-document-mcp-server.js` | Session-bound `clay-documents` MCP signal that snapshots and presents explicit Markdown editing work |
 | `sdk-bridge.js` | SDK bridge coordinator: createSDKBridge factory, worker lifecycle, query stream, tool permissions, mention sessions |
 | `sdk-skill-discovery.js` | Skill directory scanning, shell segment splitting, SDK/filesystem skill merging |

--- a/lib/project-session-handoff.js
+++ b/lib/project-session-handoff.js
@@ -1,5 +1,19 @@
 var yoke = require("./yoke");
 var contextBuilder = require("./session-handoff-context");
+var sessionHandoffMcp = require("./session-handoff-mcp-server");
+
+var MAX_HANDOFF_CHAIN_DEPTH = 5;
+
+function toolResult(text) {
+  return Promise.resolve({ content: [{ type: "text", text: text }] });
+}
+
+function toolError(message) {
+  return Promise.resolve({
+    content: [{ type: "text", text: "Error: " + message }],
+    isError: true,
+  });
+}
 
 function hasUserContext(session) {
   var history = (session && session.history) || [];
@@ -38,7 +52,7 @@ function attachSessionHandoff(ctx) {
     }
     var ownerId = ws._clayUser && ctx.usersModule.isMultiUser() ? ws._clayUser.id : null;
     if ((source.ownerId || null) !== ownerId) throw new Error("Session access denied.");
-    return linuxUser;
+    return { linuxUser: linuxUser, vendorInfo: vendorInfo };
   }
 
   function quietRecord(session, entry) {
@@ -50,9 +64,9 @@ function attachSessionHandoff(ctx) {
     var source = sm.sessions.get(ws._clayActiveSession) || null;
     var targetVendor = typeof msg.targetVendor === "string" ? msg.targetVendor.trim() : "";
     var targetModel = typeof msg.model === "string" ? msg.model.trim() : "";
-    var linuxUser;
+    var validation;
     try {
-      linuxUser = validate(ws, source, targetVendor);
+      validation = validate(ws, source, targetVendor);
     } catch (err) {
       sendResult(ws, false, { error: err.message || String(err) });
       return;
@@ -102,6 +116,7 @@ function attachSessionHandoff(ctx) {
       cwd: ctx.cwd,
       source: source,
       targetVendor: targetVendor,
+      sourceReadTool: (validation.vendorInfo || {}).sessionBoundTools !== false,
     });
     target.isProcessing = true;
     target.lastActivity = Date.now();
@@ -128,7 +143,7 @@ function attachSessionHandoff(ctx) {
     target._queryStartTs = Date.now();
     var startPromise;
     try {
-      startPromise = sdk.startQuery(target, prompt, undefined, linuxUser);
+      startPromise = sdk.startQuery(target, prompt, undefined, validation.linuxUser);
     } catch (err) {
       failStart(err);
       return;
@@ -153,7 +168,111 @@ function attachSessionHandoff(ctx) {
     return false;
   }
 
-  return { handleMessage: handleMessage };
+  function resolveSourceChain(boundSession) {
+    var chain = [];
+    var visited = new Set();
+    var sourceSessionId = boundSession.handoff.sourceSessionId;
+    var ownerId = boundSession.ownerId || null;
+    for (var depth = 0; depth < MAX_HANDOFF_CHAIN_DEPTH; depth++) {
+      var visitKey = String(sourceSessionId);
+      if (visited.has(visitKey)) break;
+      visited.add(visitKey);
+      var source = sm.sessions.get(sourceSessionId);
+      if (!source) return { error: "Source session was not found: " + sourceSessionId };
+      if ((source.ownerId || null) !== ownerId) return { error: "Source session owner does not match this session" };
+      chain.push(source);
+      if (!source.handoff || source.handoff.sourceSessionId === undefined || source.handoff.sourceSessionId === null) break;
+      sourceSessionId = source.handoff.sourceSessionId;
+    }
+    return { chain: chain };
+  }
+
+  function findSource(chain, requestedId) {
+    if (requestedId === undefined || requestedId === null || requestedId === "") return chain[0] || null;
+    for (var i = 0; i < chain.length; i++) {
+      if (String(chain[i].localId) === String(requestedId)) return chain[i];
+    }
+    return null;
+  }
+
+  function boundedInteger(value, fallback, min, max) {
+    if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+    return Math.min(max, Math.max(min, Math.floor(value)));
+  }
+
+  function formatHistory(source, args) {
+    var history = Array.isArray(source.history) ? source.history : [];
+    var limit = boundedInteger(args.limit, 30, 1, 100);
+    var offset = typeof args.offset === "number" && Number.isFinite(args.offset)
+      ? boundedInteger(args.offset, 0, 0, history.length)
+      : Math.max(0, history.length - limit);
+    var slice = history.slice(offset, offset + limit);
+    var end = offset + slice.length;
+    var out = [];
+    out.push("# " + (source.title || "Untitled session") + " — " + (source.vendor || "unknown") + "/" + source.localId);
+    out.push("Showing entries " + (slice.length ? offset + 1 : 0) + "-" + end + " of " + history.length + "\n");
+    for (var i = 0; i < slice.length; i++) {
+      var entry = slice[i];
+      if (!entry) continue;
+      var label;
+      var text = "";
+      if (entry.type === "user_message") {
+        label = "USER";
+        text = entry.text || "";
+      } else if (entry.type === "delta") {
+        label = "ASSISTANT";
+        text = entry.text || "";
+      } else if (entry.type === "tool_executing" || entry.type === "tool_result") {
+        label = "TOOL";
+        text = (entry.name || "") + (entry.input ? " " + JSON.stringify(entry.input).substring(0, 120) : "");
+      } else {
+        continue;
+      }
+      if (text.length > 800) text = text.substring(0, 800) + "...";
+      out.push("[" + label + "] " + text);
+    }
+    return out.join("\n");
+  }
+
+  function readHandoffSource(args, boundSession) {
+    if (!boundSession) return toolError("read_handoff_source requires a session-bound tool server");
+    if (!boundSession.handoff) return toolError("this session does not have a handoff source");
+    var resolved = resolveSourceChain(boundSession);
+    if (resolved.error) return toolError(resolved.error);
+    var source = findSource(resolved.chain, args.sourceSessionId);
+    if (!source) return toolError("sourceSessionId is not in this session's handoff chain");
+    return toolResult(formatHistory(source, args));
+  }
+
+  function getToolDefs(boundSession) {
+    if (ctx.isMate) return [];
+    if (boundSession && !boundSession.handoff) return [];
+    return sessionHandoffMcp.getToolDefs({
+      read: function (args) { return readHandoffSource(args, boundSession || null); },
+    });
+  }
+
+  function createMcpServer(adapter, boundSession) {
+    if (ctx.isMate || !adapter || typeof adapter.createToolServer !== "function") return null;
+    var tools = getToolDefs(boundSession || null);
+    if (tools.length === 0) return null;
+    return adapter.createToolServer({
+      name: "clay-handoff",
+      version: "1.0.0",
+      tools: tools,
+    });
+  }
+
+  function getSystemPrompt() {
+    return "";
+  }
+
+  return {
+    createMcpServer: createMcpServer,
+    getSystemPrompt: getSystemPrompt,
+    getToolDefs: getToolDefs,
+    handleMessage: handleMessage,
+  };
 }
 
 module.exports = {

--- a/lib/project.js
+++ b/lib/project.js
@@ -620,6 +620,16 @@ function createProjectContext(opts) {
       }
     }
 
+    // Session-bound access to the source of a handoff (main projects only).
+    if (!isMate) {
+      try {
+        var sessionHandoffMcpConfig = _sessionHandoff.createMcpServer(adapter);
+        if (sessionHandoffMcpConfig) servers[sessionHandoffMcpConfig.name || "clay-handoff"] = sessionHandoffMcpConfig;
+      } catch (e) {
+        console.error("[project] Failed to create session handoff MCP server:", e.message);
+      }
+    }
+
     // Explicit agent signal for user-requested Markdown presentation.
     if (!isMate) {
       try {
@@ -780,7 +790,7 @@ function createProjectContext(opts) {
   //   clay-email   -> only when the user has an account or server SMTP
   //
   // forSession (optional): the session whose query these servers are mounted
-  // into. Session, notes, and document tools must know their caller, so they
+  // into. Session, notes, handoff, and document tools must know their caller, so they
   // are re-instantiated bound to that session; static instances only serve
   // descriptor listing and fail closed on calls.
   function getLocalMcpServers(forSession) {
@@ -809,6 +819,15 @@ function createProjectContext(opts) {
           if (boundNotes) { filtered[name] = boundNotes; hasAny = true; }
         } catch (e) {
           console.error("[project] Failed to bind session notes MCP server:", e.message);
+        }
+        continue;
+      }
+      if (name === "clay-handoff" && forSession) {
+        try {
+          var boundHandoff = _sessionHandoff.createMcpServer(adapter, forSession);
+          if (boundHandoff) { filtered[name] = boundHandoff; hasAny = true; }
+        } catch (e) {
+          console.error("[project] Failed to bind session handoff MCP server:", e.message);
         }
         continue;
       }
@@ -879,12 +898,14 @@ function createProjectContext(opts) {
       return composeSystemPrompts([
         _sessionPair.getSystemPrompt(session),
         _sessionNotes.getSystemPrompt(session),
+        _sessionHandoff.getSystemPrompt(session),
         _sessionDocument.getSystemPrompt(session),
       ]);
     },
     getSessionToolDefs: function (session) {
       return _sessionPair.getToolDefs(session)
         .concat(_sessionNotes.getToolDefs(session))
+        .concat(_sessionHandoff.getToolDefs(session))
         .concat(_sessionDocument.getToolDefs(session));
     },
   });
@@ -1489,6 +1510,15 @@ function createProjectContext(opts) {
               inputSchema: normalizeToolSchema(noteTools[nti].inputSchema),
             });
           }
+          var handoffTools = _sessionHandoff.getToolDefs(boundSession);
+          for (var hti = 0; hti < handoffTools.length; hti++) {
+            tools.push({
+              server: "clay-handoff",
+              name: handoffTools[hti].name,
+              description: handoffTools[hti].description || handoffTools[hti].name,
+              inputSchema: normalizeToolSchema(handoffTools[hti].inputSchema),
+            });
+          }
           var documentTools = _sessionDocument.getToolDefs(boundSession);
           for (var dti = 0; dti < documentTools.length; dti++) {
             tools.push({
@@ -1509,7 +1539,7 @@ function createProjectContext(opts) {
         if (localMcp) {
           var inAppNames = Object.keys(localMcp);
           for (var i = 0; i < inAppNames.length; i++) {
-            if (inAppNames[i] === "clay-sessions" || inAppNames[i] === "clay-notes" || inAppNames[i] === "clay-documents") continue;
+            if (inAppNames[i] === "clay-sessions" || inAppNames[i] === "clay-notes" || inAppNames[i] === "clay-handoff" || inAppNames[i] === "clay-documents") continue;
             extractServerTools(inAppNames[i], localMcp[inAppNames[i]]);
           }
         }
@@ -1544,6 +1574,14 @@ function createProjectContext(opts) {
             }
           }
         }
+        if (boundSession && serverName === "clay-handoff") {
+          var handoffTools = _sessionHandoff.getToolDefs(boundSession);
+          for (var hti = 0; hti < handoffTools.length; hti++) {
+            if (handoffTools[hti].name === toolName && typeof handoffTools[hti].handler === "function") {
+              return Promise.resolve(handoffTools[hti].handler(args || {}));
+            }
+          }
+        }
         if (boundSession && serverName === "clay-documents") {
           var documentTools = _sessionDocument.getToolDefs(boundSession);
           for (var dti = 0; dti < documentTools.length; dti++) {
@@ -1552,7 +1590,7 @@ function createProjectContext(opts) {
             }
           }
         }
-        if (serverName === "clay-sessions" || serverName === "clay-notes" || serverName === "clay-documents") {
+        if (serverName === "clay-sessions" || serverName === "clay-notes" || serverName === "clay-handoff" || serverName === "clay-documents") {
           return Promise.reject(new Error("Session-bound tool requires a valid Clay session: " + serverName + "/" + toolName));
         }
         if (sessionOnly) return Promise.reject(new Error("Session tool not found: " + serverName + "/" + toolName));

--- a/lib/session-handoff-context.js
+++ b/lib/session-handoff-context.js
@@ -97,6 +97,9 @@ function buildHandoffContext(options) {
   if (latestUser) parts.push("Current user request, verbatim:\n" + latestUser);
   parts.push("Repository state at handoff:\n" + repositoryState(options.cwd));
   parts.push("Recent conversation:\n" + transcriptText(turns));
+  if (options.sourceReadTool) {
+    parts.push("The snapshot above is partial. The read_handoff_source tool from the clay-handoff MCP server can read the full original session, including summarized tool calls and older turns. Call it when the snapshot leaves a question open.");
+  }
   parts.push("Continue from the unresolved work above. Preserve the user's decisions and constraints, inspect the actual files before making assumptions, and proceed without asking the user to repeat context.");
   return trimText(parts.join("\n\n"), MAX_CONTEXT_CHARS);
 }

--- a/lib/session-handoff-mcp-server.js
+++ b/lib/session-handoff-mcp-server.js
@@ -1,0 +1,36 @@
+// Session-bound access to the source of a Clay session handoff.
+
+var buildShape = require("./session-spawn-mcp-server").buildShape;
+
+var TOOL_DESCRIPTION =
+  "This session was continued from another agent's session via a context snapshot. " +
+  "That snapshot omitted tool calls and older turns. Read the original Clay session record directly, including user messages, assistant text, and summarized tool calls, regardless of which vendor produced it.";
+
+function getToolDefs(handlers) {
+  return [
+    {
+      name: "read_handoff_source",
+      description: TOOL_DESCRIPTION,
+      inputSchema: buildShape({
+        offset: {
+          type: "number",
+          description: "Skip the first N history entries. Omit to return the last limit entries.",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum history entries to return. Defaults to 30 and is capped at 100.",
+        },
+        sourceSessionId: {
+          type: "string",
+          description: "Source session in this session's handoff chain. Omit to read the immediate source.",
+        },
+      }),
+      handler: function (args) { return handlers.read(args || {}); },
+    },
+  ];
+}
+
+module.exports = {
+  TOOL_DESCRIPTION: TOOL_DESCRIPTION,
+  getToolDefs: getToolDefs,
+};

--- a/lib/yoke/vendor-registry.js
+++ b/lib/yoke/vendor-registry.js
@@ -7,6 +7,7 @@
 // codex "xhigh").
 var EFFORT_ORDER = ["minimal", "low", "medium", "high", "xhigh", "max"];
 
+// sessionBoundTools gates whether per-session MCP tool mounting reaches a vendor's process.
 var VENDOR_REGISTRY = {
   claude: {
     displayName: "Claude Code",
@@ -16,6 +17,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui", "tui"],
     effortLevels: ["low", "medium", "high", "xhigh", "max"],
     osUserIsolation: true,
+    sessionBoundTools: true,
     usageDashboard: {
       icon: "/claude-code-avatar.png",
       alt: "Claude Code",
@@ -32,6 +34,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: ["minimal", "low", "medium", "high", "xhigh"],
     osUserIsolation: true,
+    sessionBoundTools: false,
     usageDashboard: {
       icon: "/codex-avatar.png",
       alt: "Codex",
@@ -48,6 +51,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: ["low", "medium", "high"],
     osUserIsolation: false,
+    sessionBoundTools: false,
     usageDashboard: null,
     rateLimitTracking: false,
   },
@@ -59,6 +63,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: [],
     osUserIsolation: false,
+    sessionBoundTools: true,
     usageDashboard: null,
     rateLimitTracking: false,
   },
@@ -70,6 +75,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: [],
     osUserIsolation: false,
+    sessionBoundTools: true,
     usageDashboard: null,
     rateLimitTracking: false,
   },
@@ -81,6 +87,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: [],
     osUserIsolation: false,
+    sessionBoundTools: true,
     usageDashboard: null,
     rateLimitTracking: false,
   },
@@ -92,6 +99,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: [],
     osUserIsolation: false,
+    sessionBoundTools: true,
     usageDashboard: null,
     rateLimitTracking: false,
   },
@@ -103,6 +111,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: [],
     osUserIsolation: false,
+    sessionBoundTools: true,
     usageDashboard: null,
     rateLimitTracking: false,
   },
@@ -114,6 +123,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: [],
     osUserIsolation: false,
+    sessionBoundTools: true,
     usageDashboard: null,
     rateLimitTracking: false,
   },
@@ -125,6 +135,7 @@ var VENDOR_REGISTRY = {
     sessionModes: ["gui"],
     effortLevels: [],
     osUserIsolation: false,
+    sessionBoundTools: true,
     usageDashboard: null,
     rateLimitTracking: false,
   },

--- a/test/session-handoff-tools.test.js
+++ b/test/session-handoff-tools.test.js
@@ -1,0 +1,173 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+var handoffModule = require("../lib/project-session-handoff");
+var contextBuilder = require("../lib/session-handoff-context");
+var vendorRegistry = require("../lib/yoke/vendor-registry").VENDOR_REGISTRY;
+
+function attachWithSessions(sessions) {
+  return handoffModule.attachSessionHandoff({
+    cwd: process.cwd(),
+    sm: { sessions: sessions },
+    isMate: false,
+  });
+}
+
+function textOf(result) {
+  return result.content[0].text;
+}
+
+test("handoff tool definitions fail closed without a bound session and hide on ordinary sessions", async function () {
+  var attached = attachWithSessions(new Map());
+  var staticDefs = attached.getToolDefs(null);
+  assert.strictEqual(staticDefs.length, 1);
+  assert.strictEqual(staticDefs[0].name, "read_handoff_source");
+  var result = await staticDefs[0].handler({});
+  assert.strictEqual(result.isError, true);
+  assert.match(textOf(result), /requires a session-bound tool server/);
+  assert.deepStrictEqual(attached.getToolDefs({ localId: 9, history: [] }), []);
+});
+
+test("handoff MCP server is not created for a session without handoff metadata", function () {
+  var attached = attachWithSessions(new Map());
+  var calls = [];
+  var adapter = {
+    createToolServer: function (config) {
+      calls.push(config);
+      return config;
+    },
+  };
+  var result = attached.createMcpServer(adapter, { localId: 9, history: [] });
+  assert.strictEqual(result, null);
+  assert.strictEqual(calls.length, 0);
+});
+
+test("handoff tool formats source history and caps entry text", async function () {
+  var longText = "x".repeat(900);
+  var source = {
+    localId: 1,
+    ownerId: null,
+    vendor: "claude",
+    title: "Source work",
+    history: [
+      { type: "user_message", text: "Please inspect this." },
+      { type: "delta", text: longText },
+      { type: "tool_executing", name: "Read", input: { file_path: "/tmp/example.js" } },
+      { type: "tool_result", name: "Read", input: { file_path: "/tmp/example.js" } },
+      { type: "usage", inputTokens: 10 },
+    ],
+  };
+  var target = { localId: 2, ownerId: null, handoff: { sourceSessionId: 1 } };
+  var attached = attachWithSessions(new Map([[1, source], [2, target]]));
+  var result = await attached.getToolDefs(target)[0].handler({ offset: 0, limit: 10 });
+  var text = textOf(result);
+  assert.match(text, /# Source work — claude\/1/);
+  assert.match(text, /Showing entries 1-5 of 5/);
+  assert.match(text, /\[USER\] Please inspect this\./);
+  assert.match(text, /\[ASSISTANT\] x{800}\.\.\./);
+  assert.match(text, /\[TOOL\] Read \{"file_path":"\/tmp\/example\.js"\}/);
+  assert.doesNotMatch(text, /inputTokens/);
+});
+
+test("handoff tool defaults to the tail and supports explicit pagination", async function () {
+  var history = [];
+  for (var i = 0; i < 35; i++) history.push({ type: "user_message", text: "entry-" + i });
+  var source = { localId: 1, ownerId: null, vendor: "kiro", title: "Paged", history: history };
+  var target = { localId: 2, ownerId: null, handoff: { sourceSessionId: 1 } };
+  var attached = attachWithSessions(new Map([[1, source], [2, target]]));
+  var tool = attached.getToolDefs(target)[0];
+
+  var tail = textOf(await tool.handler({}));
+  assert.match(tail, /Showing entries 6-35 of 35/);
+  assert.doesNotMatch(tail, /\[USER\] entry-4\n/);
+  assert.match(tail, /\[USER\] entry-5/);
+  assert.match(tail, /\[USER\] entry-34/);
+
+  var page = textOf(await tool.handler({ offset: 10, limit: 3 }));
+  assert.match(page, /Showing entries 11-13 of 35/);
+  assert.match(page, /entry-10/);
+  assert.match(page, /entry-12/);
+  assert.doesNotMatch(page, /entry-13/);
+});
+
+test("handoff tool rejects a source owned by another user without leaking content", async function () {
+  var source = { localId: 1, ownerId: "other", history: [{ type: "user_message", text: "PRIVATE" }] };
+  var target = { localId: 2, ownerId: "owner", handoff: { sourceSessionId: 1 } };
+  var attached = attachWithSessions(new Map([[1, source], [2, target]]));
+  var result = await attached.getToolDefs(target)[0].handler({});
+  assert.strictEqual(result.isError, true);
+  assert.match(textOf(result), /owner does not match/);
+  assert.doesNotMatch(textOf(result), /PRIVATE/);
+});
+
+test("handoff tool reads a valid grandparent and rejects sessions outside the chain", async function () {
+  var grandparent = {
+    localId: 1,
+    ownerId: "owner",
+    vendor: "claude",
+    history: [{ type: "user_message", text: "grandparent context" }],
+  };
+  var parent = { localId: 2, ownerId: "owner", handoff: { sourceSessionId: 1 }, history: [] };
+  var target = { localId: 3, ownerId: "owner", handoff: { sourceSessionId: 2 } };
+  var unrelated = { localId: 4, ownerId: "owner", history: [{ type: "user_message", text: "unrelated secret" }] };
+  var attached = attachWithSessions(new Map([[1, grandparent], [2, parent], [3, target], [4, unrelated]]));
+  var tool = attached.getToolDefs(target)[0];
+
+  var result = await tool.handler({ sourceSessionId: "1" });
+  assert.strictEqual(result.isError, undefined);
+  assert.match(textOf(result), /grandparent context/);
+
+  var rejected = await tool.handler({ sourceSessionId: "4" });
+  assert.strictEqual(rejected.isError, true);
+  assert.match(textOf(rejected), /not in this session's handoff chain/);
+  assert.doesNotMatch(textOf(rejected), /unrelated secret/);
+});
+
+test("handoff chain cycle is bounded and does not prevent reading a valid source", async function () {
+  var first = { localId: 1, ownerId: null, handoff: { sourceSessionId: 2 }, history: [] };
+  var second = {
+    localId: 2,
+    ownerId: null,
+    handoff: { sourceSessionId: 1 },
+    history: [{ type: "user_message", text: "cycle source" }],
+  };
+  var target = { localId: 3, ownerId: null, handoff: { sourceSessionId: 2 } };
+  var attached = attachWithSessions(new Map([[1, first], [2, second], [3, target]]));
+  var result = await attached.getToolDefs(target)[0].handler({});
+  assert.strictEqual(result.isError, undefined);
+  assert.match(textOf(result), /cycle source/);
+});
+
+test("handoff tool reports a missing source session", async function () {
+  var target = { localId: 2, ownerId: null, handoff: { sourceSessionId: 999 } };
+  var attached = attachWithSessions(new Map([[2, target]]));
+  var result = await attached.getToolDefs(target)[0].handler({});
+  assert.strictEqual(result.isError, true);
+  assert.match(textOf(result), /Source session was not found: 999/);
+});
+
+test("handoff context mentions source reading only when the target can mount session tools", function () {
+  var options = {
+    cwd: process.cwd(),
+    source: {
+      localId: 1,
+      vendor: "claude",
+      title: "Context source",
+      history: [{ type: "user_message", text: "Continue the work." }],
+    },
+    targetVendor: "kiro",
+    sourceReadTool: true,
+  };
+  assert.match(contextBuilder.buildHandoffContext(options), /read_handoff_source/);
+  options.sourceReadTool = false;
+  assert.doesNotMatch(contextBuilder.buildHandoffContext(options), /read_handoff_source/);
+});
+
+test("vendor registry exposes session-bound MCP reachability", function () {
+  var supported = ["claude", "kiro", "opencode", "kimi", "grok", "copilot", "qwen", "junie"];
+  for (var i = 0; i < supported.length; i++) {
+    assert.strictEqual(vendorRegistry[supported[i]].sessionBoundTools, true, supported[i]);
+  }
+  assert.strictEqual(vendorRegistry.codex.sessionBoundTools, false);
+  assert.strictEqual(vendorRegistry.antigravity.sessionBoundTools, false);
+});

--- a/test/session-handoff.test.js
+++ b/test/session-handoff.test.js
@@ -111,6 +111,7 @@ test("handoff creates and switches to a new vendor session with bounded context"
   assert.match(f.started[0].prompt, /Current user request, verbatim:\nContinue and run the focused tests\./);
   assert.match(f.started[0].prompt, /Source agent: Claude Code/);
   assert.match(f.started[0].prompt, /Target agent: Codex/);
+  assert.doesNotMatch(f.started[0].prompt, /read_handoff_source/);
   assert.ok(f.started[0].prompt.length <= contextBuilder.MAX_CONTEXT_CHARS);
   assert.strictEqual(f.source.history[f.source.history.length - 1].type, "handoff_created");
   assert.strictEqual(f.started[0].session.history[0].type, "handoff_context");
@@ -148,6 +149,7 @@ test("handoff supports a new session with the same vendor", function () {
   assert.strictEqual(same.started[0].session.cliSessionId, undefined);
   assert.match(same.started[0].prompt, /Source agent: Claude Code/);
   assert.match(same.started[0].prompt, /Target agent: Claude Code/);
+  assert.match(same.started[0].prompt, /read_handoff_source/);
 });
 
 test("handoff rejects missing vendors and split-group sources", function () {


### PR DESCRIPTION
## Summary

- add the session-bound `clay-handoff` MCP tool for reading validated handoff source chains
- expose the tool only to vendors with per-session MCP mounting and only on handoff sessions
- add bounded history pagination, ownership checks, cycle/depth guards, and regression coverage
- strengthen the repository's Angular Commit Convention requirements

## Tests

- `node --test test/session-handoff-tools.test.js test/session-handoff.test.js test/project-session-document.test.js`
- required module load check
