### PR TITLE
feat(codex): support inline image generation

### DIFF
--- a/lib/project-image.js
+++ b/lib/project-image.js
@@ -34,7 +34,7 @@ function attachImage(ctx) {
       return hydrated;
     }
     if (!entry.imageRefs) return entry;
-    if (entry.type !== "user_message" && entry.type !== "mention_user" && entry.type !== "user_mention") return entry;
+    if (entry.type !== "user_message" && entry.type !== "mention_user" && entry.type !== "user_mention" && entry.type !== "generated_image") return entry;
     var images = [];
     for (var ri = 0; ri < entry.imageRefs.length; ri++) {
       var ref = entry.imageRefs[ri];

--- a/lib/project.js
+++ b/lib/project.js
@@ -882,6 +882,7 @@ function createProjectContext(opts) {
     scheduleMessage: function (session, text, resetsAt) {
       scheduleMessage(session, text, resetsAt);
     },
+    saveImageFile: saveImageFile,
     getAutoContinueSetting: function (session) {
       // Per-user setting in multi-user mode
       if (usersModule.isMultiUser() && session && session.ownerId) {

--- a/lib/public/css/generated-images.css
+++ b/lib/public/css/generated-images.css
@@ -1,0 +1,124 @@
+.generated-image-card {
+  width: min(640px, calc(100% - 40px));
+  margin: 4px auto 16px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--bg-alt);
+  box-shadow: 0 8px 28px rgba(var(--shadow-rgb), 0.16);
+}
+
+.generated-image-preview {
+  display: grid;
+  place-items: center;
+  min-height: 180px;
+  max-height: 680px;
+  overflow: hidden;
+  background:
+    linear-gradient(45deg, rgba(var(--overlay-rgb), 0.025) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(var(--overlay-rgb), 0.025) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(var(--overlay-rgb), 0.025) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(var(--overlay-rgb), 0.025) 75%);
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+  background-size: 16px 16px;
+}
+
+.generated-image-preview img {
+  display: block;
+  width: 100%;
+  max-height: 680px;
+  object-fit: contain;
+  cursor: zoom-in;
+}
+
+.generated-image-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  min-height: 52px;
+  padding: 9px 10px 9px 14px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.generated-image-meta {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.generated-image-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.generated-image-label .lucide {
+  width: 13px;
+  height: 13px;
+  color: var(--accent);
+}
+
+.generated-image-prompt {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.generated-image-actions {
+  display: flex;
+  flex-shrink: 0;
+  gap: 4px;
+}
+
+.generated-image-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 32px;
+  padding: 0 9px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 11px;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.generated-image-action:hover {
+  border-color: var(--border);
+  background: rgba(var(--overlay-rgb), 0.04);
+  color: var(--text);
+}
+
+.generated-image-action .lucide {
+  width: 14px;
+  height: 14px;
+}
+
+@media (max-width: 560px) {
+  .generated-image-card {
+    width: calc(100% - 24px);
+    border-radius: 12px;
+  }
+
+  .generated-image-action span {
+    display: none;
+  }
+
+  .generated-image-action {
+    width: 32px;
+    justify-content: center;
+    padding: 0;
+  }
+}

--- a/lib/public/css/generated-images.css
+++ b/lib/public/css/generated-images.css
@@ -1,11 +1,114 @@
-.generated-image-card {
-  width: min(640px, calc(100% - 40px));
+.generated-image-row {
+  width: 100%;
+  max-width: var(--content-width);
   margin: 4px auto 16px;
+  padding: 0 20px;
+}
+
+.generated-image-card {
+  width: min(560px, 100%);
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: 14px;
   background: var(--bg-alt);
   box-shadow: 0 8px 28px rgba(var(--shadow-rgb), 0.16);
+}
+
+.generated-image-status {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: min(560px, 100%);
+  min-height: 30px;
+  padding: 0 2px 7px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.generated-image-status .lucide {
+  width: 14px;
+  height: 14px;
+  color: var(--accent);
+  animation: generated-image-sparkle 2.4s ease-in-out infinite;
+}
+
+.generated-image-status-dots::after {
+  content: "";
+  animation: generated-image-ellipsis 1.4s steps(4, end) infinite;
+}
+
+.generated-image-card--pending {
+  position: relative;
+  width: min(560px, 100%);
+  aspect-ratio: 1 / 1;
+  border-color: var(--border-subtle);
+  background: var(--bg-alt);
+  box-shadow: none;
+}
+
+.generated-image-particle-field {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.generated-image-particle-field::before {
+  position: absolute;
+  inset: 11%;
+  content: "";
+  background-image: radial-gradient(circle, var(--text-dimmer) 1.4px, transparent 1.7px);
+  background-position: center;
+  background-size: 25px 25px;
+  opacity: 0.52;
+  -webkit-mask-image: radial-gradient(circle, #000 0%, rgba(0, 0, 0, 0.88) 38%, transparent 72%);
+  mask-image: radial-gradient(circle, #000 0%, rgba(0, 0, 0, 0.88) 38%, transparent 72%);
+  animation: generated-image-field 3.2s ease-in-out infinite;
+}
+
+.generated-image-particle-field::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 36%;
+  aspect-ratio: 1 / 1;
+  border: 1px solid var(--accent-15);
+  border-radius: 50%;
+  content: "";
+  background: radial-gradient(circle, var(--accent-12), transparent 68%);
+  transform: translate(-50%, -50%);
+  animation: generated-image-pulse 3.2s ease-in-out infinite;
+}
+
+@keyframes generated-image-field {
+  0%, 100% { opacity: 0.28; transform: scale(0.92) rotate(-2deg); }
+  50% { opacity: 0.68; transform: scale(1.04) rotate(2deg); }
+}
+
+@keyframes generated-image-pulse {
+  0%, 100% { opacity: 0.2; transform: translate(-50%, -50%) scale(0.72); }
+  50% { opacity: 0.72; transform: translate(-50%, -50%) scale(1.08); }
+}
+
+@keyframes generated-image-sparkle {
+  0%, 100% { opacity: 0.5; transform: scale(0.86) rotate(-8deg); }
+  50% { opacity: 1; transform: scale(1.08) rotate(8deg); }
+}
+
+@keyframes generated-image-ellipsis {
+  0% { content: ""; }
+  25% { content: "."; }
+  50% { content: ".."; }
+  75%, 100% { content: "..."; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .generated-image-status .lucide,
+  .generated-image-status-dots::after,
+  .generated-image-particle-field::before,
+  .generated-image-particle-field::after {
+    animation: none;
+  }
 }
 
 .generated-image-preview {
@@ -107,10 +210,8 @@
 }
 
 @media (max-width: 560px) {
-  .generated-image-card {
-    width: calc(100% - 24px);
-    border-radius: 12px;
-  }
+  .generated-image-row { padding: 0 12px; }
+  .generated-image-card { border-radius: 12px; }
 
   .generated-image-action span {
     display: none;

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -30,7 +30,7 @@
 (function(){try{var k="clay-theme-vars",v=localStorage.getItem(k),r=document.documentElement;if(v){var o=JSON.parse(v),p;for(p in o)r.style.setProperty(p,o[p]);var vt=localStorage.getItem(k.replace("-vars","-variant"));if(vt==="light"){r.classList.add("light-theme");r.classList.remove("dark-theme")}else{r.classList.add("dark-theme");r.classList.remove("light-theme")}var m=document.querySelector('meta[name="theme-color"]');if(m&&o["--bg"])m.setAttribute("content",o["--bg"])}else{var sl=window.matchMedia&&window.matchMedia("(prefers-color-scheme: light)").matches;if(sl){r.classList.add("light-theme");r.classList.remove("dark-theme")}}}catch(e){}})();
 </script>
 <script>if(window.navigator.standalone||window.matchMedia("(display-mode:standalone)").matches){document.documentElement.classList.add("pwa-standalone")}</script>
-<link rel="stylesheet" href="style.css?v=20260829-imagegen1">
+<link rel="stylesheet" href="style.css?v=20260829-imagegen3">
 <style>
 @media(max-width:768px){
   /* User messages: vertical stack, avatar on top, right-aligned */
@@ -2323,7 +2323,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0/lib/addon-fit.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0/lib/addon-web-links.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-webgl@0/lib/addon-webgl.min.js"></script>
-<script type="module" src="app.js?v=20260829-imagegen1"></script>
+<script type="module" src="app.js?v=20260829-imagegen3"></script>
 <div id="pwa-install-modal" class="pwa-modal hidden">
   <div class="pwa-modal-backdrop"></div>
   <div class="pwa-modal-card">

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -30,7 +30,7 @@
 (function(){try{var k="clay-theme-vars",v=localStorage.getItem(k),r=document.documentElement;if(v){var o=JSON.parse(v),p;for(p in o)r.style.setProperty(p,o[p]);var vt=localStorage.getItem(k.replace("-vars","-variant"));if(vt==="light"){r.classList.add("light-theme");r.classList.remove("dark-theme")}else{r.classList.add("dark-theme");r.classList.remove("light-theme")}var m=document.querySelector('meta[name="theme-color"]');if(m&&o["--bg"])m.setAttribute("content",o["--bg"])}else{var sl=window.matchMedia&&window.matchMedia("(prefers-color-scheme: light)").matches;if(sl){r.classList.add("light-theme");r.classList.remove("dark-theme")}}}catch(e){}})();
 </script>
 <script>if(window.navigator.standalone||window.matchMedia("(display-mode:standalone)").matches){document.documentElement.classList.add("pwa-standalone")}</script>
-<link rel="stylesheet" href="style.css?v=20260828-clay-theme1">
+<link rel="stylesheet" href="style.css?v=20260829-imagegen1">
 <style>
 @media(max-width:768px){
   /* User messages: vertical stack, avatar on top, right-aligned */
@@ -2323,7 +2323,7 @@
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0/lib/addon-fit.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0/lib/addon-web-links.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-webgl@0/lib/addon-webgl.min.js"></script>
-<script type="module" src="app.js?v=20260826a"></script>
+<script type="module" src="app.js?v=20260829-imagegen1"></script>
 <div id="pwa-install-modal" class="pwa-modal hidden">
   <div class="pwa-modal-backdrop"></div>
   <div class="pwa-modal-card">

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -46,7 +46,7 @@ import { showImageModal, sendExtensionCommand, handleMcpToolCallMessage } from '
 import { handleMcpServersState } from './mcp-ui.js';
 import { handleShellCommandResult } from './shell-command.js';
 import { handleLoopRegistryUpdated, handleScheduleRunStarted, handleScheduleRunFinished, handleLoopScheduled, isSchedulerOpen, enterCraftingMode, exitCraftingMode, handleLoopRegistryFiles } from './scheduler.js';
-import { renderGeneratedImage } from './generated-images.js';
+import { renderGeneratedImage, renderImageGenerationProgress, clearImageGenerationProgress, clearAllImageGenerationProgress } from './generated-images.js';
 
 // --- App module imports ---
 import { scrollToBottom, addToMessages, addUserMessage, addSystemMessage, removeMatePreThinking, appendDelta, finalizeAssistantBlock, addConflictMessage, addContextOverflowMessage, showSuggestionChips, armStickyBottom, VENDOR_AVATARS, VENDOR_NAMES } from './app-rendering.js';
@@ -997,6 +997,7 @@ export function processMessage(msg) {
         break;
 
       case "tool_executing":
+        if (msg.name === "ImageGen") renderImageGenerationProgress(msg);
         if ((msg.name === "propose_debate" || (msg.name && msg.name.indexOf("propose_debate") !== -1)) && msg.input) {
           var _dpTool = getTools()[msg.id];
           if (_dpTool) {
@@ -1048,6 +1049,7 @@ export function processMessage(msg) {
       case "tool_result": {
           var tr = getTools()[msg.id];
           if (tr && tr.hidden) break; // skip hidden plan tools
+          if (msg.is_error && tr && tr.name === "ImageGen") clearImageGenerationProgress(msg.id);
           // Always call updateToolResult for Edit (to show diff from input), or when content exists
           if (msg.content != null || msg.images || (tr && tr.name === "Edit" && tr.input && tr.input.old_string)) {
             updateToolResult(msg.id, msg.content || "", msg.is_error || false, msg.images);
@@ -1165,6 +1167,7 @@ export function processMessage(msg) {
         stopThinking();
         markAllToolsDone();
         closeToolGroup();
+        clearAllImageGenerationProgress();
         finalizeAssistantBlock();
         addTurnMeta(msg.cost, msg.duration);
         accumulateUsage(msg.cost, msg.usage);

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -46,6 +46,7 @@ import { showImageModal, sendExtensionCommand, handleMcpToolCallMessage } from '
 import { handleMcpServersState } from './mcp-ui.js';
 import { handleShellCommandResult } from './shell-command.js';
 import { handleLoopRegistryUpdated, handleScheduleRunStarted, handleScheduleRunFinished, handleLoopScheduled, isSchedulerOpen, enterCraftingMode, exitCraftingMode, handleLoopRegistryFiles } from './scheduler.js';
+import { renderGeneratedImage } from './generated-images.js';
 
 // --- App module imports ---
 import { scrollToBottom, addToMessages, addUserMessage, addSystemMessage, removeMatePreThinking, appendDelta, finalizeAssistantBlock, addConflictMessage, addContextOverflowMessage, showSuggestionChips, armStickyBottom, VENDOR_AVATARS, VENDOR_NAMES } from './app-rendering.js';
@@ -1059,6 +1060,10 @@ export function processMessage(msg) {
             refreshIfOpen(changedFilePath);
           }
         }
+        break;
+
+      case "generated_image":
+        renderGeneratedImage(msg);
         break;
 
       case "ask_user_answered":

--- a/lib/public/modules/generated-images.js
+++ b/lib/public/modules/generated-images.js
@@ -1,0 +1,81 @@
+// Inline presentation for images produced by Codex ImageGen.
+
+import { refreshIcons, iconHtml } from './icons.js';
+import { showImageModal } from './app-misc.js';
+import { addToMessages, scrollToBottom } from './app-rendering.js';
+
+function fileNameFromImage(image) {
+  if (image.fileName) return image.fileName;
+  try {
+    var url = new URL(image.url, window.location.href);
+    return decodeURIComponent(url.pathname.split('/').pop()) || 'generated-image.png';
+  } catch (e) {
+    return 'generated-image.png';
+  }
+}
+
+function actionButton(icon, label) {
+  var button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'generated-image-action';
+  button.title = label;
+  button.setAttribute('aria-label', label);
+  button.innerHTML = iconHtml(icon) + '<span>' + label + '</span>';
+  return button;
+}
+
+export function renderGeneratedImage(msg) {
+  var image = msg.images && msg.images[0];
+  if (!image || !image.url) return;
+
+  var card = document.createElement('figure');
+  card.className = 'generated-image-card';
+  card.dataset.toolId = msg.id || '';
+
+  var imageWrap = document.createElement('div');
+  imageWrap.className = 'generated-image-preview';
+  var img = document.createElement('img');
+  img.src = image.url;
+  img.alt = msg.prompt ? 'Generated image: ' + msg.prompt : 'Generated image';
+  img.loading = 'lazy';
+  img.addEventListener('click', function () { showImageModal(image.url); });
+  imageWrap.appendChild(img);
+  card.appendChild(imageWrap);
+
+  var footer = document.createElement('figcaption');
+  footer.className = 'generated-image-footer';
+  var meta = document.createElement('div');
+  meta.className = 'generated-image-meta';
+  var label = document.createElement('span');
+  label.className = 'generated-image-label';
+  label.innerHTML = iconHtml('sparkles') + '<span>Generated image</span>';
+  meta.appendChild(label);
+  if (msg.prompt) {
+    var prompt = document.createElement('span');
+    prompt.className = 'generated-image-prompt';
+    prompt.textContent = msg.prompt;
+    prompt.title = msg.prompt;
+    meta.appendChild(prompt);
+  }
+  footer.appendChild(meta);
+
+  var actions = document.createElement('div');
+  actions.className = 'generated-image-actions';
+  var openButton = actionButton('maximize-2', 'Open');
+  openButton.addEventListener('click', function () { showImageModal(image.url); });
+  actions.appendChild(openButton);
+  var downloadLink = document.createElement('a');
+  downloadLink.className = 'generated-image-action';
+  downloadLink.href = image.url;
+  downloadLink.download = fileNameFromImage(image);
+  downloadLink.title = 'Download';
+  downloadLink.setAttribute('aria-label', 'Download');
+  downloadLink.innerHTML = iconHtml('download') + '<span>Download</span>';
+  actions.appendChild(downloadLink);
+  footer.appendChild(actions);
+  card.appendChild(footer);
+
+  addToMessages(card);
+  refreshIcons(card);
+  scrollToBottom();
+}

--- a/lib/public/modules/generated-images.js
+++ b/lib/public/modules/generated-images.js
@@ -24,10 +24,58 @@ function actionButton(icon, label) {
   return button;
 }
 
+function findProgressRow(toolId) {
+  var rows = document.querySelectorAll('.generated-image-row[data-image-tool-id]');
+  for (var i = 0; i < rows.length; i++) {
+    if (rows[i].dataset.imageToolId === String(toolId || '')) return rows[i];
+  }
+  return null;
+}
+
+export function renderImageGenerationProgress(msg) {
+  if (!msg.id || findProgressRow(msg.id)) return;
+
+  var row = document.createElement('div');
+  row.className = 'generated-image-row generated-image-row--pending';
+  row.dataset.imageToolId = msg.id;
+
+  var status = document.createElement('div');
+  status.className = 'generated-image-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  status.innerHTML = iconHtml('sparkles') + '<span>Creating image</span><span class="generated-image-status-dots" aria-hidden="true"></span>';
+  row.appendChild(status);
+
+  var card = document.createElement('div');
+  card.className = 'generated-image-card generated-image-card--pending';
+  card.setAttribute('aria-hidden', 'true');
+  var field = document.createElement('div');
+  field.className = 'generated-image-particle-field';
+  card.appendChild(field);
+  row.appendChild(card);
+
+  addToMessages(row);
+  refreshIcons(row);
+  scrollToBottom();
+}
+
+export function clearImageGenerationProgress(toolId) {
+  var row = findProgressRow(toolId);
+  if (row && row.classList.contains('generated-image-row--pending')) row.remove();
+}
+
+export function clearAllImageGenerationProgress() {
+  var rows = document.querySelectorAll('.generated-image-row--pending');
+  for (var i = 0; i < rows.length; i++) rows[i].remove();
+}
+
 export function renderGeneratedImage(msg) {
   var image = msg.images && msg.images[0];
   if (!image || !image.url) return;
 
+  var row = document.createElement('div');
+  row.className = 'generated-image-row';
+  row.dataset.imageToolId = msg.id || '';
   var card = document.createElement('figure');
   card.className = 'generated-image-card';
   card.dataset.toolId = msg.id || '';
@@ -74,8 +122,11 @@ export function renderGeneratedImage(msg) {
   actions.appendChild(downloadLink);
   footer.appendChild(actions);
   card.appendChild(footer);
+  row.appendChild(card);
 
-  addToMessages(card);
-  refreshIcons(card);
+  var progressRow = findProgressRow(msg.id);
+  if (progressRow) progressRow.replaceWith(row);
+  else addToMessages(row);
+  refreshIcons(row);
   scrollToBottom();
 }

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -8,7 +8,7 @@
 @import url("css/overlays.css?v=20260827-brand3");
 @import url("css/menus.css");
 @import url("css/messages.css?v=20260828-delegated-muted1");
-@import url("css/generated-images.css?v=20260829a");
+@import url("css/generated-images.css?v=20260829c");
 @import url("css/rewind.css");
 @import url("css/input.css?v=20260828-composer-depth1");
 @import url("css/filebrowser.css?v=20260828-workbench4");

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -8,6 +8,7 @@
 @import url("css/overlays.css?v=20260827-brand3");
 @import url("css/menus.css");
 @import url("css/messages.css?v=20260828-delegated-muted1");
+@import url("css/generated-images.css?v=20260829a");
 @import url("css/rewind.css");
 @import url("css/input.css?v=20260828-composer-depth1");
 @import url("css/filebrowser.css?v=20260828-workbench4");

--- a/lib/sdk-bridge.js
+++ b/lib/sdk-bridge.js
@@ -392,6 +392,8 @@ function createSDKBridge(opts) {
     pushModule: pushModule,
     getNotificationsModule: getNotificationsModule,
     adapter: adapter,
+    saveImageFile: opts.saveImageFile,
+    getSessionLinuxUser: getSessionLinuxUser,
     onProcessingChanged: onProcessingChanged,
     onTurnDone: onTurnDone,
     onAutoTitle: function (session) { autoGenerateTitle(session); },

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -18,6 +18,8 @@ function attachMessageProcessor(ctx) {
   var opts = ctx.opts;
   var discoverSkillDirs = ctx.discoverSkillDirs;
   var mergeSkills = ctx.mergeSkills;
+  var saveImageFile = ctx.saveImageFile;
+  var getSessionLinuxUser = ctx.getSessionLinuxUser || function () { return null; };
 
   var AUTO_TITLE_TURN_THRESHOLD = 2;
 
@@ -29,8 +31,19 @@ function attachMessageProcessor(ctx) {
     return null;
   }
 
-  function sendAndRecord(session, obj) {
-    sm.sendAndRecord(session, obj);
+  function sendAndRecord(session, obj, clientObj) {
+    sm.sendAndRecord(session, obj, clientObj);
+  }
+
+  function parseGeneratedImage(parsed) {
+    var data = parsed.data || "";
+    var mediaType = parsed.mediaType || "image/png";
+    var dataUrlMatch = /^data:(image\/[a-z0-9.+-]+);base64,([\s\S]+)$/i.exec(data);
+    if (dataUrlMatch) {
+      mediaType = dataUrlMatch[1];
+      data = dataUrlMatch[2];
+    }
+    return { mediaType: mediaType, data: data.replace(/\s/g, "") };
   }
 
   function sendToSession(session, obj) {
@@ -275,6 +288,48 @@ function attachMessageProcessor(ctx) {
         content: parsed.content || "",
         is_error: !!parsed.isError,
       });
+
+    } else if (parsed.yokeType === "generated_image") {
+      var generated = parseGeneratedImage(parsed);
+      var fileName = null;
+      if (!parsed.isError && generated.data && typeof saveImageFile === "function") {
+        fileName = saveImageFile(generated.mediaType, generated.data, getSessionLinuxUser(session));
+      }
+      if (!fileName) {
+        sendAndRecord(session, {
+          type: "tool_result",
+          id: parsed.toolId,
+          content: parsed.isError ? "Image generation failed." : "The generated image could not be saved.",
+          is_error: true,
+        });
+      } else {
+        sendAndRecord(session, {
+          type: "tool_result",
+          id: parsed.toolId,
+          content: "Image generated",
+          is_error: false,
+        });
+        var imageRef = { mediaType: generated.mediaType, file: fileName };
+        var storedImage = {
+          type: "generated_image",
+          id: parsed.toolId,
+          prompt: parsed.prompt || "",
+          transparentBackground: parsed.transparentBackground,
+          imageRefs: [imageRef],
+        };
+        var liveImage = {
+          type: "generated_image",
+          id: parsed.toolId,
+          prompt: parsed.prompt || "",
+          transparentBackground: parsed.transparentBackground,
+          images: [{
+            mediaType: generated.mediaType,
+            url: "/p/" + slug + "/images/" + fileName,
+            fileName: fileName,
+          }],
+        };
+        sendAndRecord(session, storedImage, liveImage);
+      }
 
     } else if (parsed.yokeType === "plan_updated") {
       var todos = Array.isArray(parsed.plan) ? parsed.plan.map(function(step, idx) {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -874,9 +874,11 @@ function createSessionManager(opts) {
     }
   }
 
-  function doSendAndRecord(session, obj) {
+  function doSendAndRecord(session, obj, clientObj) {
     // Stamp every recorded message so history replay preserves original times
     if (!obj._ts) obj._ts = Date.now();
+    var outgoingObj = clientObj || obj;
+    if (!outgoingObj._ts) outgoingObj._ts = obj._ts;
     session.history.push(obj);
     appendToSessionFile(session, obj);
     // Per-session out-of-band subscribers (used by home-chat to mirror
@@ -885,12 +887,12 @@ function createSessionManager(opts) {
     // clients; they are responsible for any transform + dispatch.
     if (session._subscribers && session._subscribers.size > 0) {
       for (var sub of session._subscribers) {
-        try { sub(obj); } catch (e) { /* swallow — subscriber is optional */ }
+        try { sub(outgoingObj); } catch (e) { /* swallow — subscriber is optional */ }
       }
     }
     if (sendEach) {
       // Multi-user: send to clients whose active session matches this one
-      var data = JSON.stringify(obj);
+      var data = JSON.stringify(outgoingObj);
       var ioData = null;
       sendEach(function (ws) {
         if (ws._clayActiveSession === session.localId) {
@@ -901,7 +903,7 @@ function createSessionManager(opts) {
         }
         // Track unread: increment on "done" for clients not viewing this session
         // Only count if session has no owner (my session) or owner matches this client
-        if (obj.type === "done" && ws._clayActiveSession !== session.localId) {
+        if (outgoingObj.type === "done" && ws._clayActiveSession !== session.localId) {
           var _isMySession = !session.ownerId || (ws._clayUser && ws._clayUser.id === session.ownerId);
           if (_isMySession) {
             if (!ws._clayUnread) ws._clayUnread = {};
@@ -917,10 +919,10 @@ function createSessionManager(opts) {
         setTimeout(function () { session._ioThrottle = false; }, 80);
       }
     } else if (session.localId === activeSessionId) {
-      send(obj);
+      send(outgoingObj);
     } else {
       // Track unread for single-user mode on "done"
-      if (obj.type === "done") {
+      if (outgoingObj.type === "done") {
         singleUserUnread[session.localId] = (singleUserUnread[session.localId] || 0) + 1;
         send({ type: "session_unread", id: session.localId, count: singleUserUnread[session.localId] });
       }

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -31,6 +31,7 @@ var backgroundTasks = require("../codex-background-tasks");
 //   agentMessage       -> text response
 //   reasoning          -> thinking
 //   commandExecution   -> bash/shell
+//   imageGeneration    -> ImageGen with a persisted inline image
 //   fileChange         -> file edits
 //   mcpToolCall        -> MCP tool
 //   webSearch          -> web search
@@ -413,6 +414,44 @@ function flattenEvent(notification, state) {
       }
       if (evtPhase === "completed") {
         events.push({ yokeType: "thinking_stop", blockId: state.thinkingBlocks[item.id] });
+      }
+      return events;
+    }
+
+    // Image generation. Codex emits the generated PNG as base64 in `result`;
+    // the message processor persists it before anything reaches the browser.
+    if (item.type === "imageGeneration" || item.type === "image_generation") {
+      if (!state.toolBlocks[item.id]) {
+        state.blockCounter++;
+        state.toolBlocks[item.id] = "blk_" + state.blockCounter;
+        var imageBlockId = state.toolBlocks[item.id];
+        events.push({
+          yokeType: "tool_start",
+          blockId: imageBlockId,
+          toolId: item.id,
+          toolName: "ImageGen",
+        });
+        events.push({
+          yokeType: "tool_executing",
+          blockId: imageBlockId,
+          toolId: item.id,
+          toolName: "ImageGen",
+          input: { prompt: item.revisedPrompt || "" },
+        });
+      }
+      if (evtPhase === "completed") {
+        events.push({
+          yokeType: "generated_image",
+          toolId: item.id,
+          blockId: state.toolBlocks[item.id],
+          data: item.result || "",
+          mediaType: item.mediaType || "image/png",
+          prompt: item.revisedPrompt || "",
+          savedPath: item.savedPath || null,
+          transparentBackground: item.transparentBackground == null ? null : !!item.transparentBackground,
+          isError: item.status === "failed",
+          status: item.status || "completed",
+        });
       }
       return events;
     }

--- a/test/codex-image-generation.test.js
+++ b/test/codex-image-generation.test.js
@@ -1,0 +1,146 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+
+var codex = require("../lib/yoke/adapters/codex");
+var createSDKBridge = require("../lib/sdk-bridge").createSDKBridge;
+var attachImage = require("../lib/project-image").attachImage;
+var createSessionManager = require("../lib/sessions").createSessionManager;
+
+test("Codex image generation normalizes to an ImageGen tool and generated image", function() {
+  var state = codex.contractTestKit.createEventState("test-model");
+  var started = codex.contractTestKit.normalizeEvent({
+    method: "item/started",
+    params: { item: { id: "image-1", type: "imageGeneration", status: "inProgress" } },
+  }, state);
+  var completed = codex.contractTestKit.normalizeEvent({
+    method: "item/completed",
+    params: {
+      item: {
+        id: "image-1",
+        type: "imageGeneration",
+        status: "completed",
+        result: "cG5n",
+        revisedPrompt: "A clay workspace",
+        savedPath: "/tmp/image.png",
+        transparentBackground: true,
+      },
+    },
+  }, state);
+
+  assert.strictEqual(started[0].yokeType, "tool_start");
+  assert.strictEqual(started[0].toolName, "ImageGen");
+  assert.strictEqual(started[1].yokeType, "tool_executing");
+  assert.strictEqual(completed.length, 1);
+  assert.deepStrictEqual(completed[0], {
+    yokeType: "generated_image",
+    toolId: "image-1",
+    blockId: started[0].blockId,
+    data: "cG5n",
+    mediaType: "image/png",
+    prompt: "A clay workspace",
+    savedPath: "/tmp/image.png",
+    transparentBackground: true,
+    isError: false,
+    status: "completed",
+  });
+});
+
+test("generated image data is persisted by reference and delivered by URL", function() {
+  var calls = [];
+  var saved = [];
+  var bridge = createSDKBridge({
+    cwd: process.cwd(),
+    slug: "demo",
+    adapter: { vendor: "codex" },
+    send: function () {},
+    sessionManager: {
+      sendAndRecord: function(session, stored, live) { calls.push({ stored: stored, live: live }); },
+    },
+    saveImageFile: function(mediaType, data) {
+      saved.push({ mediaType: mediaType, data: data });
+      return "generated.png";
+    },
+  });
+  var session = { localId: 1 };
+
+  bridge.processSDKMessage(session, {
+    yokeType: "generated_image",
+    toolId: "image-1",
+    data: "data:image/png;base64,cG5n\n",
+    prompt: "A clay workspace",
+  });
+
+  assert.deepStrictEqual(saved, [{ mediaType: "image/png", data: "cG5n" }]);
+  assert.strictEqual(calls.length, 2);
+  assert.deepStrictEqual(calls[0].stored, {
+    type: "tool_result",
+    id: "image-1",
+    content: "Image generated",
+    is_error: false,
+  });
+  assert.deepStrictEqual(calls[1].stored.imageRefs, [{ mediaType: "image/png", file: "generated.png" }]);
+  assert.strictEqual(calls[1].stored.images, undefined);
+  assert.strictEqual(calls[1].live.images[0].url, "/p/demo/images/generated.png");
+  assert.strictEqual(JSON.stringify(calls).indexOf("cG5n"), -1);
+});
+
+test("generated image history references hydrate for replay", function() {
+  var image = attachImage({ cwd: "/tmp/clay-image-generation-test", slug: "demo" });
+  var hydrated = image.hydrateImageRefs({
+    type: "generated_image",
+    id: "image-1",
+    imageRefs: [{ mediaType: "image/png", file: "generated.png" }],
+  });
+
+  assert.strictEqual(hydrated.imageRefs, undefined);
+  assert.deepStrictEqual(hydrated.images, [{
+    mediaType: "image/png",
+    url: "/p/demo/images/generated.png",
+  }]);
+});
+
+test("session history stores image references while clients receive hydrated URLs", function() {
+  var root = fs.mkdtempSync(path.join(os.tmpdir(), "clay-generated-image-session-"));
+  try {
+    var sent = [];
+    var manager = createSessionManager({
+      cwd: path.join(root, "project"),
+      sessionsBase: path.join(root, "sessions"),
+      cliSessionsDir: path.join(root, "cli-sessions"),
+      send: function(message) { sent.push(message); },
+    });
+    var session = manager.createSession({ vendor: "codex" });
+    sent.length = 0;
+    var stored = {
+      type: "generated_image",
+      imageRefs: [{ mediaType: "image/png", file: "generated.png" }],
+    };
+    var live = {
+      type: "generated_image",
+      images: [{ mediaType: "image/png", url: "/p/demo/images/generated.png" }],
+    };
+
+    manager.sendAndRecord(session, stored, live);
+
+    assert.strictEqual(session.history[0], stored);
+    assert.strictEqual(session.history[0].images, undefined);
+    assert.strictEqual(sent[0], live);
+    assert.strictEqual(sent[0]._ts, stored._ts);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generated image UI includes inline open and download actions", function() {
+  var source = fs.readFileSync(path.join(__dirname, "../lib/public/modules/generated-images.js"), "utf8");
+  var router = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-messages.js"), "utf8");
+  var stylesheet = fs.readFileSync(path.join(__dirname, "../lib/public/style.css"), "utf8");
+  assert.match(source, /showImageModal\(image\.url\)/);
+  assert.match(source, /downloadLink\.download/);
+  assert.match(source, /renderGeneratedImage/);
+  assert.match(router, /case "generated_image":/);
+  assert.match(stylesheet, /css\/generated-images\.css/);
+});

--- a/test/codex-image-generation.test.js
+++ b/test/codex-image-generation.test.js
@@ -141,6 +141,10 @@ test("generated image UI includes inline open and download actions", function() 
   assert.match(source, /showImageModal\(image\.url\)/);
   assert.match(source, /downloadLink\.download/);
   assert.match(source, /renderGeneratedImage/);
+  assert.match(source, /generated-image-row/);
+  assert.match(source, /renderImageGenerationProgress/);
+  assert.match(source, /progressRow\.replaceWith\(row\)/);
   assert.match(router, /case "generated_image":/);
+  assert.match(router, /renderImageGenerationProgress\(msg\)/);
   assert.match(stylesheet, /css\/generated-images\.css/);
 });


### PR DESCRIPTION
## Summary

- normalize Codex `imageGeneration` events into Clay's tool event flow
- persist generated image data as project-scoped Clay image files without storing base64 in session history
- replay generated images from lightweight references across reconnects
- render responsive inline image cards with open and download actions

## Test plan

- `node --test test/codex-image-generation.test.js test/sdk-bridge-delivery.test.js`
- `node --input-type=module --check < lib/public/modules/generated-images.js`
- `node --input-type=module --check < lib/public/modules/app-messages.js`
