### PR TITLE
feat(ui): enhance file browser and terminal theming

### DIFF
--- a/lib/project-http.js
+++ b/lib/project-http.js
@@ -254,6 +254,57 @@ function attachHTTP(ctx) {
       return true;
     }
 
+    // File browser: download project files
+    if (req.method === "GET" && urlPath.startsWith("/api/file/download?")) {
+      if (usersModule.isMultiUser()) {
+        var downloadUser = req._clayUser;
+        var downloadPermissions = downloadUser ? usersModule.getEffectivePermissions(downloadUser, osUsers) : null;
+        if (!downloadPermissions || !downloadPermissions.fileBrowser) {
+          res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+          res.end("File browser access is not permitted");
+          return true;
+        }
+      }
+
+      var downloadQueryIndex = urlPath.indexOf("?");
+      var downloadParams = new URLSearchParams(urlPath.substring(downloadQueryIndex));
+      var downloadPath = downloadParams.get("path");
+      if (!downloadPath) { res.writeHead(400); res.end("Missing path"); return true; }
+      var downloadFile = safePath(cwd, downloadPath);
+      if (!downloadFile && getOsUserInfoForReq(req)) {
+        downloadFile = safeAbsPath(downloadPath);
+      }
+      if (!downloadFile) { res.writeHead(403); res.end("Access denied"); return true; }
+
+      try {
+        var downloadUserInfo = getOsUserInfoForReq(req);
+        var downloadContent;
+        if (downloadUserInfo) {
+          downloadContent = fsAsUser("read_binary", { file: downloadFile }, downloadUserInfo).buffer;
+        } else {
+          downloadContent = fs.readFileSync(downloadFile);
+        }
+        var downloadName = path.basename(downloadPath).replace(/[\x00-\x1f\x7f"\\]/g, "_") || "download";
+        var asciiDownloadName = downloadName.replace(/[^\x20-\x7e]/g, "_");
+        var encodedDownloadName = encodeURIComponent(downloadName).replace(/[!'()*]/g, function (character) {
+          return "%" + character.charCodeAt(0).toString(16).toUpperCase();
+        });
+        var contentDisposition = "attachment; filename=\"" + asciiDownloadName + "\"; filename*=UTF-8''" + encodedDownloadName;
+        res.writeHead(200, {
+          "Content-Type": "application/octet-stream",
+          "Content-Length": downloadContent.length,
+          "Content-Disposition": contentDisposition,
+          "Cache-Control": "no-store",
+          "X-Content-Type-Options": "nosniff",
+        });
+        res.end(downloadContent);
+      } catch (e) {
+        res.writeHead(404);
+        res.end("Not found");
+      }
+      return true;
+    }
+
     // File browser: serve project images
     if (req.method === "GET" && urlPath.startsWith("/api/file?")) {
       var qIdx = urlPath.indexOf("?");

--- a/lib/project.js
+++ b/lib/project.js
@@ -111,6 +111,7 @@ var BINARY_EXTS = new Set([
 ]);
 var IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".ico"]);
 var FS_MAX_SIZE = 512 * 1024;
+var FS_VIEWER_MAX_SIZE = 5 * 1024 * 1024;
 function safePath(base, requested) {
   var resolved = path.resolve(base, requested);
   if (resolved !== base && !resolved.startsWith(base + path.sep)) return null;
@@ -1438,7 +1439,7 @@ function createProjectContext(opts) {
     IGNORED_DIRS: IGNORED_DIRS,
     BINARY_EXTS: BINARY_EXTS,
     IMAGE_EXTS: IMAGE_EXTS,
-    FS_MAX_SIZE: FS_MAX_SIZE,
+    FS_MAX_SIZE: FS_VIEWER_MAX_SIZE,
   });
 
   // --- MCP bridge handler for Codex and session-bound Kiro tools ---

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -1851,25 +1851,6 @@
 
 /* --- Web Terminal --- */
 
-/* Terminal chrome intentionally stays on Clay Studio Dark. These local
-   tokens isolate it from the workspace theme without changing user settings. */
-#terminal-container,
-.terminal-tab-ctx {
-  --bg: #171715;
-  --bg-alt: #20201d;
-  --text: #e8e8e2;
-  --text-secondary: #d1d1ca;
-  --text-muted: #a0a098;
-  --text-dimmer: #686861;
-  --accent: #7776ff;
-  --accent-hover: #8786ff;
-  --border: #393934;
-  --border-subtle: #252522;
-  --overlay-rgb: 255, 255, 255;
-  --shadow-rgb: 0, 0, 0;
-  color-scheme: dark;
-}
-
 /* Terminal header with tabs */
 .terminal-header {
   display: flex;
@@ -2096,8 +2077,8 @@
   align-items: center;
   gap: 6px;
   padding: 6px 8px;
-  background: #252525;
-  border-bottom: 1px solid #333;
+  background: var(--bg-alt);
+  border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
@@ -2113,9 +2094,9 @@
   min-width: 40px;
   padding: 0 10px;
   border-radius: 6px;
-  border: 1px solid #444;
-  background: #333;
-  color: #d4d4d4;
+  border: 1px solid var(--border);
+  background: var(--sidebar-active);
+  color: var(--text-secondary);
   font-family: "Roboto Mono", monospace;
   font-size: 12px;
   font-weight: 500;
@@ -2127,8 +2108,8 @@
 }
 
 .term-key:active {
-  background: #555;
-  border-color: #666;
+  background: var(--sidebar-hover);
+  border-color: var(--text-dimmer);
 }
 
 .term-key-toggle.active {

--- a/lib/public/css/filebrowser.css
+++ b/lib/public/css/filebrowser.css
@@ -259,6 +259,11 @@
 
 .file-tree-item:hover { background: var(--sidebar-hover); color: var(--text); }
 .file-tree-item.active { background: var(--sidebar-active); color: var(--text); }
+.file-tree-item.context-open {
+  background: var(--sidebar-active);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
 /* Keyboard focus ring (arrow-key navigation) — separate from .active
    so the currently-opened file stays visually marked even while the
    user is exploring elsewhere with the arrows. */
@@ -322,6 +327,65 @@
   padding: 12px 16px;
   font-size: 12px;
   color: var(--error);
+}
+
+/* --- File tree context menu --- */
+.file-tree-context-menu {
+  position: fixed;
+  z-index: 10040;
+  min-width: 164px;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--sidebar-bg);
+  box-shadow: 0 12px 34px rgba(var(--shadow-rgb), 0.34);
+  animation: file-tree-context-in 0.12s ease-out both;
+}
+
+.file-tree-context-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.file-tree-context-item:hover,
+.file-tree-context-item:focus-visible {
+  outline: none;
+  background: rgba(var(--overlay-rgb), 0.06);
+  color: var(--text);
+}
+
+.file-tree-context-item .lucide {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.file-tree-context-separator {
+  height: 1px;
+  margin: 4px 5px;
+  background: var(--border-subtle);
+}
+
+@keyframes file-tree-context-in {
+  from { opacity: 0; transform: translateY(-3px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .file-tree-context-menu { animation: none; }
 }
 
 /* --- Panel fullscreen --- */
@@ -1695,6 +1759,51 @@
   padding: 0;
 }
 
+.file-viewer-large-text {
+  min-height: 100%;
+}
+
+.file-viewer-large-notice {
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: fit-content;
+  margin: 10px 12px 0;
+  padding: 6px 9px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--bg) 92%, var(--accent));
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.file-viewer-large-notice svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.file-viewer-large-text pre {
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+  padding: 12px 14px;
+  box-sizing: border-box;
+  white-space: pre;
+  tab-size: 2;
+}
+
+.file-viewer-large-text code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
 .file-viewer-binary {
   display: flex;
   align-items: center;
@@ -1741,6 +1850,25 @@
 }
 
 /* --- Web Terminal --- */
+
+/* Terminal chrome intentionally stays on Clay Studio Dark. These local
+   tokens isolate it from the workspace theme without changing user settings. */
+#terminal-container,
+.terminal-tab-ctx {
+  --bg: #171715;
+  --bg-alt: #20201d;
+  --text: #e8e8e2;
+  --text-secondary: #d1d1ca;
+  --text-muted: #a0a098;
+  --text-dimmer: #686861;
+  --accent: #7776ff;
+  --accent-hover: #8786ff;
+  --border: #393934;
+  --border-subtle: #252522;
+  --overlay-rgb: 255, 255, 255;
+  --shadow-rgb: 0, 0, 0;
+  color-scheme: dark;
+}
 
 /* Terminal header with tabs */
 .terminal-header {
@@ -1948,6 +2076,7 @@
   min-height: 0;
   overflow: hidden;
   position: relative;
+  background: #141412;
 }
 
 .terminal-tab-body {

--- a/lib/public/css/tui-attention.css
+++ b/lib/public/css/tui-attention.css
@@ -5,9 +5,7 @@
    #main-area's existing border-left so the line reads as one
    continuous edge with the rest of the chrome. */
 #tui-session-host {
-  --border-subtle: #252522;
   border-left: 1px solid var(--border-subtle);
-  color-scheme: dark;
 }
 
 /* Lazy-resume bar: shown in place of the composer when a born-TUI session is
@@ -282,22 +280,15 @@ body.tui-suspended #tui-resume-bar {
 }
 .tui-modal-backdrop.hidden { display: none; }
 .tui-modal {
-  --sidebar-bg: #141412;
-  --text: #e8e8e2;
-  --text-secondary: #d1d1ca;
-  --text-dimmer: #686861;
-  --border: #393934;
-  --overlay-rgb: 255, 255, 255;
   width: min(960px, 100%);
   height: min(640px, 100%);
-  background: #000;
+  background: var(--bg);
   border-radius: 12px;
   overflow: hidden;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--border);
   box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
-  color-scheme: dark;
 }
 /* Compact variant for short content (e.g. login wizard): smaller box so the
    terminal hugs the content instead of leaving a tall empty area below. */

--- a/lib/public/css/tui-attention.css
+++ b/lib/public/css/tui-attention.css
@@ -5,7 +5,9 @@
    #main-area's existing border-left so the line reads as one
    continuous edge with the rest of the chrome. */
 #tui-session-host {
+  --border-subtle: #252522;
   border-left: 1px solid var(--border-subtle);
+  color-scheme: dark;
 }
 
 /* Lazy-resume bar: shown in place of the composer when a born-TUI session is
@@ -280,6 +282,12 @@ body.tui-suspended #tui-resume-bar {
 }
 .tui-modal-backdrop.hidden { display: none; }
 .tui-modal {
+  --sidebar-bg: #141412;
+  --text: #e8e8e2;
+  --text-secondary: #d1d1ca;
+  --text-dimmer: #686861;
+  --border: #393934;
+  --overlay-rgb: 255, 255, 255;
   width: min(960px, 100%);
   height: min(640px, 100%);
   background: #000;
@@ -289,6 +297,7 @@ body.tui-suspended #tui-resume-bar {
   flex-direction: column;
   border: 1px solid var(--border);
   box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
+  color-scheme: dark;
 }
 /* Compact variant for short content (e.g. login wizard): smaller box so the
    terminal hugs the content instead of leaving a tall empty area below. */
@@ -683,4 +692,3 @@ body.tui-suspended #tui-resume-bar {
   .wna-content { padding: 32px 20px 80px; }
   .wna-title { font-size: 26px; }
 }
