### PR TITLE
feat(document-viewer): add VS Code-style preview tabs

### DIFF
--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -1002,31 +1002,73 @@
 }
 
 .file-viewer-header {
+  display: block;
+  padding: 0;
+  flex-shrink: 0;
+  min-height: 0;
+  background: var(--bg);
+}
+
+.file-viewer-tabbar {
+  display: flex;
+  align-items: stretch;
+  height: 36px;
+  min-width: 0;
+  background: var(--bg-deep);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.file-viewer-tabs { display: flex; min-width: 0; flex: 1; overflow-x: auto; overflow-y: hidden; gap: 0; scrollbar-width: none; }
+.file-viewer-tabs::-webkit-scrollbar { display: none; }
+.file-viewer-tab { position: relative; display: inline-flex; align-items: center; flex: 0 0 auto; gap: 7px; min-width: 108px; max-width: 190px; height: 36px; overflow: hidden; white-space: nowrap; border: 0; border-right: 1px solid var(--border-subtle); border-radius: 0; padding: 0 8px 0 10px; background: var(--bg-alt); color: var(--text-secondary); font: inherit; font-size: 12px; cursor: pointer; }
+.file-viewer-tab::before { content: ""; position: absolute; inset: 0 0 auto; height: 1px; background: transparent; }
+.file-viewer-tab:hover { background: var(--bg-hover); color: var(--text); }
+.file-viewer-tab.active { background: var(--bg); color: var(--text); }
+.file-viewer-tab.active::before { background: var(--accent); }
+.file-viewer-tab.preview .file-viewer-tab-label { font-style: italic; }
+.file-viewer-tab-icon { display: inline-flex; width: 16px; height: 16px; flex: 0 0 16px; }
+.file-viewer-tab-icon:empty { display: none; }
+.file-viewer-tab-icon svg { width: 16px; height: 16px; }
+.file-viewer-tab-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.file-viewer-tab-close { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; margin-left: auto; border-radius: 4px; flex: 0 0 18px; color: var(--text-muted); font-size: 16px; font-style: normal; line-height: 1; opacity: 0; }
+.file-viewer-tab:hover .file-viewer-tab-close, .file-viewer-tab.active .file-viewer-tab-close { opacity: 1; }
+.file-viewer-tab-close:hover { background: var(--bg-hover); color: var(--text); }
+
+.file-viewer-toolbar {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--border-subtle);
-  flex-shrink: 0;
-  min-height: 44px;
+  flex: 0 0 auto;
+  gap: 1px;
+  padding: 0 6px;
+  background: var(--bg-deep);
+  border-left: 1px solid var(--border-subtle);
 }
 
-.file-viewer-tabs { display: flex; min-width: 0; flex: 1; overflow-x: auto; gap: 2px; }
-.file-viewer-tab { display: inline-flex; align-items: center; gap: 6px; max-width: 170px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; border: 0; border-radius: 5px; padding: 4px 7px; background: transparent; color: var(--text-secondary); font: inherit; font-size: 12px; cursor: pointer; }
-.file-viewer-tab.active { background: var(--sidebar-hover); color: var(--text); }
-.file-viewer-tab-close { font-size: 16px; line-height: 12px; color: var(--text-muted); }
+.file-viewer-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 30px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg);
+}
 
 .file-viewer-path {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
   flex: 1;
-  font-family: "Roboto Mono", monospace;
-  font-size: 13px;
-  color: var(--text-secondary);
+  font-size: 12px;
+  color: var(--text-muted);
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
-  direction: rtl;
-  text-align: left;
 }
+
+.file-viewer-path-segment { flex: 0 0 auto; }
+.file-viewer-path-segment.current { color: var(--text-secondary); }
+.file-viewer-path-separator { color: var(--text-dimmer); font-size: 15px; line-height: 1; }
 
 .file-viewer-btn {
   display: flex;
@@ -1179,10 +1221,10 @@
   color: var(--text);
 }
 
