### PR TITLE
fix(ui): dock document viewer on the right

### DIFF
--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -960,7 +960,7 @@
     width: 50%;
     max-width: 720px;
     min-width: 360px;
-    border-right: 1px solid var(--border);
+    border-left: 1px solid var(--border);
     background: var(--bg);
     display: flex;
     flex-direction: column;

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -32,7 +32,7 @@ var pendingFileAt = null;    // callback for pending file-at
 export function initFileBrowser(_ctx) {
   ctx = _ctx;
   var mainPanels = document.getElementById("main-panels");
-  if (mainPanels && ctx.fileViewerEl) mainPanels.insertBefore(ctx.fileViewerEl, mainPanels.firstChild);
+  if (mainPanels && ctx.fileViewerEl) mainPanels.appendChild(ctx.fileViewerEl);
   initFileViewerTabs({
     onFocus: function(path) {
       if (path !== currentFilePath) requestFileContent(path);

--- a/test/filebrowser-tabs.test.js
+++ b/test/filebrowser-tabs.test.js
@@ -22,6 +22,15 @@ test("document viewer reset clears every tab before full teardown", function() {
   assert.match(reset, /teardownFileViewer\(\);/);
 });
 
+test("document viewer docks on the right side of the workspace", function() {
+  var browser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+  var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");
+  var init = browser.slice(browser.indexOf("export function initFileBrowser"), browser.indexOf("// Load material file icons"));
+  assert.match(init, /mainPanels\.appendChild\(ctx\.fileViewerEl\)/);
+  assert.doesNotMatch(init, /mainPanels\.insertBefore/);
+  assert.match(css, /#file-viewer\s*\{[^}]*border-left:\s*1px solid var\(--border\)/s);
+});
+
 test("split and pane markdown presents use the parent-owned viewer path", function() {
   var messages = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-messages.js"), "utf8");
   var bridge = fs.readFileSync(path.join(__dirname, "../lib/public/modules/pane-bridge.js"), "utf8");


### PR DESCRIPTION
## Summary

- dock the global tabbed document viewer after the chat and split panes
- move the workspace divider to the viewer's left edge
- add regression coverage for right-side docking

## Testing

- `npm test` (333 tests passed)
- `node scripts/check-client-imports.js`