-

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -30,7 +30,7 @@
 (function(){try{var k="clay-theme-vars",v=localStorage.getItem(k),r=document.documentElement;if(v){var o=JSON.parse(v),p;for(p in o)r.style.setProperty(p,o[p]);var vt=localStorage.getItem(k.replace("-vars","-variant"));if(vt==="light"){r.classList.add("light-theme");r.classList.remove("dark-theme")}else{r.classList.add("dark-theme");r.classList.remove("light-theme")}var m=document.querySelector('meta[name="theme-color"]');if(m&&o["--bg"])m.setAttribute("content",o["--bg"])}else{var sl=window.matchMedia&&window.matchMedia("(prefers-color-scheme: light)").matches;if(sl){r.classList.add("light-theme");r.classList.remove("dark-theme")}}}catch(e){}})();
 </script>
 <script>if(window.navigator.standalone||window.matchMedia("(display-mode:standalone)").matches){document.documentElement.classList.add("pwa-standalone")}</script>
-<link rel="stylesheet" href="style.css?v=20260829-terminal-dark1">
+<link rel="stylesheet" href="style.css?v=20260829-terminal-canvas1">
 <style>
 @media(max-width:768px){
   /* User messages: vertical stack, avatar on top, right-aligned */

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -30,7 +30,7 @@
 (function(){try{var k="clay-theme-vars",v=localStorage.getItem(k),r=document.documentElement;if(v){var o=JSON.parse(v),p;for(p in o)r.style.setProperty(p,o[p]);var vt=localStorage.getItem(k.replace("-vars","-variant"));if(vt==="light"){r.classList.add("light-theme");r.classList.remove("dark-theme")}else{r.classList.add("dark-theme");r.classList.remove("light-theme")}var m=document.querySelector('meta[name="theme-color"]');if(m&&o["--bg"])m.setAttribute("content",o["--bg"])}else{var sl=window.matchMedia&&window.matchMedia("(prefers-color-scheme: light)").matches;if(sl){r.classList.add("light-theme");r.classList.remove("dark-theme")}}}catch(e){}})();
 </script>
 <script>if(window.navigator.standalone||window.matchMedia("(display-mode:standalone)").matches){document.documentElement.classList.add("pwa-standalone")}</script>
-<link rel="stylesheet" href="style.css?v=20260829-imagegen3">
+<link rel="stylesheet" href="style.css?v=20260829-terminal-dark1">
 <style>
 @media(max-width:768px){
   /* User messages: vertical stack, avatar on top, right-aligned */
@@ -2282,7 +2282,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0/lib/addon-fit.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0/lib/addon-web-links.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-webgl@0/lib/addon-webgl.min.js"></script>
-<script type="module" src="app.js?v=20260829-imagegen3"></script>
+<script type="module" src="app.js?v=20260829-terminal-dark1"></script>
 <div id="pwa-install-modal" class="pwa-modal hidden">
   <div class="pwa-modal-backdrop"></div>
   <div class="pwa-modal-card">

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -703,6 +703,7 @@
           <button class="file-viewer-btn file-viewer-slide-level hidden" id="file-viewer-slide-level" title="Split slides by heading level" aria-haspopup="menu" aria-expanded="false"><span>H1</span><i data-lucide="chevron-down"></i></button>
           <button class="file-viewer-btn hidden" id="file-viewer-history" title="Edit history"><i data-lucide="clock"></i></button>
           <button class="file-viewer-btn" id="file-viewer-refresh" title="Refresh"><i data-lucide="refresh-cw"></i></button>
+          <button class="file-viewer-btn" id="file-viewer-download" title="Download file" aria-label="Download file"><i data-lucide="download"></i></button>
           <button class="file-viewer-btn" id="file-viewer-copy" title="Copy contents" aria-label="Copy contents"><i data-lucide="copy"></i></button>
           <button class="file-viewer-btn hidden" id="file-viewer-copy-formatted" title="Copy Markdown formatting" aria-label="Copy Markdown formatting"><i data-lucide="clipboard-copy"></i></button>
         </div>

--- a/lib/public/modules/filebrowser-context-menu.js
+++ b/lib/public/modules/filebrowser-context-menu.js
@@ -1,0 +1,148 @@
+// File-tree context menu and shared file download action.
+
+import { iconHtml, refreshIcons } from './icons.js';
+import { insertTextAtCursor } from './input.js';
+import { copyToClipboard, showToast } from './utils.js';
+
+var MAX_COPY_CONTENT_BYTES = 1024 * 1024;
+
+function closeFileContextMenu() {
+  var menu = document.getElementById('file-tree-context-menu');
+  if (menu) menu.remove();
+  var activeRows = document.querySelectorAll('.file-tree-item.context-open');
+  for (var i = 0; i < activeRows.length; i++) activeRows[i].classList.remove('context-open');
+}
+
+export function downloadProjectFile(filePath) {
+  if (!filePath) return;
+  var link = document.createElement('a');
+  link.href = 'api/file/download?path=' + encodeURIComponent(filePath);
+  link.download = filePath.split('/').pop() || 'download';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}
+
+function copyProjectFileContents(filePath) {
+  var url = 'api/file/download?path=' + encodeURIComponent(filePath);
+  fetch(url, { credentials: 'same-origin', cache: 'no-store' })
+    .then(function (response) {
+      if (!response.ok) throw new Error('Could not read file');
+      var contentLength = parseInt(response.headers.get('content-length') || '0', 10);
+      if (contentLength > MAX_COPY_CONTENT_BYTES) {
+        if (response.body && response.body.cancel) response.body.cancel();
+        throw new Error('File is too large to copy');
+      }
+      return response.arrayBuffer();
+    })
+    .then(function (buffer) {
+      if (buffer.byteLength > MAX_COPY_CONTENT_BYTES) throw new Error('File is too large to copy');
+      var bytes = new Uint8Array(buffer);
+      for (var i = 0; i < bytes.length; i++) {
+        if (bytes[i] === 0) throw new Error('Binary files cannot be copied as text');
+      }
+      var decoder = new TextDecoder('utf-8', { fatal: true });
+      var text;
+      try { text = decoder.decode(buffer); } catch (e) { throw new Error('Binary files cannot be copied as text'); }
+      return copyToClipboard(text);
+    })
+    .catch(function (error) {
+      var message = error && error.message ? error.message : 'Could not copy file contents';
+      showToast(message, 'error');
+    });
+}
+
+function menuItem(icon, label, handler) {
+  var item = document.createElement('button');
+  item.type = 'button';
+  item.className = 'file-tree-context-item';
+  item.setAttribute('role', 'menuitem');
+  item.innerHTML = iconHtml(icon) + '<span>' + label + '</span>';
+  item.addEventListener('click', handler);
+  return item;
+}
+
+function positionMenu(menu, clientX, clientY) {
+  var edge = 8;
+  var rect = menu.getBoundingClientRect();
+  var left = Math.max(edge, Math.min(clientX, window.innerWidth - rect.width - edge));
+  var top = Math.max(edge, Math.min(clientY, window.innerHeight - rect.height - edge));
+  menu.style.left = left + 'px';
+  menu.style.top = top + 'px';
+}
+
+function showFileContextMenu(event, row) {
+  closeFileContextMenu();
+  row.classList.add('context-open');
+
+  var menu = document.createElement('div');
+  menu.id = 'file-tree-context-menu';
+  menu.className = 'file-tree-context-menu';
+  menu.setAttribute('role', 'menu');
+  menu.setAttribute('aria-label', 'File actions');
+
+  var mention = menuItem('at-sign', 'Mention in chat', function (clickEvent) {
+    clickEvent.stopPropagation();
+    var filePath = row.dataset.path;
+    closeFileContextMenu();
+    insertTextAtCursor(filePath + ' ');
+  });
+  menu.appendChild(mention);
+
+  var copyPath = menuItem('copy', 'Copy path', function (clickEvent) {
+    clickEvent.stopPropagation();
+    var filePath = row.dataset.path;
+    closeFileContextMenu();
+    copyToClipboard(filePath).catch(function () { showToast('Could not copy path', 'error'); });
+  });
+  menu.appendChild(copyPath);
+
+  var copyContents = menuItem('clipboard-copy', 'Copy contents', function (clickEvent) {
+    clickEvent.stopPropagation();
+    var filePath = row.dataset.path;
+    closeFileContextMenu();
+    copyProjectFileContents(filePath);
+  });
+  menu.appendChild(copyContents);
+
+  var separator = document.createElement('div');
+  separator.className = 'file-tree-context-separator';
+  separator.setAttribute('role', 'separator');
+  menu.appendChild(separator);
+
+  var download = menuItem('download', 'Download', function (clickEvent) {
+    clickEvent.stopPropagation();
+    var filePath = row.dataset.path;
+    closeFileContextMenu();
+    downloadProjectFile(filePath);
+  });
+  menu.appendChild(download);
+  document.body.appendChild(menu);
+  refreshIcons(menu);
+  positionMenu(menu, event.clientX, event.clientY);
+  try { mention.focus({ preventScroll: true }); } catch (e) { mention.focus(); }
+}
+
+export function initFileBrowserContextMenu(treeEl) {
+  if (!treeEl || treeEl.dataset.contextMenuReady === 'true') return;
+  treeEl.dataset.contextMenuReady = 'true';
+
+  treeEl.addEventListener('contextmenu', function (event) {
+    var row = event.target && event.target.closest ? event.target.closest('.file-tree-item') : null;
+    if (!row || !treeEl.contains(row) || row.dataset.entryType !== 'file' || !row.dataset.path) return;
+    event.preventDefault();
+    event.stopPropagation();
+    showFileContextMenu(event, row);
+  });
+
+  document.addEventListener('pointerdown', function (event) {
+    var menu = document.getElementById('file-tree-context-menu');
+    if (menu && !menu.contains(event.target)) closeFileContextMenu();
+  });
+  document.addEventListener('keydown', function (event) {
+    if (event.key === 'Escape') closeFileContextMenu();
+  });
+  window.addEventListener('resize', closeFileContextMenu);
+  window.addEventListener('blur', closeFileContextMenu);
+  treeEl.addEventListener('scroll', closeFileContextMenu, { passive: true });
+}

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -180,6 +180,16 @@ export function initFileBrowser(_ctx) {
     });
   });
 