-#file-viewer.panel-fullscreen .file-viewer-header {
-  padding-left: clamp(18px, 3vw, 48px);
-  padding-right: clamp(18px, 3vw, 48px);
-  background: var(--bg);
+#file-viewer.panel-fullscreen .file-viewer-breadcrumbs { padding-left: clamp(18px, 3vw, 48px); padding-right: clamp(18px, 3vw, 48px); }
+
+@media (hover: none) {
+  .file-viewer-tab-close { opacity: 1; }
 }
 
 #file-viewer.panel-fullscreen .file-viewer-body {

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -1694,6 +1694,28 @@
   border: 1px solid var(--border-subtle);
 }
 
+.file-viewer-svg-preview {
+  display: grid;
+  place-items: center;
+  min-height: 100%;
+  padding: clamp(24px, 5vw, 56px);
+  background-color: var(--bg);
+  background-image:
+    linear-gradient(45deg, var(--bg-alt) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--bg-alt) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--bg-alt) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--bg-alt) 75%);
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0;
+  background-size: 20px 20px;
+}
+
+.file-viewer-svg-preview img {
+  display: block;
+  max-width: 100%;
+  max-height: calc(100dvh - 150px);
+  filter: drop-shadow(0 8px 24px rgba(var(--shadow-rgb), 0.18));
+}
+
 /* --- Web Terminal --- */
 
 /* Terminal header with tabs */

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -680,22 +680,28 @@
 
   <div id="file-viewer" class="hidden">
     <div class="file-viewer-header">
-      <div class="file-viewer-tabs" id="file-viewer-tabs" role="tablist"></div>
-      <span class="file-viewer-path" id="file-viewer-path"></span>
-      <span class="file-viewer-live-status hidden" id="file-viewer-live-status" aria-live="polite">
-        <span class="file-viewer-live-dot"></span>
-        <span class="file-viewer-live-label">Editing</span>
-      </span>
-      <button class="file-viewer-btn hidden" id="file-viewer-render" title="Toggle rendered view"><i data-lucide="book-open"></i></button>
-      <button class="file-viewer-btn hidden" id="file-viewer-pdf" title="Export PDF"><i data-lucide="file-down"></i></button>
-      <button class="file-viewer-btn hidden" id="file-viewer-slides" title="Present as slides" aria-label="Present Markdown as slides" aria-pressed="false"><i data-lucide="presentation"></i></button>
-      <button class="file-viewer-btn file-viewer-slide-level hidden" id="file-viewer-slide-level" title="Split slides by heading level" aria-haspopup="menu" aria-expanded="false"><span>H1</span><i data-lucide="chevron-down"></i></button>
-      <button class="file-viewer-btn hidden" id="file-viewer-history" title="Edit history"><i data-lucide="clock"></i></button>
-      <button class="file-viewer-btn" id="file-viewer-refresh" title="Refresh"><i data-lucide="refresh-cw"></i></button>
-      <button class="file-viewer-btn" id="file-viewer-copy" title="Copy contents" aria-label="Copy contents"><i data-lucide="copy"></i></button>
-      <button class="file-viewer-btn hidden" id="file-viewer-copy-formatted" title="Copy Markdown formatting" aria-label="Copy Markdown formatting"><i data-lucide="clipboard-copy"></i></button>
-      <button class="file-viewer-btn" id="file-viewer-fullscreen" title="Toggle fullscreen"><i data-lucide="maximize-2"></i></button>
-      <button class="file-viewer-btn" id="file-viewer-close" title="Close"><i data-lucide="x"></i></button>
+      <div class="file-viewer-tabbar">
+        <div class="file-viewer-tabs" id="file-viewer-tabs" role="tablist"></div>
+        <div class="file-viewer-toolbar" aria-label="Editor actions">
+          <button class="file-viewer-btn hidden" id="file-viewer-render" title="Toggle rendered view"><i data-lucide="book-open"></i></button>
+          <button class="file-viewer-btn hidden" id="file-viewer-pdf" title="Export PDF"><i data-lucide="file-down"></i></button>
+          <button class="file-viewer-btn hidden" id="file-viewer-slides" title="Present as slides" aria-label="Present Markdown as slides" aria-pressed="false"><i data-lucide="presentation"></i></button>
+          <button class="file-viewer-btn file-viewer-slide-level hidden" id="file-viewer-slide-level" title="Split slides by heading level" aria-haspopup="menu" aria-expanded="false"><span>H1</span><i data-lucide="chevron-down"></i></button>
+          <button class="file-viewer-btn hidden" id="file-viewer-history" title="Edit history"><i data-lucide="clock"></i></button>
+          <button class="file-viewer-btn" id="file-viewer-refresh" title="Refresh"><i data-lucide="refresh-cw"></i></button>
+          <button class="file-viewer-btn" id="file-viewer-copy" title="Copy contents" aria-label="Copy contents"><i data-lucide="copy"></i></button>
+          <button class="file-viewer-btn hidden" id="file-viewer-copy-formatted" title="Copy Markdown formatting" aria-label="Copy Markdown formatting"><i data-lucide="clipboard-copy"></i></button>
+          <button class="file-viewer-btn" id="file-viewer-fullscreen" title="Toggle fullscreen"><i data-lucide="maximize-2"></i></button>
+          <button class="file-viewer-btn" id="file-viewer-close" title="Close"><i data-lucide="x"></i></button>
+        </div>
+      </div>
+      <div class="file-viewer-breadcrumbs">
+        <div class="file-viewer-path" id="file-viewer-path" aria-label="Current file path"></div>
+        <span class="file-viewer-live-status hidden" id="file-viewer-live-status" aria-live="polite">
+          <span class="file-viewer-live-dot"></span>
+          <span class="file-viewer-live-label">Editing</span>
+        </span>
+      </div>
     </div>
     <div class="file-viewer-body" id="file-viewer-body"></div>
   </div>

