### PR TITLE
refactor(ui): remove composer vendor picker

### DIFF
--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -762,7 +762,7 @@
   color: var(--text-muted);
 }
 
-/* --- Bottom toolbar (attach left, model+send right) --- */
+/* --- Bottom toolbar (attach left, session config + send right) --- */
 #input-bottom {
   display: flex;
   align-items: center;
@@ -777,21 +777,7 @@
   flex-shrink: 0;
 }
 
-/* --- Vendor toggle (split toggle) --- */
-#vendor-toggle-wrap {
-  display: flex;
-  align-items: center;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
-  height: 30px;
-  flex-shrink: 0;
-}
-#vendor-toggle-wrap.hidden { display: none; }
-
-/* Compact session-vendor icon shown next to the config-chip when the
-   full vendor-toggle is hidden (because the session's vendor is already
-   committed). Visual only - not clickable. */
+/* Compact committed-session vendor icon next to the config chip. */
 #active-vendor-indicator {
   display: inline-flex;
   align-items: center;
@@ -806,72 +792,12 @@
   border-radius: 4px;
   object-fit: cover;
 }
-#vendor-toggle-wrap.locked {
-  border: none;
-  height: auto;
-  pointer-events: none;
-}
-#vendor-toggle-wrap.locked .vendor-toggle-btn:not(.active) { display: none; }
-#vendor-toggle-wrap.locked .vendor-toggle-btn.active {
-  background: transparent;
-  padding: 0;
-  gap: 0;
-  opacity: 0.7;
-}
-#vendor-toggle-wrap.locked .vendor-toggle-btn.active .vendor-toggle-label { display: none; }
-#vendor-toggle-wrap.locked .vendor-toggle-btn:first-child { border-right: none; }
-.vendor-toggle-btn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 0 10px;
-  height: 100%;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 12px;
-  color: var(--text-secondary);
-  transition: background 0.15s, color 0.15s;
-  white-space: nowrap;
-}
-.vendor-toggle-btn:first-child { border-right: 1px solid var(--border); }
-.vendor-toggle-btn.active {
-  background: var(--accent-12);
-  color: var(--accent);
-  font-weight: 600;
-}
-.vendor-toggle-btn.disabled {
-  opacity: 0.35;
-  cursor: default;
-}
-.vendor-toggle-btn.disabled:not(.active) { display: none; }
-.vendor-toggle-icon {
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
-  object-fit: cover;
-}
-.vendor-toggle-label {
-  pointer-events: none;
-}
-.vendor-toggle-btn.experimental::after,
 .vendor-experimental-badge {
-  content: "🧪";
   font-size: 10px;
   line-height: 1;
   font-weight: 400;
   filter: saturate(0.85);
-}
-.vendor-experimental-badge {
   margin-left: auto;
-}
-@media (min-width: 901px) {
-  .vendor-toggle-btn:not(.active) .vendor-toggle-label { display: none; }
-  .vendor-toggle-btn:not(.active) { padding: 0 8px; }
-}
-@media (max-width: 900px) {
-  .vendor-toggle-label { display: none; }
-  .vendor-toggle-btn { padding: 0 8px; }
 }
 
 /* --- Attach buttons & menu --- */
@@ -1290,7 +1216,6 @@
    Attach (files/images -> path injection) and voice input stay available. */
 body.tui-composer-active #schedule-btn,
 body.tui-composer-active #ask-mate-btn,
-body.tui-composer-active #vendor-toggle-wrap,
 body.tui-composer-active #active-vendor-indicator,
 body.tui-composer-active #config-chip-wrap {
   display: none !important;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -524,48 +524,6 @@
               </div>
             </div>
             <div id="input-bottom-right">