+  document.getElementById("file-viewer-download").addEventListener("click", function () {
+    if (!currentFilePath) return;
+    var link = document.createElement("a");
+    link.href = "api/file/download?path=" + encodeURIComponent(currentFilePath);
+    link.download = currentFilePath.split("/").pop() || "download";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  });
+
   // Markdown render toggle
   document.getElementById("file-viewer-render").addEventListener("click", function () {
     if (!currentContent || (!currentIsMarkdown && !currentIsSvg)) return;

--- a/lib/public/modules/filebrowser.js
+++ b/lib/public/modules/filebrowser.js
@@ -10,6 +10,7 @@ import { animateMarkdownChange, beginMarkdownPresentation, cancelMarkdownFollow,
 import { store } from './store.js';
 import { enterMarkdownSlides, exitMarkdownSlides, handleMarkdownSlideKey, syncMarkdownSlidesButton, toggleMarkdownSlideLevelMenu } from './markdown-slides.js';
 import { initFileViewerTabs, openFileViewerTab, previewFileViewerTab, updateFileViewerTab, closeFileViewerTab, focusedFileViewerTab, clearFileViewerTabs } from './filebrowser-tabs.js';
+import { initFileBrowserContextMenu, downloadProjectFile } from './filebrowser-context-menu.js';
 
 var ctx;
 var showDropHint = function () {};
@@ -29,6 +30,7 @@ var gitDiffCache = {};       // hash -> diff text
 var pendingGitDiff = null;   // callback for pending git diff
 var fileAtCache = {};        // hash -> file content
 var pendingFileAt = null;    // callback for pending file-at
+var FILE_RICH_PREVIEW_MAX_BYTES = 1024 * 1024;
 
 export function initFileBrowser(_ctx) {
   ctx = _ctx;
@@ -55,6 +57,7 @@ export function initFileBrowser(_ctx) {
   // collapses/expands folders and ascends/descends into them. The tree
   // gets a tabindex so it can receive focus and keydown events.
   if (ctx.fileTreeEl) {
+    initFileBrowserContextMenu(ctx.fileTreeEl);
     ctx.fileTreeEl.setAttribute('tabindex', '0');
     ctx.fileTreeEl.addEventListener('keydown', handleTreeKeyDown);
     // When the user clicks any tree row, promote it to keyboard focus
@@ -182,12 +185,7 @@ export function initFileBrowser(_ctx) {
 
   document.getElementById("file-viewer-download").addEventListener("click", function () {
     if (!currentFilePath) return;
-    var link = document.createElement("a");
-    link.href = "api/file/download?path=" + encodeURIComponent(currentFilePath);
-    link.download = currentFilePath.split("/").pop() || "download";
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
+    downloadProjectFile(currentFilePath);
   });
 
   // Markdown render toggle
@@ -764,6 +762,7 @@ function renderFilteredTree(container, tree, depth, query) {
 
     var row = document.createElement("div");
     row.className = "file-tree-item" + (isDir ? " expanded" : "");
+    row.dataset.entryType = isDir ? "dir" : "file";
     row.style.paddingLeft = (8 + depth * 16) + "px";
     if (entry) {
       row.draggable = true;
@@ -982,6 +981,7 @@ function renderEntries(container, entries, depth) {
     var entry = sorted[i];
     var row = document.createElement("div");
     row.className = "file-tree-item";
+    row.dataset.entryType = entry.type;
     row.style.paddingLeft = (8 + depth * 16) + "px";
 
     row.draggable = true;
@@ -1089,6 +1089,7 @@ function showFileContent(msg) {
   var previousContent = currentContent;
   var previousPath = currentFilePath;
   var previousWasMarkdown = currentIsMarkdown;
+  var lightweightPreview = false;
   var refreshSlideIndex = pendingRefresh && store.get('markdownSlidesActive')
     ? store.get('markdownSlideIndex') || 0
     : null;
@@ -1126,8 +1127,10 @@ function showFileContent(msg) {
   } else {
     currentContent = msg.content;
     var ext = requestedExt;
-    currentIsMarkdown = (ext === "md" || ext === "mdx");
-    currentIsSvg = ext === "svg";
+    lightweightPreview = (msg.size || 0) > FILE_RICH_PREVIEW_MAX_BYTES;
+    currentIsMarkdown = !lightweightPreview && (ext === "md" || ext === "mdx");
+    currentIsSvg = !lightweightPreview && ext === "svg";
+    if (lightweightPreview) isRendered = false;
     if (pendingRenderedOpen && currentIsMarkdown) isRendered = true;
 
     if (currentIsMarkdown || currentIsSvg) {
@@ -1139,7 +1142,9 @@ function showFileContent(msg) {
     }
 
     // Markdown starts as source; SVG starts as a safe image preview.
-    if (currentIsMarkdown) {
+    if (lightweightPreview) {
+      renderLargeTextFile(bodyEl, msg.content, msg.size);
+    } else if (currentIsMarkdown) {
       var transitionFrom = keepRenderState && prevRendered && previousWasMarkdown &&
         isFollowingMarkdown(msg.path) && pathsReferToSameFile(previousPath, msg.path)
         ? (previousContent == null ? "" : previousContent)
@@ -1159,7 +1164,9 @@ function showFileContent(msg) {
   refreshIcons();
 
   // If opened with a diff request, show full-file split diff in wide mode
-  if (pendingOpenMode && pendingOpenMode.type === "diff" && currentContent != null) {
+  if (pendingOpenMode && lightweightPreview) {
+    pendingOpenMode = null;
+  } else if (pendingOpenMode && pendingOpenMode.type === "diff" && currentContent != null) {
     var diffOpts = pendingOpenMode;
     pendingOpenMode = null;
     historyVisible = false;
@@ -1452,6 +1459,26 @@ function renderCodeWithLineNumbers(bodyEl, content, ext) {
   if (typeof hljs !== "undefined" && lang) {
     hljs.highlightElement(codeEl);
   }
+}
+
+function renderLargeTextFile(bodyEl, content, size) {
+  var viewer = document.createElement("div");
+  viewer.className = "file-viewer-large-text";
+
+  var notice = document.createElement("div");
+  notice.className = "file-viewer-large-notice";
+  notice.innerHTML = iconHtml("file-text") +
+    "<span>Large file (" + formatSize(size || 0) + ") — showing plain text for performance</span>";
+
+  var codeWrap = document.createElement("pre");
+  var codeEl = document.createElement("code");
+  codeEl.textContent = content;
+  codeWrap.appendChild(codeEl);
+
+  viewer.appendChild(notice);
+  viewer.appendChild(codeWrap);
+  bodyEl.innerHTML = "";
+  bodyEl.appendChild(viewer);
 }
 
 function formatSize(bytes) {

--- a/lib/public/modules/input.js
+++ b/lib/public/modules/input.js
@@ -428,7 +428,7 @@ function extractFilePaths(cd) {
 }
 
 // --- Insert text at cursor in textarea ---
-function insertTextAtCursor(text) {
+export function insertTextAtCursor(text) {
   var el = ctx.inputEl;
   el.focus();
   var start = el.selectionStart;

--- a/lib/public/modules/session-tui-view.js
+++ b/lib/public/modules/session-tui-view.js
@@ -23,9 +23,8 @@ import { attachTuiGrab, detachTuiGrab } from './tui-grab.js';
 import { createKeyToolbar, TERMINAL_TOOLBAR_HTML } from './terminal-toolbar.js';
 import { refreshIcons, iconHtml } from './icons.js';
 
-// Claude TUI session terminal colors follow Clay's active theme via
-// getTerminalTheme(). Live theme switches are wired through
-// setTuiSessionTheme() below, which theme.js calls from applyTheme.
+// Claude TUI sessions always use Clay Studio Dark via getTerminalTheme().
+// Theme switches reapply that fixed palette through setTuiSessionTheme().
 
 var hostEl = null;       // container div mounted over #messages
 var xtermContainerEl = null;

--- a/lib/public/modules/theme.js
+++ b/lib/public/modules/theme.js
@@ -262,7 +262,7 @@ export function getComputedVar(varName) {
 }
 
 export function getTerminalTheme() {
-  return computeTerminalTheme(getCurrentTheme());
+  return computeTerminalTheme(getTheme(DEFAULT_DARK_THEME_ID) || defaultDarkFallback);
 }
 
 export function getMermaidThemeVars() {
@@ -305,7 +305,9 @@ export function applyTheme(themeId, fromPicker) {
 
   try { updateMascotSvgs(vars, isLight); } catch (e) {}
 
-  var termTheme = computeTerminalTheme(theme);
+  // Terminals deliberately keep Clay Studio Dark for predictable ANSI
+  // contrast, even while the surrounding workspace uses a light theme.
+  var termTheme = getTerminalTheme();
   try { setTerminalTheme(termTheme); } catch (e) {}
   try { setTuiSessionTheme(termTheme); } catch (e) {}
   try { setTuiAttentionTheme(termTheme); } catch (e) {}

--- a/lib/public/modules/tui-attention.js
+++ b/lib/public/modules/tui-attention.js
@@ -16,9 +16,9 @@
 import { getTerminalTheme } from './theme.js';
 import { getTerminalFontFamily, getTerminalFontSize, onTerminalFontChange } from './terminal-prefs.js';
 
-// TUI attention modal xterm follows Clay's active theme via
-// getTerminalTheme() and live-updates through setTuiAttentionTheme()
-// which theme.js calls from applyTheme.
+// The TUI attention modal always uses Clay Studio Dark via
+// getTerminalTheme(). Theme switches reapply that fixed palette through
+// setTuiAttentionTheme(), which theme.js calls from applyTheme().
 
 var modalEl = null;
 var modalXterm = null;
@@ -266,9 +266,8 @@ export function tuiModalHandleTermResized() { return false; }
 export function tuiModalHandleTermExited() { return false; }
 export function tuiModalHandleTermClosed() { return false; }
 
-// Live theme update for the attention modal. Called by theme.js when
-// the user switches themes. Also retints the surrounding modal chrome
-// so the frame doesn't stay black when a light theme is active.
+// Theme update hook for the attention modal. The supplied palette remains
+// Clay Studio Dark even when the surrounding workspace switches themes.
 export function setTuiAttentionTheme(xtermTheme) {
   if (modalXterm) {
     try { modalXterm.options.theme = xtermTheme; } catch (e) {}

--- a/lib/public/modules/tui-attention.js
+++ b/lib/public/modules/tui-attention.js
@@ -275,8 +275,6 @@ export function setTuiAttentionTheme(xtermTheme) {
   if (modalEl && xtermTheme && xtermTheme.background) {
     var bodyEl = modalEl.querySelector(".tui-modal-body");
     if (bodyEl) bodyEl.style.background = xtermTheme.background;
-    var frameEl = modalEl.querySelector(".tui-modal");
-    if (frameEl) frameEl.style.background = xtermTheme.background;
   }
 }
 

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -11,7 +11,7 @@
 @import url("css/generated-images.css?v=20260829c");
 @import url("css/rewind.css");
 @import url("css/input.css?v=20260828-composer-depth1");
-@import url("css/filebrowser.css?v=20260829-terminal-dark1");
+@import url("css/filebrowser.css?v=20260829-terminal-canvas1");
 @import url("css/git-panel.css");
 @import url("css/diff.css");
 @import url("css/highlight.css");
@@ -36,5 +36,5 @@
 @import url("css/mention.css");
 @import url("css/debate.css");
 @import url("css/notifications-center.css");
-@import url("css/tui-attention.css?v=20260829-terminal-dark1");
+@import url("css/tui-attention.css?v=20260829-terminal-canvas1");
 @import url("css/pwa-mobile.css?v=20260824f");

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -11,7 +11,7 @@
 @import url("css/generated-images.css?v=20260829c");
 @import url("css/rewind.css");
 @import url("css/input.css?v=20260828-composer-depth1");
-@import url("css/filebrowser.css?v=20260828-workbench4");
+@import url("css/filebrowser.css?v=20260829-terminal-dark1");
 @import url("css/git-panel.css");
 @import url("css/diff.css");
 @import url("css/highlight.css");
@@ -36,5 +36,5 @@
 @import url("css/mention.css");
 @import url("css/debate.css");
 @import url("css/notifications-center.css");
-@import url("css/tui-attention.css");
+@import url("css/tui-attention.css?v=20260829-terminal-dark1");
 @import url("css/pwa-mobile.css?v=20260824f");

--- a/test/filebrowser-download.test.js
+++ b/test/filebrowser-download.test.js
@@ -87,8 +87,28 @@ test("file browser download enforces the file browser permission", function () {
 test("file viewer exposes a download action for the open file", function () {
   var html = fs.readFileSync(path.join(__dirname, "../lib/public/index.html"), "utf8");
   var fileBrowser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+  var contextMenu = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser-context-menu.js"), "utf8");
 
   assert.match(html, /id="file-viewer-download"[^>]*title="Download file"/);
-  assert.match(fileBrowser, /api\/file\/download\?path=/);
-  assert.match(fileBrowser, /encodeURIComponent\(currentFilePath\)/);
+  assert.match(fileBrowser, /downloadProjectFile\(currentFilePath\)/);
+  assert.match(contextMenu, /api\/file\/download\?path=/);
+  assert.match(contextMenu, /encodeURIComponent\(filePath\)/);
+});
+
+test("file rows expose a right-click download context menu", function () {
+  var fileBrowser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+  var contextMenu = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser-context-menu.js"), "utf8");
+
+  assert.match(fileBrowser, /initFileBrowserContextMenu\(ctx\.fileTreeEl\)/);
+  assert.match(fileBrowser, /row\.dataset\.entryType = entry\.type/);
+  assert.match(contextMenu, /addEventListener\('contextmenu'/);
+  assert.match(contextMenu, /row\.dataset\.entryType !== 'file'/);
+  assert.match(contextMenu, /'Mention in chat'/);
+  assert.match(contextMenu, /insertTextAtCursor\(filePath \+ ' '\)/);
+  assert.match(contextMenu, /'Copy path'/);
+  assert.match(contextMenu, /copyToClipboard\(filePath\)/);
+  assert.match(contextMenu, /'Copy contents'/);
+  assert.match(contextMenu, /MAX_COPY_CONTENT_BYTES/);
+  assert.match(contextMenu, /TextDecoder\('utf-8', \{ fatal: true \}\)/);
+  assert.match(contextMenu, /'Download'/);
 });

--- a/test/filebrowser-download.test.js
+++ b/test/filebrowser-download.test.js
@@ -1,0 +1,94 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+var { attachHTTP } = require("../lib/project-http");
+var usersModule = require("../lib/users");
+
+function createResponse() {
+  return {
+    status: null,
+    headers: null,
+    body: null,
+    writeHead: function (status, headers) {
+      this.status = status;
+      this.headers = headers || {};
+    },
+    end: function (body) {
+      this.body = body;
+    },
+  };
+}
+
+function createHandler(allowedPath, filePath) {
+  return attachHTTP({
+    cwd: path.dirname(filePath),
+    project: "Test",
+    sm: { sessions: new Map() },
+    osUsers: null,
+    safePath: function (cwd, requestedPath) {
+      return requestedPath === allowedPath ? filePath : null;
+    },
+    safeAbsPath: function () { return null; },
+    getOsUserInfoForReq: function () { return null; },
+    _browserTabList: {},
+  }).handleHTTP;
+}
+
+function createRequest() {
+  return { method: "GET", _clayUser: { role: "admin" } };
+}
+
+test("file browser download returns the selected file as an attachment", function () {
+  var requestedPath = "docs/filebrowser-download.test.js";
+  var handler = createHandler(requestedPath, __filename);
+  var response = createResponse();
+
+  var handled = handler(
+    createRequest(),
+    response,
+    "/api/file/download?path=" + encodeURIComponent(requestedPath)
+  );
+
+  assert.equal(handled, true);
+  assert.equal(response.status, 200);
+  assert.equal(response.headers["Content-Type"], "application/octet-stream");
+  assert.match(response.headers["Content-Disposition"], /^attachment; filename="filebrowser-download\.test\.js"/);
+  assert.deepEqual(response.body, fs.readFileSync(__filename));
+});
+
+test("file browser download rejects paths outside the project", function () {
+  var handler = createHandler("allowed.txt", __filename);
+  var response = createResponse();
+
+  handler(createRequest(), response, "/api/file/download?path=..%2Fsecret.txt");
+
+  assert.equal(response.status, 403);
+  assert.equal(response.body, "Access denied");
+});
+
+test("file browser download enforces the file browser permission", function () {
+  var originalIsMultiUser = usersModule.isMultiUser;
+  usersModule.isMultiUser = function () { return true; };
+  try {
+    var handler = createHandler("allowed.txt", __filename);
+    var response = createResponse();
+    var request = { method: "GET", _clayUser: { role: "user", permissions: { fileBrowser: false } } };
+
+    handler(request, response, "/api/file/download?path=allowed.txt");
+
+    assert.equal(response.status, 403);
+    assert.equal(response.body, "File browser access is not permitted");
+  } finally {
+    usersModule.isMultiUser = originalIsMultiUser;
+  }
+});
+
+test("file viewer exposes a download action for the open file", function () {
+  var html = fs.readFileSync(path.join(__dirname, "../lib/public/index.html"), "utf8");
+  var fileBrowser = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+
+  assert.match(html, /id="file-viewer-download"[^>]*title="Download file"/);
+  assert.match(fileBrowser, /api\/file\/download\?path=/);
+  assert.match(fileBrowser, /encodeURIComponent\(currentFilePath\)/);
+});

--- a/test/filebrowser-large-file.test.js
+++ b/test/filebrowser-large-file.test.js
@@ -1,0 +1,62 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var { attachFilesystem } = require("../lib/project-filesystem");
+
+test("file browser reads text files larger than the live preview limit", function () {
+  var tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "clay-large-file-"));
+  var filePath = path.join(tempDir, "large.txt");
+  var content = "x".repeat(768 * 1024);
+  var response = null;
+  fs.writeFileSync(filePath, content);
+
+  try {
+    var filesystem = attachFilesystem({
+      cwd: tempDir,
+      slug: "test",
+      osUsers: null,
+      sm: { sessions: new Map() },
+      send: function () {},
+      sendTo: function (ws, msg) { response = msg; },
+      safePath: function (cwd, requestedPath) {
+        return requestedPath === "large.txt" ? filePath : null;
+      },
+      safeAbsPath: function () { return null; },
+      getOsUserInfoForWs: function () { return null; },
+      startFileWatch: function () {},
+      stopFileWatch: function () {},
+      startDirWatch: function () {},
+      usersModule: { getEffectivePermissions: function () { return { fileBrowser: true }; } },
+      fsAsUser: function () {},
+      validateEnvString: function () {},
+      opts: {},
+      IGNORED_DIRS: new Set(),
+      BINARY_EXTS: new Set(),
+      IMAGE_EXTS: new Set(),
+      FS_MAX_SIZE: 5 * 1024 * 1024,
+    });
+
+    filesystem.handleFilesystemMessage({}, { type: "fs_read", path: "large.txt" });
+
+    assert.equal(response.type, "fs_read_result");
+    assert.equal(response.error, undefined);
+    assert.equal(response.size, content.length);
+    assert.equal(response.content, content);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("large file previews use a separate hard limit and lightweight rendering", function () {
+  var projectSource = fs.readFileSync(path.join(__dirname, "../lib/project.js"), "utf8");
+  var browserSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
+
+  assert.match(projectSource, /var FS_MAX_SIZE = 512 \* 1024;/);
+  assert.match(projectSource, /var FS_VIEWER_MAX_SIZE = 5 \* 1024 \* 1024;/);
+  assert.match(projectSource, /FS_MAX_SIZE: FS_VIEWER_MAX_SIZE/);
+  assert.match(browserSource, /var FILE_RICH_PREVIEW_MAX_BYTES = 1024 \* 1024;/);
+  assert.match(browserSource, /renderLargeTextFile\(bodyEl, msg\.content, msg\.size\)/);
+  assert.match(browserSource, /showing plain text for performance/);
+});

--- a/test/filebrowser-tabs.test.js
+++ b/test/filebrowser-tabs.test.js
@@ -44,7 +44,7 @@ test("document viewer uses an editor tab strip with a separate breadcrumb row", 
 test("document viewer renders SVG files safely with a source toggle", function() {
   var source = fs.readFileSync(path.join(__dirname, "../lib/public/modules/filebrowser.js"), "utf8");
   var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/filebrowser.css"), "utf8");
-  assert.match(source, /currentIsSvg = ext === "svg"/);
+  assert.match(source, /currentIsSvg = !lightweightPreview && ext === "svg"/);
   assert.match(source, /image\.src = "api\/file\?path=" \+ encodeURIComponent\(currentFilePath\)/);
   assert.doesNotMatch(source, /file-viewer-svg-preview[^\n]*currentContent/);
   assert.match(css, /\.file-viewer-svg-preview\s*\{/);

--- a/test/theme-defaults.test.js
+++ b/test/theme-defaults.test.js
@@ -42,9 +42,10 @@ test("terminals always use the Clay Studio Dark palette", function() {
 
   assert.match(source, /getTerminalTheme\(\)[\s\S]*getTheme\(DEFAULT_DARK_THEME_ID\)/);
   assert.match(source, /var termTheme = getTerminalTheme\(\)/);
-  assert.match(terminalCss, /#terminal-container,[\s\S]*--bg: #171715/);
   assert.match(terminalCss, /#terminal-body[\s\S]*background: #141412/);
-  assert.match(tuiCss, /\.tui-modal[\s\S]*--sidebar-bg: #141412/);
+  assert.match(terminalCss, /\.term-toolbar[\s\S]*background: var\(--bg-alt\)/);
+  assert.doesNotMatch(terminalCss, /#terminal-container,\s*\.terminal-tab-ctx/);
+  assert.match(tuiCss, /\.tui-modal[\s\S]*background: var\(--bg\)/);
 });
 
 test("theme selection lives in Appearance settings", function() {

--- a/test/theme-defaults.test.js
+++ b/test/theme-defaults.test.js
@@ -35,6 +35,18 @@ test("Clay Studio themes are the default system-mode pair", function() {
   assert.match(source, /pinFirst\(lightIds, DEFAULT_LIGHT_THEME_ID\)/);
 });
 
+test("terminals always use the Clay Studio Dark palette", function() {
+  var source = read("lib/public/modules/theme.js");
+  var terminalCss = read("lib/public/css/filebrowser.css");
+  var tuiCss = read("lib/public/css/tui-attention.css");
+
+  assert.match(source, /getTerminalTheme\(\)[\s\S]*getTheme\(DEFAULT_DARK_THEME_ID\)/);
+  assert.match(source, /var termTheme = getTerminalTheme\(\)/);
+  assert.match(terminalCss, /#terminal-container,[\s\S]*--bg: #171715/);
+  assert.match(terminalCss, /#terminal-body[\s\S]*background: #141412/);
+  assert.match(tuiCss, /\.tui-modal[\s\S]*--sidebar-bg: #141412/);
+});
+
 test("theme selection lives in Appearance settings", function() {
   var index = read("lib/public/index.html");
   var themeSource = read("lib/public/modules/theme.js");


### PR DESCRIPTION
## Summary
- add a file-tree context menu with mention, copy path, copy contents, and download actions
- reuse the path-safe, permission-checked download endpoint from both the file tree and open-file toolbar
- raise text preview capacity to 5 MB while using lightweight plain-text rendering above 1 MB
- keep xterm canvases on Clay Studio Dark while tabs, headers, modals, and mobile key toolbars follow the workspace theme

## Testing
- `node --test test/filebrowser-download.test.js test/filebrowser-large-file.test.js test/theme-defaults.test.js`
- `node --test --test-name-pattern="document viewer renders SVG files safely" test/filebrowser-tabs.test.js`
- client and server JavaScript syntax checks
- `git diff --check`

## Notes
- the repository test script uses `--test-force-exit`, which is unavailable in the local Node 18.12.1 runtime; focused tests pass locally and CI runs the supported test environment
