### PR TITLE
fix(session): persist active Worker identity immediately

### DIFF
--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -157,6 +157,9 @@ function attachMessageProcessor(ctx) {
     if (parsed.sessionId && !session.cliSessionId) {
       session.cliSessionId = parsed.sessionId;
       sm.saveSessionFile(session);
+      if (typeof sm.notifySessionIdentityAssigned === "function") {
+        sm.notifySessionIdentityAssigned(session.localId);
+      }
       sendAndRecord(session, { type: "session_id", cliSessionId: session.cliSessionId });
     } else if (parsed.sessionId) {
       session.cliSessionId = parsed.sessionId;

--- a/lib/session-split-groups.js
+++ b/lib/session-split-groups.js
@@ -238,6 +238,16 @@ function createSplitGroupStore(opts) {
     return true;
   }
 
+  function refreshAnchors(localId) {
+    var group = groupForMember(localId);
+    if (!group) return false;
+    var fresh = currentCliIds(group);
+    var prev = Array.isArray(group.memberCliIds) ? group.memberCliIds : [null, null];
+    if (fresh[0] === prev[0] && fresh[1] === prev[1]) return false;
+    save();
+    return true;
+  }
+
   function refreshAutoName(localId) {
     var group = groupForMember(localId);
     if (!group) return false;
@@ -245,9 +255,7 @@ function createSplitGroupStore(opts) {
       // Auto-title fires on a member's first message, which is also when a
       // blank member gains its cliSessionId. Re-save so the durable anchor
       // is captured even when the name itself stays untouched.
-      var fresh = currentCliIds(group);
-      var prev = Array.isArray(group.memberCliIds) ? group.memberCliIds : [null, null];
-      if (fresh[0] !== prev[0] || fresh[1] !== prev[1]) save();
+      refreshAnchors(localId);
       return false;
     }
     group.name = autoGroupName(sessions.get(group.members[0]).title, sessions.get(group.members[1]).title);
@@ -258,7 +266,7 @@ function createSplitGroupStore(opts) {
 
   load();
   return { create: create, rename: rename, setPair: setPair, dissolve: dissolve, dissolveBySession: dissolveBySession,
-    refreshAutoName: refreshAutoName,
+    refreshAutoName: refreshAutoName, refreshAnchors: refreshAnchors,
     listFor: listFor, groupForMember: groupForMember, get groups() { return groups; } };
 }
 
@@ -296,6 +304,7 @@ function attachSplitGroups(ctx) {
 
   ctx.sm.setOnSessionDeleted(store.dissolveBySession);
   ctx.sm.setOnSessionRenamed(store.refreshAutoName);
+  ctx.sm.setOnSessionIdentityAssigned(store.refreshAnchors);
   return { handleMessage: handleMessage, sendConnectionState: sendState, store: store };
 }
 

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -15,6 +15,7 @@ function createSessionManager(opts) {
   var onSessionDone = opts.onSessionDone || function () {};
   var onSessionDeleted = opts.onSessionDeleted || function () {};
   var onSessionRenamed = opts.onSessionRenamed || function () {};
+  var onSessionIdentityAssigned = opts.onSessionIdentityAssigned || function () {};
 
   // --- Multi-session state ---
   var nextLocalId = 1;
@@ -1184,7 +1185,9 @@ function createSessionManager(opts) {
     sessionsDir: sessionsDir,
     setOnSessionDeleted: function (fn) { onSessionDeleted = fn || function () {}; },
     setOnSessionRenamed: function (fn) { onSessionRenamed = fn || function () {}; },
+    setOnSessionIdentityAssigned: function (fn) { onSessionIdentityAssigned = fn || function () {}; },
     notifySessionRenamed: function (localId) { onSessionRenamed(localId); },
+    notifySessionIdentityAssigned: function (localId) { onSessionIdentityAssigned(localId); },
     HISTORY_PAGE_SIZE: HISTORY_PAGE_SIZE,
     getActiveSession: getActiveSession,
     createSession: createSession,

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -1044,6 +1044,9 @@ function createCodexQueryHandle(appServer, queryOpts) {
         state.threadId = threadResult.thread.id;
         handlerEntry.threadId = state.threadId;
       }
+      if (state.threadId) {
+        pushEvent({ yokeType: "session_started", sessionId: state.threadId });
+      }
 
       while (!isCancelled()) {
         // Reset per-turn state

--- a/test/codex-dynamic-tools.test.js
+++ b/test/codex-dynamic-tools.test.js
@@ -54,7 +54,9 @@ test("Codex registers and executes session-bound dynamic tools", async function 
 
   await handle.setModel("gpt-5.6-sol");
   handle.pushMessage("Implement the feature");
+  var events = [];
   for await (var event of handle) {
+    events.push(event);
     if (event.yokeType === "result") break;
   }
   handle.close();
@@ -66,6 +68,7 @@ test("Codex registers and executes session-bound dynamic tools", async function 
   assert.match(turnCall.params.input[0].text, /Base instructions/);
   assert.match(turnCall.params.input[0].text, /You are the Driver/);
   assert.deepStrictEqual(receivedArgs, { message: "Build it" });
+  assert.deepStrictEqual(events[0], { yokeType: "session_started", sessionId: "thread-pair" });
   assert.deepStrictEqual(responses, [{
     id: 41,
     result: { contentItems: [{ type: "inputText", text: "Worker complete" }], success: true },

--- a/test/sdk-bridge-delivery.test.js
+++ b/test/sdk-bridge-delivery.test.js
@@ -54,6 +54,23 @@ test("pushMessage retires a query handle that rejects delivery", function() {
   assert.strictEqual(session.messageQueue, null);
 });
 
+test("a started session persists its identity and refreshes split anchors immediately", function() {
+  var saved = [];
+  var assigned = [];
+  var recorded = [];
+  var bridge = createBridge({
+    saveSessionFile: function(session) { saved.push(session.cliSessionId); },
+    notifySessionIdentityAssigned: function(localId) { assigned.push(localId); },
+    sendAndRecord: function(session, msg) { recorded.push(msg); },
+  });
+  var session = { localId: 5, cliSessionId: null };
+  bridge.processSDKMessage(session, { yokeType: "session_started", sessionId: "thread-worker" });
+  assert.strictEqual(session.cliSessionId, "thread-worker");
+  assert.deepStrictEqual(saved, ["thread-worker"]);
+  assert.deepStrictEqual(assigned, [5]);
+  assert.deepStrictEqual(recorded, [{ type: "session_id", cliSessionId: "thread-worker" }]);
+});
+
 test("mention sessions preserve the mapped Linux user", async function() {
   var capturedOptions = null;
   var handle = createEndingHandle([]);

--- a/test/split-groups.test.js
+++ b/test/split-groups.test.js
@@ -139,6 +139,31 @@ test("configured pair roles survive member renumbering", function (t) {
   assert.deepStrictEqual(reloaded.groups[0].pair, { driverId: 21, workerId: 22 });
 });
 
+test("an in-progress Worker becomes restart-safe when its session identity arrives", function (t) {
+  var f = fixture(t, false);
+  f.sessions.get(1).cliSessionId = "cli-driver";
+  var created = f.store.create(f.ws1, {
+    members: [1, 2],
+    pair: { driverId: 1, workerId: 2 },
+  });
+  assert.strictEqual(created.ok, true);
+  assert.deepStrictEqual(created.group.memberCliIds, ["cli-driver", null]);
+
+  f.sessions.get(2).cliSessionId = "cli-worker";
+  assert.strictEqual(f.store.refreshAnchors(2), true);
+  var persisted = JSON.parse(fs.readFileSync(path.join(f.dir, "split-groups.json")));
+  assert.deepStrictEqual(persisted[0].memberCliIds, ["cli-driver", "cli-worker"]);
+  assert.deepStrictEqual(persisted[0].pairCliIds, ["cli-driver", "cli-worker"]);
+
+  var renumbered = new Map([
+    [11, { localId: 11, title: "Driver", cliSessionId: "cli-driver" }],
+    [12, { localId: 12, title: "Worker", cliSessionId: "cli-worker" }],
+  ]);
+  var reloaded = createSplitGroupStore({ sessions: renumbered, sessionsDir: f.dir, usersModule: null });
+  assert.deepStrictEqual(reloaded.groups[0].members, [11, 12]);
+  assert.deepStrictEqual(reloaded.groups[0].pair, { driverId: 11, workerId: 12 });
+});
+
 test("configured pair roles must reference both members", function (t) {
   var f = fixture(t, false);
   var result = f.store.create(f.ws1, {


### PR DESCRIPTION
## Summary

- emit the Codex thread identity immediately after thread creation
- persist newly assigned session identities before the first turn completes
- refresh durable split-group and Driver/Worker anchors as soon as the identity arrives
- restore in-progress Worker pairs after daemon restarts and local session ID renumbering

## Testing

- `node --test test/codex-dynamic-tools.test.js test/sdk-bridge-delivery.test.js test/split-groups.test.js test/session-pair.test.js test/worker-proposal.test.js` (55 passed)
- `npm test` (335 passed)
- `git diff --check`