--- a/lib/public/modules/filebrowser-tabs.js
+++ b/lib/public/modules/filebrowser-tabs.js
@@ -1,5 +1,8 @@
+import { getFileIconSvg } from './fileicons.js';
+
 var tabs = new Map();
 var focusedPath = null;
+var previewPath = null;
 var onFocus = null;
 var onEmpty = null;
 
@@ -15,14 +18,23 @@ function render() {
   tabs.forEach(function(value, path) {
     var tab = document.createElement("button");
     tab.type = "button";
-    tab.className = "file-viewer-tab" + (path === focusedPath ? " active" : "");
-    tab.textContent = label(path);
+    tab.className = "file-viewer-tab" + (path === focusedPath ? " active" : "") + (path === previewPath ? " preview" : "");
+    tab.setAttribute("role", "tab");
+    tab.setAttribute("aria-selected", path === focusedPath ? "true" : "false");
     tab.title = path;
     tab.addEventListener("click", function() { focusFileViewerTab(path); });
+    var icon = document.createElement("span");
+    icon.className = "file-viewer-tab-icon";
+    icon.innerHTML = getFileIconSvg(label(path));
+    var name = document.createElement("span");
+    name.className = "file-viewer-tab-label";
+    name.textContent = label(path);
     var close = document.createElement("span");
     close.className = "file-viewer-tab-close";
     close.textContent = "×";
     close.addEventListener("click", function(event) { event.stopPropagation(); closeFileViewerTab(path); });
+    tab.appendChild(icon);
+    tab.appendChild(name);
     tab.appendChild(close);
     root.appendChild(tab);
   });
@@ -37,9 +49,35 @@ export function openFileViewerTab(path, data) {
   if (!path) return false;
   var exists = tabs.has(path);
   tabs.set(path, Object.assign(tabs.get(path) || {}, data || {}));
+  if (path === previewPath) previewPath = null;
   focusedPath = path;
   render();
   return !exists;
+}
+
+export function previewFileViewerTab(path, data) {
+  if (!path) return false;
+  if (tabs.has(path) && path !== previewPath) {
+    focusedPath = path;
+    render();
+    return false;
+  }
+  if (previewPath && previewPath !== path) tabs.delete(previewPath);
+  var exists = tabs.has(path);
+  tabs.set(path, Object.assign(tabs.get(path) || {}, data || {}));
+  previewPath = path;
+  focusedPath = path;
+  render();
+  return !exists;
+}
+
+export function updateFileViewerTab(path, data) {
+  if (!path) return false;
+  if (!tabs.has(path)) return false;
+  tabs.set(path, Object.assign(tabs.get(path) || {}, data || {}));
+  if (focusedPath !== path) return false;
+  render();
+  return true;
 }
 
 export function focusFileViewerTab(path) {
@@ -55,6 +93,7 @@ export function closeFileViewerTab(path) {
   var paths = Array.from(tabs.keys());
   var index = paths.indexOf(path);
   tabs.delete(path);
+  if (previewPath === path) previewPath = null;
   if (focusedPath === path) focusedPath = paths[index + 1] || paths[index - 1] || null;
   render();
   if (focusedPath && onFocus) onFocus(focusedPath, tabs.get(focusedPath));
@@ -62,4 +101,4 @@ export function closeFileViewerTab(path) {
 }
 
 export function focusedFileViewerTab() { return focusedPath; }
-export function clearFileViewerTabs() { tabs.clear(); focusedPath = null; render(); }
+export function clearFileViewerTabs() { tabs.clear(); focusedPath = null; previewPath = null; render(); }

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -18,6 +18,7 @@ var currentContent = null;  // last read file content for copy
 var currentFilePath = null;  // path of the currently viewed file
 var isRendered = false;      // markdown render toggle state
 var currentIsMarkdown = false;
+var currentIsSvg = false;
 var historyVisible = false;
 var currentHistoryEntries = [];
 var pendingNavigate = null;  // { sessionLocalId, assistantUuid }
@@ -181,8 +182,12 @@ export function initFileBrowser(_ctx) {
 
   // Markdown render toggle
   document.getElementById("file-viewer-render").addEventListener("click", function () {
-    if (!currentContent || !currentIsMarkdown) return;
+    if (!currentContent || (!currentIsMarkdown && !currentIsSvg)) return;
     isRendered = !isRendered;
+    if (currentIsSvg) {
+      renderSvgBody();
+      return;
+    }
     if (!isRendered && isFollowingMarkdown(currentFilePath)) cancelMarkdownFollow();
     renderBody();
   });
@@ -504,6 +509,7 @@ export function resetFileBrowser() {
   currentFilePath = null;
   isRendered = false;
   currentIsMarkdown = false;
+  currentIsSvg = false;
   historyVisible = false;
   currentHistoryEntries = [];
   pendingNavigate = null;
@@ -1086,6 +1092,7 @@ function showFileContent(msg) {
   currentContent = null;
   currentFilePath = msg.path;
   currentIsMarkdown = false;
+  currentIsSvg = false;
   if (!keepRenderState) isRendered = false;
   var requestedExt = msg.path.split(".").pop().toLowerCase();
   if (pendingRenderedOpen && (requestedExt === "md" || requestedExt === "mdx")) {
@@ -1110,23 +1117,27 @@ function showFileContent(msg) {
     currentContent = msg.content;
     var ext = requestedExt;
     currentIsMarkdown = (ext === "md" || ext === "mdx");
+    currentIsSvg = ext === "svg";
     if (pendingRenderedOpen && currentIsMarkdown) isRendered = true;
 
-    if (currentIsMarkdown) {
+    if (currentIsMarkdown || currentIsSvg) {
       renderBtn.classList.remove("hidden");
-      renderBtn.title = "Render markdown";
-      copyBtn.title = "Copy Markdown source";
+      renderBtn.title = currentIsSvg ? "Show SVG source" : "Render markdown";
+      copyBtn.title = currentIsSvg ? "Copy SVG source" : "Copy Markdown source";
     } else {
       copyBtn.title = "Copy contents";
     }
 
-    // Show raw by default, use renderBody for markdown toggle
+    // Markdown starts as source; SVG starts as a safe image preview.
     if (currentIsMarkdown) {
       var transitionFrom = keepRenderState && prevRendered && previousWasMarkdown &&
         isFollowingMarkdown(msg.path) && pathsReferToSameFile(previousPath, msg.path)
         ? (previousContent == null ? "" : previousContent)
         : null;
       renderBody(transitionFrom, refreshSlideIndex);
+    } else if (currentIsSvg) {
+      if (!keepRenderState) isRendered = true;
+      renderSvgBody();
     } else {
       renderCodeWithLineNumbers(bodyEl, msg.content, ext);
     }
@@ -1171,6 +1182,29 @@ function showFileContent(msg) {
     historyBtn.classList.remove("active");
     requestFileHistory(msg.path);
   }
+}
+
+function renderSvgBody() {
+  var bodyEl = document.getElementById("file-viewer-body");
+  var renderBtn = document.getElementById("file-viewer-render");
+  if (!bodyEl || !currentFilePath || currentContent == null) return;
+  if (!isRendered) {
+    renderCodeWithLineNumbers(bodyEl, currentContent, "svg");
+    renderBtn.classList.remove("active");
+    renderBtn.title = "Show SVG preview";
+    return;
+  }
+  bodyEl.innerHTML = "";
+  var preview = document.createElement("div");
+  preview.className = "file-viewer-svg-preview";
+  var image = document.createElement("img");
+  image.src = "api/file?path=" + encodeURIComponent(currentFilePath);
+  image.alt = currentFilePath;
+  image.draggable = false;
+  preview.appendChild(image);
+  bodyEl.appendChild(preview);
+  renderBtn.classList.add("active");
+  renderBtn.title = "Show SVG source";
 }
 
 function renderFileBreadcrumb(root, path) {
@@ -1487,6 +1521,8 @@ function rerenderFileContent() {
 
   if (currentIsMarkdown) {
     renderBody();
+  } else if (currentIsSvg) {
+    renderSvgBody();
   } else {
     renderCodeWithLineNumbers(bodyEl, currentContent, ext);
   }

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -9,7 +9,7 @@ import { copyMarkdownFormatting } from './rich-clipboard.js';
 import { animateMarkdownChange, beginMarkdownPresentation, cancelMarkdownFollow, isFollowingMarkdown } from './markdown-live-edit.js';
 import { store } from './store.js';
 import { enterMarkdownSlides, exitMarkdownSlides, handleMarkdownSlideKey, syncMarkdownSlidesButton, toggleMarkdownSlideLevelMenu } from './markdown-slides.js';
-import { initFileViewerTabs, openFileViewerTab, closeFileViewerTab, focusedFileViewerTab, clearFileViewerTabs } from './filebrowser-tabs.js';
+import { initFileViewerTabs, openFileViewerTab, previewFileViewerTab, updateFileViewerTab, closeFileViewerTab, focusedFileViewerTab, clearFileViewerTabs } from './filebrowser-tabs.js';
 
 var ctx;
 var showDropHint = function () {};
@@ -377,7 +377,11 @@ function kbCollapseOrAscend() {
 }
 
 function kbActivate() {
-  if (_kbFocused) _kbFocused.click();
+  if (!_kbFocused) return;
+  if (!isDirRow(_kbFocused) && _kbFocused.dataset.path) {
+    openFileViewerTab(_kbFocused.dataset.path);
+  }
+  _kbFocused.click();
 }
 
 function handleTreeKeyDown(e) {
@@ -541,6 +545,7 @@ export function openFile(filePath, opts) {
 
 export function openWorkingTreeDiff(diff) {
   if (!diff || !diff.path) return;
+  openFileViewerTab(diff.path);
   pendingRenderedOpen = false;
   pendingOpenMode = diff.binary ? null : {
     type: "diff",
@@ -801,8 +806,13 @@ function renderFilteredTree(container, tree, depth, query) {
           var prev = ctx.fileTreeEl.querySelector(".file-tree-item.active");
           if (prev) prev.classList.remove("active");
           rowEl.classList.add("active");
+          previewFileViewerTab(filePath);
           requestFileContent(filePath);
           if (window.innerWidth <= 768) closeSidebar();
+        });
+        rowEl.addEventListener("dblclick", function (e) {
+          e.stopPropagation();
+          openFileViewerTab(filePath);
         });
       })(entry.path, row);
 
@@ -1033,11 +1043,16 @@ function renderEntries(container, entries, depth) {
           var prev = ctx.fileTreeEl.querySelector(".file-tree-item.active");
           if (prev) prev.classList.remove("active");
           rowEl.classList.add("active");
+          previewFileViewerTab(filePath);
           requestFileContent(filePath);
           // Mobile: close sidebar
           if (window.innerWidth <= 768) {
             closeSidebar();
           }
+        });
+        rowEl.addEventListener("dblclick", function (e) {
+          e.stopPropagation();
+          openFileViewerTab(filePath);
         });
       })(entry.path, row);
 
@@ -1050,7 +1065,7 @@ function renderEntries(container, entries, depth) {
 // --- File viewer ---
 
 function showFileContent(msg) {
-  openFileViewerTab(msg.path, { content: msg.content });
+  if (!updateFileViewerTab(msg.path, { content: msg.content })) return;
   var pathEl = document.getElementById("file-viewer-path");
   var bodyEl = document.getElementById("file-viewer-body");
   var renderBtn = document.getElementById("file-viewer-render");
@@ -1064,7 +1079,7 @@ function showFileContent(msg) {
 
   exitMarkdownSlides();
 
-  pathEl.textContent = msg.path;
+  renderFileBreadcrumb(pathEl, msg.path);
   var keepRenderState = pendingRefresh && msg.path === currentFilePath;
   var prevRendered = isRendered;
   pendingRefresh = false;
@@ -1155,6 +1170,24 @@ function showFileContent(msg) {
     historyBtn.classList.add("hidden");
     historyBtn.classList.remove("active");
     requestFileHistory(msg.path);
+  }
+}
+
+function renderFileBreadcrumb(root, path) {
+  root.innerHTML = "";
+  root.title = path;
+  var parts = String(path || "").replace(/\\/g, "/").split("/").filter(function(part) { return part; });
+  for (var i = 0; i < parts.length; i++) {
+    if (i > 0) {
+      var separator = document.createElement("span");
+      separator.className = "file-viewer-path-separator";
+      separator.textContent = "›";
+      root.appendChild(separator);
+    }
+    var segment = document.createElement("span");
+    segment.className = "file-viewer-path-segment" + (i === parts.length - 1 ? " current" : "");
+    segment.textContent = parts[i];
+    root.appendChild(segment);
   }
 }
 

--- a/test/filebrowser-tabs.test.js
+++ b/test/filebrowser-tabs.test.js
@@ -22,6 +22,20 @@ test("document viewer reset clears every tab before full teardown", function() {
   assert.match(reset, /teardownFileViewer\(\);/);
 });
 
+test("file tree clicks preview files while double clicks pin them", function() {
+  var source = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+  assert.strictEqual((source.match(/previewFileViewerTab\(filePath\)/g) || []).length, 2);
+  assert.strictEqual((source.match(/rowEl\.addEventListener\("dblclick"/g) || []).length, 2);
+});
+
+test("document viewer uses an editor tab strip with a separate breadcrumb row", function() {
+  var html = fs.readFileSync(path.join(__dirname, "../lib/public/index.html"), "utf8");
+  var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");
+  assert.match(html, /file-viewer-tabbar[\s\S]*file-viewer-toolbar[\s\S]*file-viewer-breadcrumbs/);
+  assert.match(css, /\.file-viewer-tab\.active::before\s*\{[^}]*var\(--accent\)/s);
+  assert.match(css, /\.file-viewer-breadcrumbs\s*\{/);
+});
+
 test("document viewer docks on the right side of the workspace", function() {
   var browser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
   var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");
@@ -47,6 +61,7 @@ test("document viewer tabs execute focus and close click handlers", async functi
       classList: { add: function() {}, remove: function() {}, toggle: function() {} },
       appendChild: function(child) { this.children.push(child); },
       addEventListener: function(type, handler) { this.handlers[type] = handler; },
+      setAttribute: function() {},
     };
     Object.defineProperty(node, "innerHTML", {
       get: function() { return ""; },
@@ -73,11 +88,50 @@ test("document viewer tabs execute focus and close click handlers", async functi
   assert.strictEqual(tabs.focusedFileViewerTab(), "one.md");
   root.children[0].handlers.click({ stopPropagation: function() {} });
   assert.strictEqual(focused[0], "one.md");
-  root.children[0].children[0].handlers.click({ stopPropagation: function() {} });
+  root.children[0].children[2].handlers.click({ stopPropagation: function() {} });
   assert.strictEqual(root.children.length, 1);
   assert.strictEqual(tabs.focusedFileViewerTab(), "two.md");
   assert.strictEqual(focused[1], "two.md");
   tabs.closeFileViewerTab("two.md");
   assert.strictEqual(emptied, 1);
+  delete global.document;
+});
+
+test("document viewer reuses one preview tab until the file is explicitly opened", async function() {
+  function element() {
+    var node = {
+      children: [], handlers: {},
+      appendChild: function(child) { this.children.push(child); },
+      addEventListener: function(type, handler) { this.handlers[type] = handler; },
+      setAttribute: function() {},
+    };
+    Object.defineProperty(node, "innerHTML", {
+      get: function() { return ""; },
+      set: function() { node.children = []; },
+    });
+    return node;
+  }
+  var root = element();
+  global.document = {
+    getElementById: function(id) { return id === "file-viewer-tabs" ? root : null; },
+    createElement: element,
+  };
+  var moduleUrl = "file://" + path.join(__dirname, "../lib/public/modules/filebrowser-tabs.js") + "?preview=" + Date.now();
+  var tabs = await import(moduleUrl);
+  tabs.initFileViewerTabs({});
+  tabs.previewFileViewerTab("one.md");
+  tabs.previewFileViewerTab("two.md");
+  assert.strictEqual(root.children.length, 1);
+  assert.strictEqual(tabs.focusedFileViewerTab(), "two.md");
+  tabs.openFileViewerTab("two.md");
+  tabs.previewFileViewerTab("three.md");
+  assert.strictEqual(root.children.length, 2);
+  tabs.previewFileViewerTab("four.md");
+  assert.strictEqual(root.children.length, 2);
+  assert.strictEqual(tabs.focusedFileViewerTab(), "four.md");
+  tabs.updateFileViewerTab("four.md", { content: "updated" });
+  assert.strictEqual(root.children.length, 2);
+  assert.strictEqual(tabs.updateFileViewerTab("stale.md", { content: "late" }), false);
+  assert.strictEqual(root.children.length, 2);
   delete global.document;
 });

--- a/test/filebrowser-tabs.test.js
+++ b/test/filebrowser-tabs.test.js
@@ -36,6 +36,15 @@ test("document viewer uses an editor tab strip with a separate breadcrumb row", 
   assert.match(css, /\.file-viewer-breadcrumbs\s*\{/);
 });
 
+test("document viewer renders SVG files safely with a source toggle", function() {
+  var source = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+  var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");
+  assert.match(source, /currentIsSvg = ext === "svg"/);
+  assert.match(source, /image\.src = "api\/file\?path=" \+ encodeURIComponent\(currentFilePath\)/);
+  assert.doesNotMatch(source, /file-viewer-svg-preview[^\n]*currentContent/);
+  assert.match(css, /\.file-viewer-svg-preview\s*\{/);
+});
+
 test("document viewer docks on the right side of the workspace", function() {
   var browser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
   var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");


### PR DESCRIPTION
## Summary

- reuse a single preview tab while skimming files and pin files opened with double-click, Enter, or explicit viewer actions
- replace the document viewer header with a VS Code-style tab strip, editor toolbar, file icons, and breadcrumb path
- preview SVG files safely on a transparency grid with a visual/source toggle
- ignore stale file responses so rapid preview navigation does not jump back to an older file
- cover preview replacement, pinning, close behavior, editor chrome, and SVG rendering with tests

## Testing

- `npm test` (339 tests passed)