-              <div id="vendor-toggle-wrap">
-                <button id="vendor-btn-claude" class="vendor-toggle-btn active" data-vendor="claude">
-                  <img src="/claude-code-avatar.png" class="vendor-toggle-icon" alt="Claude">
-                  <span class="vendor-toggle-label">Claude Code</span>
-                </button>
-                <button id="vendor-btn-codex" class="vendor-toggle-btn" data-vendor="codex">
-                  <img src="/codex-avatar.png" class="vendor-toggle-icon" alt="Codex">
-                  <span class="vendor-toggle-label">Codex</span>
-                </button>
-                <button id="vendor-btn-antigravity" class="vendor-toggle-btn" data-vendor="antigravity">
-                  <img src="/antigravity-avatar.png" class="vendor-toggle-icon" alt="Antigravity">
-                  <span class="vendor-toggle-label">Antigravity CLI</span>
-                </button>
-                <button id="vendor-btn-opencode" class="vendor-toggle-btn" data-vendor="opencode">
-                  <img src="/opencode-avatar.svg" class="vendor-toggle-icon" alt="OpenCode">
-                  <span class="vendor-toggle-label">OpenCode</span>
-                </button>
-                <button id="vendor-btn-kimi" class="vendor-toggle-btn" data-vendor="kimi">
-                  <img src="/kimi-avatar.svg" class="vendor-toggle-icon" alt="Kimi">
-                  <span class="vendor-toggle-label">Kimi Code</span>
-                </button>
-                <button id="vendor-btn-grok" class="vendor-toggle-btn" data-vendor="grok">
-                  <img src="/grok-avatar.svg" class="vendor-toggle-icon" alt="Grok">
-                  <span class="vendor-toggle-label">Grok Build</span>
-                </button>
-                <button id="vendor-btn-copilot" class="vendor-toggle-btn" data-vendor="copilot">
-                  <img src="/copilot-avatar.svg" class="vendor-toggle-icon" alt="GitHub Copilot">
-                  <span class="vendor-toggle-label">GitHub Copilot CLI</span>
-                </button>
-                <button id="vendor-btn-qwen" class="vendor-toggle-btn" data-vendor="qwen">
-                  <img src="/qwen-avatar.svg" class="vendor-toggle-icon" alt="Qwen">
-                  <span class="vendor-toggle-label">Qwen Code</span>
-                </button>
-                <button id="vendor-btn-junie" class="vendor-toggle-btn" data-vendor="junie">
-                  <img src="/junie-avatar.svg" class="vendor-toggle-icon" alt="Junie">
-                  <span class="vendor-toggle-label">Junie CLI</span>
-                </button>
-                <button id="vendor-btn-kiro" class="vendor-toggle-btn" data-vendor="kiro">
-                  <img src="/kiro-avatar.svg" class="vendor-toggle-icon" alt="Kiro">
-                  <span class="vendor-toggle-label">Kiro CLI</span>
-                </button>
-              </div>
               <div id="active-vendor-indicator" class="hidden" title="Session vendor">
                 <img id="active-vendor-icon" alt="">
               </div>

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -178,17 +178,6 @@ export function processMessage(msg) {
         if (!store.get('sessionIsProcessing')) {
           applyDeadSessionTodoCompaction();
         }
-        // Show the locked vendor toggle only when history exists AND the
-        // vendor isn't already committed. With a committed vendor,
-        // session_switched has already hidden the toggle and shown the
-        // small #active-vendor-indicator; re-showing the locked toggle
-        // here would duplicate the avatar next to the indicator.
-        var _hTotal = store.get('historyTotal') || 0;
-        var _vtw2 = document.getElementById("vendor-toggle-wrap");
-        if (_vtw2 && _hTotal > 0 && !store.get('currentVendor')) {
-          _vtw2.classList.remove("hidden");
-          _vtw2.classList.add("locked");
-        }
         // Restore cached rich context usage BEFORE updateContextPanel runs
         if (msg.contextUsage) {
           store.set({ richContextUsage: msg.contextUsage });
@@ -747,30 +736,9 @@ export function processMessage(msg) {
           selectDefaultVendorForBlankSession();
         }
         if (!msg.model) requestVendorModels(store.get('currentVendor') || "claude", true);
-        // Vendor toggle visibility + active-vendor indicator next to the
-        // model chip.
-        //   - Session has an explicit vendor: hide the toggle (it's
-        //     committed for this conversation) and show a small avatar
-        //     next to the config chip so the user still sees which vendor
-        //     is in use.
-        //   - History without recorded vendor: show locked toggle, no icon
-        //     (we don't know what to render).
-        //   - Brand-new no-vendor session: show toggle, no icon.
-        var _vtw = document.getElementById("vendor-toggle-wrap");
+        // Show the committed session vendor next to the model chip.
         var _avi = document.getElementById("active-vendor-indicator");
         var _avIcon = document.getElementById("active-vendor-icon");
-        if (_vtw) {
-          if (msg.vendor) {
-            _vtw.classList.add("hidden");
-            _vtw.classList.remove("locked");
-          } else if (msg.hasHistory) {
-            _vtw.classList.remove("hidden");
-            _vtw.classList.add("locked");
-          } else {
-            _vtw.classList.remove("locked");
-            _vtw.classList.remove("hidden");
-          }
-        }
         if (_avi && _avIcon) {
           if (msg.vendor && VENDOR_AVATARS[msg.vendor]) {
             _avIcon.src = VENDOR_AVATARS[msg.vendor];

--- a/lib/public/modules/app-panels.js
+++ b/lib/public/modules/app-panels.js
@@ -5,7 +5,6 @@ import { refreshIcons } from "./icons.js";
 import { escapeHtml, showToast } from "./utils.js";
 import { store } from './store.js';
 import { getWs } from './ws-ref.js';
-import { VENDOR_NAMES, isExperimentalVendor } from './app-rendering.js';
 import { reportPaneContext } from './pane-bridge.js';
 import { setupModelPicker, renderModelPicker, requestVendorModels, prepareModelPickerOpen, modelDisplayName } from './model-picker.js';
 
@@ -368,79 +367,8 @@ export function initPanels() {
   configWebsearchSection = $("config-websearch-section");
   configWebsearchBar = $("config-websearch-bar");
 
-  // --- Vendor toggle ---
-  var vendorToggleWrap = $("vendor-toggle-wrap");
-  var vendorBtnClaude = $("vendor-btn-claude");
-  var vendorBtnCodex = $("vendor-btn-codex");
-  var vendorBtnAntigravity = $("vendor-btn-antigravity");
-  var vendorBtnOpenCode = $("vendor-btn-opencode");
-  var vendorBtnKimi = $("vendor-btn-kimi");
-  var vendorBtnGrok = $("vendor-btn-grok");
-  var vendorBtnCopilot = $("vendor-btn-copilot");
-  var vendorBtnQwen = $("vendor-btn-qwen");
-  var vendorBtnJunie = $("vendor-btn-junie");
-  var vendorBtnKiro = $("vendor-btn-kiro");
-  var vendorBtns = {
-    claude: vendorBtnClaude,
-    codex: vendorBtnCodex,
-    antigravity: vendorBtnAntigravity,
-    opencode: vendorBtnOpenCode,
-    kimi: vendorBtnKimi,
-    grok: vendorBtnGrok,
-    copilot: vendorBtnCopilot,
-    qwen: vendorBtnQwen,
-    junie: vendorBtnJunie,
-    kiro: vendorBtnKiro,
-  };
-
-  function updateVendorToggle() {
-    var installed = store.get('installedVendors') || [];
-    var current = store.get('currentVendor') || "claude";
-
-    var vendors = Object.keys(vendorBtns);
-    for (var i = 0; i < vendors.length; i++) {
-      var v = vendors[i];
-      var btn = vendorBtns[v];
-      if (!btn) continue;
-      var isInstalled = installed.indexOf(v) !== -1;
-      btn.classList.toggle("active", v === current);
-      btn.classList.toggle("disabled", !isInstalled);
-      btn.classList.toggle("experimental", isExperimentalVendor(v));
-      var title = isInstalled ? (VENDOR_NAMES[v] || v) : (VENDOR_NAMES[v] || v) + " is not installed";
-      if (isExperimentalVendor(v)) title += " · Experimental integration; not yet validated through direct use testing";
-      btn.title = title;
-    }
-  }
-
-  function onVendorClick(vendor) {
-    if (vendor === (store.get('currentVendor') || "claude")) return;
-    var installed = store.get('installedVendors') || [];
-    if (installed.indexOf(vendor) === -1) return;
-    store.set({ currentVendor: vendor, currentModel: "", currentModels: [], vendorCapabilities: {}, vendorSelectionLocked: true, sessionVendorBound: true });
-    var ws = getWs();
-    if (ws) ws.send(JSON.stringify({ type: "set_vendor", vendor: vendor }));
-  }
-
-  if (vendorBtnClaude) vendorBtnClaude.addEventListener("click", function() { onVendorClick("claude"); });
-  if (vendorBtnCodex) vendorBtnCodex.addEventListener("click", function() { onVendorClick("codex"); });
-  if (vendorBtnAntigravity) vendorBtnAntigravity.addEventListener("click", function() { onVendorClick("antigravity"); });
-  if (vendorBtnOpenCode) vendorBtnOpenCode.addEventListener("click", function() { onVendorClick("opencode"); });
-  if (vendorBtnKimi) vendorBtnKimi.addEventListener("click", function() { onVendorClick("kimi"); });
-  if (vendorBtnGrok) vendorBtnGrok.addEventListener("click", function() { onVendorClick("grok"); });
-  if (vendorBtnCopilot) vendorBtnCopilot.addEventListener("click", function() { onVendorClick("copilot"); });
-  if (vendorBtnQwen) vendorBtnQwen.addEventListener("click", function() { onVendorClick("qwen"); });
-  if (vendorBtnJunie) vendorBtnJunie.addEventListener("click", function() { onVendorClick("junie"); });
-  if (vendorBtnKiro) vendorBtnKiro.addEventListener("click", function() { onVendorClick("kiro"); });
-
   // --- Reactive UI sync ---
   store.subscribe(function (state, prev) {
-    // Vendor toggle state
-    if (state.availableVendors !== prev.availableVendors ||
-        state.installedVendors !== prev.installedVendors ||
-        state.currentVendor !== prev.currentVendor) {
-      updateVendorToggle();
-    }
-
     // richContextUsage changed -> update popover + panel
     if (state.richContextUsage !== prev.richContextUsage) {
       if (state.richContextUsage) {

--- a/lib/public/modules/input.js
+++ b/lib/public/modules/input.js
@@ -78,23 +78,15 @@ export var builtinCommands = [
 
 function commitVendorForTurn() {
   var committedVendor = store.get('currentVendor');
-  var vendorToggle = document.getElementById("vendor-toggle-wrap");
   var activeIndicator = document.getElementById("active-vendor-indicator");
   var activeIcon = document.getElementById("active-vendor-icon");
   if (committedVendor) {
-    if (vendorToggle) {
-      vendorToggle.classList.add("hidden");
-      vendorToggle.classList.remove("locked");
-    }
     if (activeIndicator && activeIcon) {
       activeIcon.src = VENDOR_AVATARS[committedVendor] || VENDOR_AVATARS.claude;
       activeIcon.alt = VENDOR_NAMES[committedVendor] || VENDOR_NAMES.claude;
       activeIndicator.title = (VENDOR_NAMES[committedVendor] || VENDOR_NAMES.claude) + " session";
       activeIndicator.classList.remove("hidden");
     }
-  } else if (vendorToggle) {
-    vendorToggle.classList.remove("hidden");
-    vendorToggle.classList.add("locked");
   }
   store.set({ vendorSelectionLocked: false, sessionHasHistory: true });
 }
@@ -339,8 +331,7 @@ export function sendMessage() {
 
   // First message commits the vendor and bumps the session into
   // has-history state. The server won't re-fire session_switched after a
-  // message, so mirror the vendor-toggle/active-indicator swap locally:
-  // hide the picker, show the small avatar next to the config chip.
+  // message, so show the small vendor avatar next to the config chip.
   // Bumping sessionHasHistory drives in-session lock states (e.g. the
   // Codex model picker that becomes informational once the thread is
   // bound to a model).

--- a/test/vendor-priority.test.js
+++ b/test/vendor-priority.test.js
@@ -39,3 +39,13 @@ test("only vendors without direct use testing are marked experimental", async fu
     assert.strictEqual(vendorPriority.isExperimentalVendor(experimental[j]), true);
   }
 });
+
+test("composer relies on vendor priority instead of a segmented vendor picker", function () {
+  var html = fs.readFileSync(path.join(__dirname, "../lib/public/index.html"), "utf8");
+  var panelSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-panels.js"), "utf8");
+
+  assert.doesNotMatch(html, /id="vendor-toggle-wrap"|class="vendor-toggle-btn/);
+  assert.doesNotMatch(panelSource, /vendor-btn-|updateVendorToggle|onVendorClick/);
+  assert.match(html, /id="config-chip"/);
+  assert.match(html, /id="active-vendor-indicator"/);
+});


### PR DESCRIPTION
## Summary
- remove the segmented vendor picker from the composer
- rely on installed-vendor priority and the new-session vendor menu
- preserve the per-session model/config menu and committed-vendor indicator
- remove obsolete picker state, event, and CSS plumbing

## Testing
- `node --test test/activity-indicator.test.js test/model-picker.test.js test/server-settings-ui.test.js test/vendor-priority.test.js test/worker-proposal-ui.test.js`