### PR TITLE
fix(sessions): restore split view after daemon restart

### DIFF
--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -106,13 +106,7 @@ function attachConnection(ctx) {
     var presenceKey = wsUser ? wsUser.id : "_default";
     var storedPresence = userPresence.getPresence(slug, presenceKey);
     if (storedPresence && storedPresence.sessionId) {
-      if (sm.sessions.has(storedPresence.sessionId)) {
-        active = sm.sessions.get(storedPresence.sessionId);
-      } else {
-        sm.sessions.forEach(function (s) {
-          if (s.cliSessionId && s.cliSessionId === storedPresence.sessionId) active = s;
-        });
-      }
+      active = userPresence.findSession(sm.sessions, storedPresence.sessionId);
       if (active && usersModule.isMultiUser() && wsUser) {
         if (!usersModule.canAccessSession(wsUser.id, active, { visibility: "public" })) active = null;
       } else if (active && !usersModule.isMultiUser() && active.ownerId) {
@@ -311,7 +305,7 @@ function attachConnection(ctx) {
     }
 
     if (active && !ws._clayPane) {
-      userPresence.setPresence(slug, presenceKey, active.localId, storedPresence ? storedPresence.mateDm : null);
+      userPresence.setPresence(slug, presenceKey, userPresence.sessionIdForPersistence(active), storedPresence ? storedPresence.mateDm : null);
       if (autoCreated) {
         sendTo(ws, { type: "context_sources_state", active: [] });
       }
@@ -338,7 +332,8 @@ function attachConnection(ctx) {
     if (ws._clayActiveSession && !ws._clayPane) {
       var dcPresKey = ws._clayUser ? ws._clayUser.id : "_default";
       var dcExisting = userPresence.getPresence(slug, dcPresKey);
-      userPresence.setPresence(slug, dcPresKey, ws._clayActiveSession, dcExisting ? dcExisting.mateDm : null);
+      var dcSession = sm.sessions.get(ws._clayActiveSession);
+      userPresence.setPresence(slug, dcPresKey, userPresence.sessionIdForPersistence(dcSession), dcExisting ? dcExisting.mateDm : null);
     }
     tm.detachAll(ws);
     clients.delete(ws);

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -542,7 +542,7 @@ function attachSessions(ctx) {
         send({ type: "last_vendor", vendor: msg.vendor });
       }
       var nsPresKey = ws._clayUser ? ws._clayUser.id : "_default";
-      if (!ws._clayPane) userPresence.setPresence(slug, nsPresKey, newSess.localId, null);
+      if (!ws._clayPane) userPresence.setPresence(slug, nsPresKey, userPresence.sessionIdForPersistence(newSess), null);
       if (usersModule.isMultiUser() && !ws._clayPane) {
         broadcastPresence();
       }
@@ -684,7 +684,7 @@ function attachSessions(ctx) {
           sendTo(ws, { type: "context_sources_state", active: switchedSources });
         }
         var swPresKey = ws._clayUser ? ws._clayUser.id : "_default";
-        if (!ws._clayPane) userPresence.setPresence(slug, swPresKey, msg.id, null);
+        if (!ws._clayPane) userPresence.setPresence(slug, swPresKey, userPresence.sessionIdForPersistence(switchTargetSess), null);
       }
       return true;
     }

--- a/lib/user-presence.js
+++ b/lib/user-presence.js
@@ -7,6 +7,21 @@ var store = {};
 var presencePath = path.join(config.CONFIG_DIR, "user-presence.json");
 var saveTimer = null;
 
+function sessionIdForPersistence(session) {
+  if (!session) return null;
+  return session.cliSessionId || session.localId || null;
+}
+
+function findSession(sessions, sessionId) {
+  if (!sessions || sessionId == null) return null;
+  var found = null;
+  sessions.forEach(function (session) {
+    if (session.cliSessionId && session.cliSessionId === sessionId) found = session;
+  });
+  if (found) return found;
+  return typeof sessionId === "number" ? (sessions.get(sessionId) || null) : null;
+}
+
 // Load from disk on startup
 function load() {
   try {
@@ -84,6 +99,8 @@ function clearSession(slug, sessionId) {
 load();
 
 module.exports = {
+  sessionIdForPersistence: sessionIdForPersistence,
+  findSession: findSession,
   setPresence: setPresence,
   getPresence: getPresence,
   setMateDm: setMateDm,

--- a/test/user-presence.test.js
+++ b/test/user-presence.test.js
@@ -1,0 +1,26 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var userPresence = require("../lib/user-presence");
+
+test("sessionIdForPersistence prefers the durable CLI session id", function () {
+  assert.strictEqual(userPresence.sessionIdForPersistence({
+    localId: 17,
+    cliSessionId: "cli-durable",
+  }), "cli-durable");
+  assert.strictEqual(userPresence.sessionIdForPersistence({ localId: 17 }), 17);
+});
+
+test("findSession restores a renumbered session through its CLI session id", function () {
+  var sessions = new Map([
+    [41, { localId: 41, cliSessionId: "cli-other" }],
+    [42, { localId: 42, cliSessionId: "cli-active" }],
+  ]);
+  assert.strictEqual(userPresence.findSession(sessions, "cli-active"), sessions.get(42));
+});
+
+test("findSession accepts legacy numeric presence records", function () {
+  var sessions = new Map([
+    [8, { localId: 8, cliSessionId: "cli-eight" }],
+  ]);
+  assert.strictEqual(userPresence.findSession(sessions, 8), sessions.get(8));
+});


### PR DESCRIPTION
## Summary

- persist active session presence with durable CLI session identifiers
- resolve persisted presence across daemon-local session ID renumbering
- retain compatibility with legacy numeric presence records

## Testing

- `npm test` (332 tests passed)
