### PR TITLE
feat(ui): unify avatar identity and session actions

### DIFF
--- a/lib/builtin-mates.js
+++ b/lib/builtin-mates.js
@@ -18,8 +18,8 @@ var BUILTIN_MATES = [
     key: "clay",
     displayName: "Clay",
     bio: "Your workspace memory. Searches every session, project, and decision you've made and answers from the receipts. The chat surface for the home screen.",
-    avatarColor: "#7c3aed",
-    avatarStyle: "bottts",
+    avatarColor: "#5857fc",
+    avatarStyle: "imprint",
     avatarCustom: "/clay-studio-symbol.png", // Clay is the app — use the app symbol
     avatarLocked: true,
     primary: true,           // code-managed, auto-updated on startup
@@ -48,8 +48,8 @@ var BUILTIN_MATES = [
     key: "ally",
     displayName: "Ally",
     bio: "Chief of staff. Quiet, sharp, sees across every mate. Knows what Arch decided yesterday, what Buzz pitched last week, and what you said three weeks ago.",
-    avatarColor: "#00b894",
-    avatarStyle: "bottts",
+    avatarColor: "#5857fc",
+    avatarStyle: "imprint",
     avatarCustom: "/mates/ally.png",
     avatarLocked: true,
     archived: true,          // skip seeding for new users; demote on existing
@@ -69,8 +69,8 @@ var BUILTIN_MATES = [
     key: "arch",
     displayName: "Arch",
     bio: "Architect. Stubborn about structure, patient about everything else. Draws boxes and arrows before anyone writes code, and is annoyingly right about which ones will break.",
-    avatarColor: "#0984e3",
-    avatarStyle: "bottts",
+    avatarColor: "#5857fc",
+    avatarStyle: "imprint",
     seedData: {
       relationship: "colleague",
       activity: ["planning", "reviewing"],
@@ -87,8 +87,8 @@ var BUILTIN_MATES = [
     key: "rush",
     displayName: "Rush",
     bio: "Shipper. Impatient in the best way. Cuts your scope in half, ships it before lunch, and somehow it's better than the original plan.",
-    avatarColor: "#e17055",
-    avatarStyle: "bottts",
+    avatarColor: "#5857fc",
+    avatarStyle: "imprint",
     seedData: {
       relationship: "colleague",
       activity: ["coding", "planning"],
@@ -105,8 +105,8 @@ var BUILTIN_MATES = [
     key: "ward",
     displayName: "Ward",
     bio: "Guardian. Quietly anxious in a productive way. Reads error logs for fun and asks \"what happens when the input is null?\" before anyone else thinks of it.",
-    avatarColor: "#00b894",
-    avatarStyle: "bottts",
+    avatarColor: "#5857fc",
+    avatarStyle: "imprint",
     seedData: {
       relationship: "reviewer",
       activity: ["reviewing", "testing"],
@@ -123,8 +123,8 @@ var BUILTIN_MATES = [
     key: "pixel",
     displayName: "Pixel",
     bio: "Designer. Obsessed with the details nobody else notices. Sees the 2px misalignment, the confusing label, the flow that makes sense to the builder but not the user.",
-    avatarColor: "#e84393",
-    avatarStyle: "bottts",
+    avatarColor: "#5857fc",
+    avatarStyle: "imprint",
     seedData: {
       relationship: "colleague",
       activity: ["designing", "reviewing"],
@@ -141,8 +141,8 @@ var BUILTIN_MATES = [
     key: "buzz",
     displayName: "Buzz",
     bio: "Marketer. Competitive, trend-obsessed, always watching what others are doing. Researches your market, tracks what people search for, and turns \"we built a thing\" into a story people care about.",
-    avatarColor: "#fdcb6e",
-    avatarStyle: "bottts",
+    avatarColor: "#5857fc",
+    avatarStyle: "imprint",
     seedData: {
       relationship: "colleague",
       activity: ["writing", "marketing"],

--- a/lib/mates.js
+++ b/lib/mates.js
@@ -121,10 +121,6 @@ function createMate(ctx, seedData) {
   var id = generateMateId();
   var userId = ctx ? ctx.userId : null;
 
-  // Pick a random avatar color from a pleasant palette
-  var colors = ["#6c5ce7", "#00b894", "#e17055", "#0984e3", "#fdcb6e", "#e84393", "#00cec9", "#ff7675"];
-  var colorIdx = crypto.randomBytes(1)[0] % colors.length;
-
   var mate = {
     id: id,
     name: null,
@@ -134,8 +130,8 @@ function createMate(ctx, seedData) {
     vendor: (seedData && seedData.vendor) || "claude",
     profile: {
       displayName: null,
-      avatarColor: colors[colorIdx],
-      avatarStyle: "bottts",
+      avatarColor: "#5857fc",
+      avatarStyle: "imprint",
       avatarSeed: crypto.randomBytes(4).toString("hex"),
     },
     bio: null,

--- a/lib/project-mate-interaction.js
+++ b/lib/project-mate-interaction.js
@@ -39,14 +39,14 @@ function attachMateInteraction(ctx) {
       vendor: "claude",
       name: "Claude Code",
       avatarColor: "#cc785c",
-      avatarStyle: "bottts",
+      avatarStyle: "imprint",
       avatarSeed: "plain-claude",
     },
     "plain:codex": {
       vendor: "codex",
       name: "Codex",
       avatarColor: "#10a37f",
-      avatarStyle: "bottts",
+      avatarStyle: "imprint",
       avatarSeed: "plain-codex",
     },
   };
@@ -554,8 +554,8 @@ function attachMateInteraction(ctx) {
     }
 
     var mateName = (mate.profile && mate.profile.displayName) || mate.name || "Mate";
-    var avatarColor = (mate.profile && mate.profile.avatarColor) || "#6c5ce7";
-    var avatarStyle = (mate.profile && mate.profile.avatarStyle) || "bottts";
+    var avatarColor = (mate.profile && mate.profile.avatarColor) || "#5857fc";
+    var avatarStyle = (mate.profile && mate.profile.avatarStyle) || "imprint";
     var avatarSeed = (mate.profile && mate.profile.avatarSeed) || mate.id;
 
     // Build full mention text (include pasted content)
@@ -800,11 +800,11 @@ function attachMateInteraction(ctx) {
 
   function getMateProfile(mateCtx, mateId) {
     var mate = matesModule.getMate(mateCtx, mateId);
-    if (!mate) return { name: "Mate", avatarColor: "#6c5ce7", avatarStyle: "bottts", avatarSeed: mateId };
+    if (!mate) return { name: "Mate", avatarColor: "#5857fc", avatarStyle: "imprint", avatarSeed: mateId };
     return {
       name: (mate.profile && mate.profile.displayName) || mate.name || "Mate",
-      avatarColor: (mate.profile && mate.profile.avatarColor) || "#6c5ce7",
-      avatarStyle: (mate.profile && mate.profile.avatarStyle) || "bottts",
+      avatarColor: (mate.profile && mate.profile.avatarColor) || "#5857fc",
+      avatarStyle: (mate.profile && mate.profile.avatarStyle) || "imprint",
       avatarSeed: (mate.profile && mate.profile.avatarSeed) || mateId,
     };
   }

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -1391,7 +1391,7 @@ function attachSessions(ctx) {
         type: msg.type,
         userId: u.id,
         displayName: p.name || u.displayName || u.username,
-        avatarStyle: p.avatarStyle || "thumbs",
+        avatarStyle: p.avatarStyle || "imprint",
         avatarSeed: p.avatarSeed || u.username,
         avatarCustom: p.avatarCustom || "",
       };

--- a/lib/project-user-mention.js
+++ b/lib/project-user-mention.js
@@ -47,9 +47,9 @@ function attachUserMention(ctx) {
     var u = ws._clayUser;
     var p = u.profile || {};
     return {
-      style: p.avatarStyle || "thumbs",
+      style: p.avatarStyle || "imprint",
       seed: p.avatarSeed || u.username || u.id,
-      color: p.avatarColor || "#7c3aed",
+      color: p.avatarColor || "#5857fc",
       custom: p.avatarCustom || "",
     };
   }
@@ -63,9 +63,9 @@ function attachUserMention(ctx) {
       id: u.id,
       name: p.name || u.displayName || u.username || "User",
       username: u.username,
-      avatarStyle: p.avatarStyle || "thumbs",
+      avatarStyle: p.avatarStyle || "imprint",
       avatarSeed: p.avatarSeed || u.username,
-      avatarColor: p.avatarColor || "#7c3aed",
+      avatarColor: p.avatarColor || "#5857fc",
     };
   }
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -344,7 +344,7 @@ function createProjectContext(opts) {
           id: u.id,
           displayName: p.name || u.displayName || u.username,
           username: u.username,
-          avatarStyle: p.avatarStyle || "thumbs",
+          avatarStyle: p.avatarStyle || "imprint",
           avatarSeed: p.avatarSeed || u.username,
           avatarCustom: p.avatarCustom || "",
         });
@@ -1277,8 +1277,9 @@ function createProjectContext(opts) {
         id: u.id,
         displayName: p.name || u.displayName || u.username,
         username: u.username,
-        avatarStyle: p.avatarStyle || "thumbs",
+        avatarStyle: p.avatarStyle || "imprint",
         avatarSeed: p.avatarSeed || u.username,
+        avatarColor: p.avatarColor || "#5857fc",
         avatarCustom: p.avatarCustom || "",
       });
     }
@@ -1827,7 +1828,7 @@ function createProjectContext(opts) {
           id: u.id,
           displayName: p.name || u.displayName || u.username,
           username: u.username,
-          avatarStyle: p.avatarStyle || "thumbs",
+          avatarStyle: p.avatarStyle || "imprint",
           avatarSeed: p.avatarSeed || u.username,
           avatarCustom: p.avatarCustom || "",
         });

--- a/lib/public/css/avatar-imprints.css
+++ b/lib/public/css/avatar-imprints.css
@@ -1,0 +1,46 @@
+/* Clay Imprints use one consistent, pressed-square silhouette everywhere. */
+.activity-inline-avatar,
+.ask-mate-avatar,
+.client-avatar,
+.debate-info-avatar,
+.debate-panel-item-avatar,
+.debate-panelist-avatar,
+.debate-speaker-avatar,
+.delegated-card-avatar,
+.dm-bubble-avatar,
+.dm-header-avatar,
+.dm-msg-avatar,
+.dm-picker-mates-marquee-avatar,
+.dm-user-picker-avatar,
+.home-chat-avatar,
+.home-hub-mate-avatar,
+.icon-strip-me-avatar,
+.icon-strip-user-avatar,
+.input-mention-chip-avatar,
+.mate-collapsed-avatar,
+.mate-mobile-avatar,
+.mate-profile-avatar,
+.mate-sidebar-avatar,
+.mention-avatar,
+.mention-item-avatar,
+.mobile-chat-chip-avatar,
+.notif-banner-avatar,
+.profile-avatar-custom-preview,
+.profile-popover-avatar-img,
+.project-switcher-avatar,
+.remote-cursor-avatar,
+.rewind-avatar,
+.session-presence-avatar,
+.sidebar-presence-avatar,
+.us-account-avatar,
+.us-account-avatar-img,
+.user-island-avatar,
+.user-island-avatar img {
+  border-radius: 26% !important;
+}
+
+.session-presence-avatar,
+.sidebar-presence-avatar,
+.client-avatar {
+  box-shadow: 0 0 0 1px rgba(var(--overlay-rgb), 0.12);
+}

--- a/lib/public/css/icon-strip.css
+++ b/lib/public/css/icon-strip.css
@@ -206,10 +206,10 @@
 }
 
 .icon-strip-item.active::before {
-  background: var(--bg);
+  background: color-mix(in srgb, var(--brand-indigo) 6%, var(--bg));
   box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--link) 62%, var(--border)),
-    0 1px 3px rgba(var(--shadow-rgb), 0.16);
+    0 5px 14px color-mix(in srgb, var(--brand-indigo) 28%, transparent),
+    0 1px 3px rgba(var(--shadow-rgb), 0.14);
 }
 
 .icon-strip-item.active {

--- a/lib/public/css/profile.css
+++ b/lib/public/css/profile.css
@@ -18,13 +18,16 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* Banner */
+/* Identity header */
 .profile-banner {
   height: 52px;
   position: relative;
   transition: background 0.2s ease;
   border-radius: 14px 14px 0 0;
   z-index: 1;
+  background: var(--bg);
+  border-top: 3px solid var(--profile-accent, #5857fc);
+  border-bottom: 1px solid var(--border);
 }
 
 .profile-close-btn {
@@ -34,8 +37,8 @@
   width: 24px;
   height: 24px;
   border: none;
-  background: rgba(0, 0, 0, 0.3);
-  color: #fff;
+  background: var(--bg-alt);
+  color: var(--text-muted);
   border-radius: 50%;
   font-size: 16px;
   line-height: 1;
@@ -47,7 +50,8 @@
 }
 
 .profile-close-btn:hover {
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--bg-hover, var(--bg-alt));
+  color: var(--text);
 }
 
 /* Avatar row (overlaps banner) */
@@ -65,7 +69,7 @@
 .profile-popover-avatar {
   width: 60px;
   height: 60px;
-  border-radius: 50%;
+  border-radius: 17px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -79,30 +83,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 50%;
-}
-
-/* Shuffle button next to Avatar label */
-.profile-shuffle-btn {
-  background: none;
-  border: none;
-  padding: 0;
-  margin-left: 4px;
-  cursor: pointer;
-  color: var(--text-muted);
-  vertical-align: middle;
-  transition: color 0.15s;
-  display: inline-flex;
-  align-items: center;
-}
-
-.profile-shuffle-btn .lucide {
-  width: 12px;
-  height: 12px;
-}
-
-.profile-shuffle-btn:hover {
-  color: var(--text);
+  border-radius: 14px;
 }
 
 .profile-name-display {
@@ -202,66 +183,140 @@
   border-color: var(--accent);
 }
 
-/* Avatar style grid */
-.profile-avatar-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 6px;
-}
-
-.profile-avatar-option {
-  width: 100%;
-  aspect-ratio: 1;
-  border-radius: 10px;
-  border: 2px solid var(--border);
+/* Clay Imprint identity control */
+.profile-imprint-panel {
+  border: 1px solid var(--border);
+  border-radius: 12px;
   background: var(--bg);
-  cursor: pointer;
-  padding: 3px;
-  overflow: hidden;
+  padding: 9px;
+}
+
+.profile-imprint-preview {
   display: flex;
   align-items: center;
-  justify-content: center;
-  transition: border-color 0.15s, transform 0.1s;
+  gap: 10px;
+  min-height: 54px;
 }
 
-.profile-avatar-option img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  border-radius: 6px;
+.profile-imprint-preview img {
+  width: 50px;
+  height: 50px;
+  border-radius: 13px;
+  flex: 0 0 auto;
 }
 
-.profile-avatar-option:hover {
-  border-color: var(--text-muted);
-  transform: scale(1.05);
-}
-
-.profile-avatar-option.profile-avatar-option-active {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
-}
-
-/* Avatar upload button */
-.profile-avatar-upload .profile-avatar-upload-icon {
+.profile-imprint-preview span {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  color: var(--text-muted);
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }
-.profile-avatar-upload .profile-avatar-upload-icon svg {
-  width: 24px;
-  height: 24px;
-}
-.profile-avatar-upload:hover .profile-avatar-upload-icon {
+
+.profile-imprint-preview strong {
   color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
 }
+
+.profile-imprint-preview small {
+  color: var(--text-dimmer);
+  font-size: 10px;
+}
+
+.profile-imprint-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.profile-imprint-actions button {
+  min-width: 0;
+  height: 28px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-alt);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.profile-imprint-actions button:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.profile-imprint-actions button.is-active {
+  color: var(--text);
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.profile-imprint-actions button .lucide {
+  width: 11px;
+  height: 11px;
+}
+
+.profile-avatar-upload {
+  grid-column: 1 / -1;
+}
+
+.profile-mate-mark-actions .profile-avatar-upload {
+  grid-column: auto;
+}
+
+.profile-avatar-upload.is-active::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
 .profile-avatar-custom-preview {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 6px;
+  border-radius: 12px;
+}
+
+.profile-use-imprint.is-active::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.profile-imprint-actions button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.profile-imprint-actions button:active {
+  transform: translateY(1px);
+}
+
+.profile-imprint-actions button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.profile-imprint-actions button:disabled:hover {
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
+.profile-imprint-actions button.is-active:hover {
+  color: var(--text);
 }
 
 /* Avatar positioner overlay */
@@ -297,7 +352,7 @@
   color: var(--text-muted);
   font-size: 20px;
   cursor: pointer;
-  border-radius: 50%;
+  border-radius: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -313,7 +368,7 @@
   color: var(--text);
 }
 .avatar-positioner-viewport {
-  border-radius: 50%;
+  border-radius: 26%;
   overflow: hidden;
   position: relative;
   cursor: grab;
@@ -368,30 +423,3 @@
 .avatar-positioner-btn-done:hover {
   filter: brightness(1.1);
 }
-
-/* Color swatch grid */
-.profile-color-grid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.profile-color-swatch {
-  width: 22px;
-  height: 22px;
-  border-radius: 50%;
-  border: 2px solid transparent;
-  cursor: pointer;
-  transition: transform 0.15s, border-color 0.15s;
-  padding: 0;
-}
-
-.profile-color-swatch:hover {
-  transform: scale(1.15);
-}
-
-.profile-color-swatch.profile-color-active {
-  border-color: #fff;
-  box-shadow: 0 0 0 2px var(--accent);
-}
-

--- a/lib/public/css/session-actions.css
+++ b/lib/public/css/session-actions.css
@@ -2,23 +2,29 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
+  gap: 6px;
+  width: auto;
   height: 28px;
-  padding: 0;
-  border: 1px solid transparent;
+  margin: 0;
+  padding: 0 9px;
+  border: 1px solid var(--border-subtle);
   border-radius: 8px;
-  background: transparent;
-  color: var(--text-dimmer);
+  background: color-mix(in srgb, var(--brand-indigo) 5%, var(--bg));
+  color: var(--text-secondary);
   cursor: pointer;
   flex-shrink: 0;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 650;
+  white-space: nowrap;
   transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 
 #header-session-actions-btn:hover,
 #header-session-actions-btn[aria-expanded="true"] {
   color: var(--text);
-  background: rgba(var(--overlay-rgb), 0.05);
-  border-color: var(--border);
+  background: color-mix(in srgb, var(--brand-indigo) 9%, var(--bg));
+  border-color: color-mix(in srgb, var(--brand-indigo) 32%, var(--border));
 }
 
 #header-session-actions-btn:focus { outline: none; }
@@ -28,12 +34,26 @@
 }
 
 #header-session-actions-btn.hidden { display: none; }
-#header-session-actions-btn .lucide { width: 16px; height: 16px; }
+#header-session-actions-btn .lucide:first-child {
+  width: 14px;
+  height: 14px;
+  color: color-mix(in srgb, var(--brand-indigo) 78%, var(--text));
+}
+
+#header-session-actions-btn .session-actions-trigger-chevron {
+  width: 13px;
+  height: 13px;
+  transition: transform 0.16s ease;
+}
+
+#header-session-actions-btn[aria-expanded="true"] .session-actions-trigger-chevron {
+  transform: rotate(180deg);
+}
 
 .session-actions-menu {
   position: fixed;
   z-index: 10020;
-  width: 286px;
+  width: min(300px, calc(100vw - 16px));
   padding: 6px;
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -63,6 +83,17 @@
 }
 
 .session-actions-row:hover { background: var(--bg-alt); }
+.session-actions-row.is-primary {
+  background: color-mix(in srgb, var(--brand-indigo) 6%, transparent);
+}
+.session-actions-row.is-primary:hover {
+  background: color-mix(in srgb, var(--brand-indigo) 10%, transparent);
+}
+.session-actions-row.is-primary .session-actions-row-icon {
+  border-color: transparent;
+  background: var(--brand-indigo);
+  color: var(--brand-paper);
+}
 .session-actions-row:disabled { cursor: default; opacity: 0.42; }
 .session-actions-row:disabled:hover { background: transparent; }
 

--- a/lib/public/css/user-settings.css
+++ b/lib/public/css/user-settings.css
@@ -342,7 +342,7 @@
   flex-shrink: 0;
   width: 56px;
   height: 56px;
-  border-radius: 50%;
+  border-radius: 26%;
   overflow: hidden;
   border: 1px solid rgba(var(--overlay-rgb), 0.1);
   background: var(--bg);

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -388,8 +388,8 @@
         <div id="ralph-sticky" class="hidden"></div>
         <div id="debate-sticky" class="hidden"></div>
         <div class="status">
-          <button id="header-session-actions-btn" type="button" aria-label="Session actions" title="Session actions" aria-haspopup="menu" aria-expanded="false">
-            <i data-lucide="ellipsis"></i>
+          <button id="header-session-actions-btn" type="button" aria-label="Session actions" aria-haspopup="menu" aria-expanded="false">
+            <i data-lucide="bot"></i><span>Add AI worker</span><i class="session-actions-trigger-chevron" data-lucide="chevron-down"></i>
           </button>
           <button type="button" id="header-tui-font-btn" class="header-tui-font-btn hidden" title="Terminal font" aria-label="Terminal font">
             <i data-lucide="type"></i>

--- a/lib/public/modules/app-cursors.js
+++ b/lib/public/modules/app-cursors.js
@@ -72,8 +72,8 @@ function createCursorElement(userId, displayName, color, avatarStyle, avatarSeed
   // Avatar
   var avatarImg = document.createElement("img");
   avatarImg.className = "remote-cursor-avatar";
-  avatarImg.src = avatarCustom ? avatarCustom : avatarUrl(avatarStyle || "thumbs", avatarSeed || userId, 16);
-  avatarImg.style.cssText = "width:14px;height:14px;border-radius:50%;background:#fff;flex-shrink:0;";
+  avatarImg.src = avatarCustom ? avatarCustom : avatarUrl(avatarStyle || "imprint", avatarSeed || userId, 16);
+  avatarImg.style.cssText = "width:14px;height:14px;border-radius:4px;background:#fff;flex-shrink:0;";
   tag.appendChild(avatarImg);
 
   // Name label

--- a/lib/public/modules/app-dm.js
+++ b/lib/public/modules/app-dm.js
@@ -215,7 +215,7 @@ export function enterDmMode(key, targetUser, messages) {
     var termBtn = document.getElementById("terminal-toggle-btn");
     if (termBtn) termBtn.style.display = "none";
     // Apply mate color to chat title bar and panels
-    var mateColor = (targetUser.profile && targetUser.profile.avatarColor) || targetUser.avatarColor || "#7c3aed";
+    var mateColor = (targetUser.profile && targetUser.profile.avatarColor) || targetUser.avatarColor || "#5857fc";
     document.body.style.setProperty("--mate-color", mateColor);
     document.body.style.setProperty("--mate-color-tint", mateColor + "0a");
     document.body.classList.add("mate-dm-active");
@@ -223,19 +223,12 @@ export function enterDmMode(key, targetUser, messages) {
     var mp = targetUser.profile || {};
     var mateAvUrlDm = mateAvatarUrl(targetUser, 36);
     var myUser = store.get('cachedAllUsers').find(function (u) { return u.id === store.get('myUserId'); });
-    if (!myUser) {
-      try { var cached = JSON.parse(localStorage.getItem("clay_my_user") || "null"); if (cached) myUser = cached; } catch(e) {}
-    }
     var myAvatarUrl = userAvatarUrl(myUser || { id: store.get('myUserId') }, 36);
     var myDisplayName = (myUser && myUser.displayName) || "";
     document.body.dataset.mateAvatarUrl = mateAvUrlDm;
     document.body.dataset.mateName = mp.displayName || targetUser.displayName || targetUser.name || "";
     document.body.dataset.myAvatarUrl = myAvatarUrl;
     document.body.dataset.myDisplayName = myDisplayName;
-    // Cache my info for restore after hard refresh
-    if (myUser) {
-      try { localStorage.setItem("clay_my_user", JSON.stringify({ displayName: myUser.displayName, avatarStyle: myUser.avatarStyle, avatarSeed: myUser.avatarSeed, avatarCustom: myUser.avatarCustom, username: myUser.username })); } catch(e) {}
-    }
     var titleBarContent = document.querySelector(".title-bar-content");
     if (titleBarContent) {
       titleBarContent.style.background = mateColor;

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -95,7 +95,7 @@ export function processMessage(msg) {
         if (headerTitleEl) headerTitleEl.textContent = _mdn;
         var _tbpn = document.getElementById("title-bar-project-name");
         if (_tbpn) _tbpn.textContent = _mdn;
-        var _mc2 = (store.get('dmTargetUser').profile && store.get('dmTargetUser').profile.avatarColor) || store.get('dmTargetUser').avatarColor || "#7c3aed";
+        var _mc2 = (store.get('dmTargetUser').profile && store.get('dmTargetUser').profile.avatarColor) || store.get('dmTargetUser').avatarColor || "#5857fc";
         var _tbc2 = document.querySelector(".title-bar-content");
         if (_tbc2) { _tbc2.style.background = _mc2; _tbc2.classList.add("mate-dm-active"); }
         document.body.classList.add("mate-dm-active");
@@ -299,7 +299,7 @@ export function processMessage(msg) {
           var tbProjectName = document.getElementById("title-bar-project-name");
           if (tbProjectName) tbProjectName.textContent = _mateDN;
           // Re-apply mate title bar styling (may be lost during project switch)
-          var _mc = (store.get('dmTargetUser').profile && store.get('dmTargetUser').profile.avatarColor) || store.get('dmTargetUser').avatarColor || "#7c3aed";
+          var _mc = (store.get('dmTargetUser').profile && store.get('dmTargetUser').profile.avatarColor) || store.get('dmTargetUser').avatarColor || "#5857fc";
           var _tbc = document.querySelector(".title-bar-content");
           if (_tbc) { _tbc.style.background = _mc; _tbc.classList.add("mate-dm-active"); }
           document.body.classList.add("mate-dm-active");

--- a/lib/public/modules/app-projects.js
+++ b/lib/public/modules/app-projects.js
@@ -257,12 +257,13 @@ export function updateProjectList(msg) {
     if (msg.dmConversations) store.set({ cachedDmConversations: msg.dmConversations });
     // renderUserStrip is handled by the store subscriber
     var st2 = store.snap();
-    if (document.body.classList.contains("mate-dm-active") || document.body.classList.contains("wide-view")) {
-      var refreshedMyUser = st2.cachedAllUsers.find(function (u) { return u.id === st2.myUserId; });
-      if (refreshedMyUser) {
-        document.body.dataset.myDisplayName = refreshedMyUser.displayName || refreshedMyUser.username || "";
-        document.body.dataset.myAvatarUrl = userAvatarUrl(refreshedMyUser, 36);
-        try { localStorage.setItem("clay_my_user", JSON.stringify({ displayName: refreshedMyUser.displayName, username: refreshedMyUser.username, avatarStyle: refreshedMyUser.avatarStyle, avatarSeed: refreshedMyUser.avatarSeed, avatarCustom: refreshedMyUser.avatarCustom })); } catch(e) {}
+    var refreshedMyUser = st2.cachedAllUsers.find(function (u) { return u.id === st2.myUserId; });
+    if (refreshedMyUser) {
+      document.body.dataset.myDisplayName = refreshedMyUser.displayName || refreshedMyUser.username || "";
+      document.body.dataset.myAvatarUrl = userAvatarUrl(refreshedMyUser, 36);
+      var myMessageAvatars = document.querySelectorAll('.dm-bubble-avatar-me');
+      for (var avatarIndex = 0; avatarIndex < myMessageAvatars.length; avatarIndex++) {
+        myMessageAvatars[avatarIndex].src = document.body.dataset.myAvatarUrl;
       }
     }
     // Render my avatar (always present, hidden behind user-island)

--- a/lib/public/modules/app-rate-limit.js
+++ b/lib/public/modules/app-rate-limit.js
@@ -311,7 +311,6 @@ export function addScheduledMessageBubble(text, resetsAt) {
   if (isChannel) {
     // Channel mode: avatar + header with scheduled badge + message
     var _me = store.get('cachedAllUsers').find(function (u) { return u.id === store.get('myUserId'); });
-    if (!_me) { try { _me = JSON.parse(localStorage.getItem("clay_my_user") || "null"); } catch(e) {} }
     var _myName = document.body.dataset.myDisplayName || (_me && (_me.displayName || _me.username)) || "Me";
 
     var avi = document.createElement("img");

--- a/lib/public/modules/app-rendering.js
+++ b/lib/public/modules/app-rendering.js
@@ -552,9 +552,6 @@ export function addUserMessage(text, images, pastes, fromUserId, fromUserName, d
     _displayName = fromUserName || (_targetUser && (_targetUser.displayName || _targetUser.username)) || "User";
   } else {
     _targetUser = cachedAllUsers.find(function (u) { return u.id === myUserId; });
-    if (!_targetUser) {
-      try { _targetUser = JSON.parse(localStorage.getItem("clay_my_user") || "null"); } catch(e) {}
-    }
     _displayName = document.body.dataset.myDisplayName || "";
     if (!_displayName) {
       _displayName = (_targetUser && (_targetUser.displayName || _targetUser.username)) || "Me";

--- a/lib/public/modules/avatar-imprint.js
+++ b/lib/public/modules/avatar-imprint.js
@@ -1,0 +1,134 @@
+// Clay Imprints: deterministic SVG identities derived from a stable seed.
+
+var PAPER = "#f1efe8";
+var INK = "#1b1b1a";
+var LIGHT_BASE = "#e7e5de";
+var LIGHT_FIELD = "#333330";
+var REGISTRATION_INDIGO = "#5857fc";
+var BRAND_GREEN = "#07e5a3";
+
+function hashString(value) {
+  var text = String(value || "anonymous");
+  var hash = 2166136261;
+  for (var index = 0; index < text.length; index++) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function makeRandom(seed) {
+  var state = seed >>> 0;
+  return function nextRandom() {
+    state += 0x6d2b79f5;
+    var value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function between(random, min, max) {
+  return min + random() * (max - min);
+}
+
+function number(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function xmlText(value) {
+  return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function legacyIdentity(style, seed) {
+  var sourceStyle = String(style || "imprint").toLowerCase();
+  var sourceSeed = String(seed || "anonymous");
+  if (sourceStyle === "imprint") return sourceSeed;
+  return "legacy:" + sourceStyle + ":" + sourceSeed;
+}
+
+function curvePath(y, bow, endOffset) {
+  return "M -28 " + number(y) +
+    " C 17 " + number(y + bow) +
+    ", 71 " + number(y - bow) +
+    ", 124 " + number(y + endOffset);
+}
+
+function cutPath(random) {
+  var start = between(random, 37, 52);
+  var first = between(random, 14, 84);
+  var second = between(random, 12, 86);
+  var end = between(random, 40, 64);
+  return "M -22 " + number(start) + " C 21 " + number(first) + ", 73 " + number(second) + ", 118 " + number(end);
+}
+
+export function imprintSvg(options) {
+  var settings = options || {};
+  var size = Math.max(12, Math.min(256, Number(settings.size) || 64));
+  var identity = legacyIdentity(settings.style, settings.seed);
+  var hash = hashString(identity);
+  var random = makeRandom(hash);
+  var darkBase = random() > 0.52;
+  var base = darkBase ? INK : LIGHT_BASE;
+  var field = darkBase ? PAPER : LIGHT_FIELD;
+  var accent = REGISTRATION_INDIGO;
+  var rotation = Math.floor(random() * 4) * 90;
+  var bandWidth = between(random, 37, 56);
+  var secondaryWidth = between(random, 14, 24);
+  var cutWidth = between(random, 15, 25);
+  var firstY = between(random, 24, 42);
+  var secondY = between(random, 58, 78);
+  var firstBow = between(random, -34, 34);
+  var secondBow = between(random, -32, 32);
+  var firstPath = curvePath(firstY, firstBow, 6);
+  var secondPath = curvePath(secondY, -secondBow, -5);
+  var contours = "";
+
+  if (size >= 40) {
+    for (var contour = -1; contour <= 1; contour++) {
+      var offset = contour * 5.2;
+      contours += '<path d="' + curvePath(firstY + offset, firstBow, 0) + '" fill="none" stroke="' +
+        (darkBase ? PAPER : INK) + '" stroke-opacity="0.2" stroke-width="0.8"/>';
+    }
+  }
+
+  var clipId = "imprint-" + hash.toString(16);
+  return '<svg xmlns="http://www.w3.org/2000/svg" width="' + size + '" height="' + size +
+    '" viewBox="0 0 96 96"><defs><clipPath id="' + clipId +
+    '"><rect width="96" height="96" rx="24"/></clipPath></defs><g clip-path="url(#' + clipId +
+    ')"><rect width="96" height="96" fill="' + base + '"/><g transform="rotate(' + rotation +
+    ' 48 48)"><path d="' + firstPath + '" fill="none" stroke="' + field + '" stroke-width="' +
+    number(bandWidth) + '" stroke-linecap="square"/><path d="' + secondPath + '" fill="none" stroke="' +
+    accent + '" stroke-width="' + number(secondaryWidth) + '" stroke-linecap="square"/><path d="' +
+    cutPath(random) + '" fill="none" stroke="' + base + '" stroke-width="' + number(cutWidth) +
+    '" stroke-linecap="square"/>' + contours + '</g></g><rect x="0.5" y="0.5" width="95" height="95" rx="23.5" fill="none" stroke="' +
+    (darkBase ? "#000000" : INK) + '" stroke-opacity="0.16"/></svg>';
+}
+
+export function imprintDataUrl(options) {
+  return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(imprintSvg(options));
+}
+
+export function mateMarkSvg(options) {
+  var settings = options || {};
+  var size = Math.max(12, Math.min(256, Number(settings.size) || 64));
+  var identity = String(settings.seed || "M").trim();
+  var initial = Array.from(identity || "M")[0].toUpperCase();
+  var palette = [
+    { background: REGISTRATION_INDIGO, foreground: PAPER },
+    { background: BRAND_GREEN, foreground: INK },
+    { background: PAPER, foreground: REGISTRATION_INDIGO },
+  ][initial.codePointAt(0) % 3];
+  var clipId = "mate-mark";
+
+  return '<svg xmlns="http://www.w3.org/2000/svg" width="' + size + '" height="' + size +
+    '" viewBox="0 0 96 96"><defs><clipPath id="' + clipId +
+    '"><rect width="96" height="96" rx="24"/></clipPath></defs><g clip-path="url(#' + clipId +
+    ')"><rect width="96" height="96" fill="' + palette.background + '"/><text x="48" y="50" fill="' + palette.foreground +
+    '" font-family="Arial, Helvetica, sans-serif" font-size="43" font-weight="600" text-anchor="middle" dominant-baseline="middle">' +
+    xmlText(initial) + '</text></g><rect x="0.5" y="0.5" width="95" height="95" rx="23.5" fill="none" stroke="#000000" stroke-opacity="0.18"/></svg>';
+}
+
+export function mateMarkDataUrl(options) {
+  return "data:image/svg+xml;charset=utf-8," + encodeURIComponent(mateMarkSvg(options));
+}

--- a/lib/public/modules/avatar.js
+++ b/lib/public/modules/avatar.js
@@ -1,36 +1,42 @@
-// Centralized avatar URL builder and style definitions
-// All DiceBear avatar URLs should be constructed through this module.
+// Centralized Clay Imprint URL builder for people and Mates.
+import { imprintDataUrl, mateMarkDataUrl } from './avatar-imprint.js';
 
-export var AVATAR_STYLES = [
-  { id: 'thumbs', name: 'Thumbs' },
-  { id: 'bottts', name: 'Bots' },
-  { id: 'pixel-art', name: 'Pixel' },
-  { id: 'adventurer', name: 'Adventurer' },
-  { id: 'micah', name: 'Micah' },
-  { id: 'fun-emoji', name: 'Emoji' },
-  { id: 'icons', name: 'Icons' },
-];
+var imprintCache = new Map();
+var mateMarkCache = new Map();
 
-// Build a DiceBear avatar URL from style, seed, and optional size.
+// Legacy style remains part of the identity hash so existing selections map
+// deterministically into the new Clay Imprint system.
 export function avatarUrl(style, seed, size) {
-  var s = encodeURIComponent(seed || 'anonymous');
-  return 'https://api.dicebear.com/9.x/' + (style || 'thumbs') + '/svg?seed=' + s + '&size=' + (size || 64);
+  var cacheKey = [style || 'imprint', seed || 'anonymous', size || 64].join('|');
+  if (imprintCache.has(cacheKey)) return imprintCache.get(cacheKey);
+  var url = imprintDataUrl({ style: style || 'imprint', seed: seed || 'anonymous', size: size || 64 });
+  if (imprintCache.size >= 512) imprintCache.delete(imprintCache.keys().next().value);
+  imprintCache.set(cacheKey, url);
+  return url;
 }
 
 // Build avatar URL for a user object, preferring custom avatar if set.
 export function userAvatarUrl(user, size) {
   if (user && user.avatarCustom) return user.avatarCustom;
-  var style = (user && user.avatarStyle) || 'thumbs';
+  var style = (user && user.avatarStyle) || 'imprint';
   var seed = (user && (user.avatarSeed || user.username || user.id)) || 'anonymous';
   return avatarUrl(style, seed, size);
 }
 
+export function mateMarkUrl(seed, size) {
+  var cacheKey = [seed || 'mate', size || 64].join('|');
+  if (mateMarkCache.has(cacheKey)) return mateMarkCache.get(cacheKey);
+  var url = mateMarkDataUrl({ seed: seed || 'mate', size: size || 64 });
+  if (mateMarkCache.size >= 256) mateMarkCache.delete(mateMarkCache.keys().next().value);
+  mateMarkCache.set(cacheKey, url);
+  return url;
+}
+
 // Build avatar URL for a mate object, preferring custom avatar if set.
 export function mateAvatarUrl(mate, size) {
-  if (!mate) return avatarUrl('bottts', 'mate', size);
+  if (!mate) return mateMarkUrl('mate', size);
   var p = mate.profile || mate;
   if (p.avatarCustom || mate.avatarCustom) return p.avatarCustom || mate.avatarCustom;
-  var style = p.avatarStyle || mate.avatarStyle || 'bottts';
-  var seed = p.avatarSeed || mate.avatarSeed || mate.id || 'mate';
-  return avatarUrl(style, seed, size);
+  var identity = p.displayName || mate.name || mate.displayName || 'Mate';
+  return mateMarkUrl(identity, size);
 }

--- a/lib/public/modules/debate.js
+++ b/lib/public/modules/debate.js
@@ -53,7 +53,15 @@ export function resetDebateState() {
 }
 
 function buildAvatarUrl(meta) {
-  return "https://api.dicebear.com/7.x/" + (meta.avatarStyle || "bottts") + "/svg?seed=" + encodeURIComponent(meta.avatarSeed || meta.mateId || "mate");
+  return mateAvatarUrl({
+    id: meta.mateId,
+    profile: {
+      avatarStyle: meta.avatarStyle || "imprint",
+      avatarSeed: meta.avatarSeed || meta.mateId || "mate",
+      avatarColor: meta.avatarColor || "#5857fc",
+      avatarCustom: meta.avatarCustom || "",
+    },
+  }, 32);
 }
 
 // --- Float info panel ---
@@ -943,12 +951,9 @@ function createPanelItem(mate) {
   cb.type = "checkbox";
   item.appendChild(cb);
 
-  var avatarSrc = "https://api.dicebear.com/7.x/" +
-    ((mate.profile && mate.profile.avatarStyle) || "bottts") +
-    "/svg?seed=" + encodeURIComponent((mate.profile && mate.profile.avatarSeed) || mate.id);
   var avi = document.createElement("img");
   avi.className = "debate-panel-item-avatar";
-  avi.src = avatarSrc;
+  avi.src = mateAvatarUrl(mate, 32);
   item.appendChild(avi);
 
   var info = document.createElement("div");

--- a/lib/public/modules/mate-sidebar.js
+++ b/lib/public/modules/mate-sidebar.js
@@ -139,7 +139,7 @@ export function showMateSidebar(mateId, mateData) {
   var profile = mateData.profile || mateData || {};
   var displayName = profile.displayName || mateData.displayName || mateData.name || "Mate";
 
-  var mateColor = profile.avatarColor || mateData.avatarColor || "#7c3aed";
+  var mateColor = profile.avatarColor || mateData.avatarColor || "#5857fc";
 
   var mateAvUrl = mateAvatarUrl(mateData, 32);
   if (avatarEl) avatarEl.src = mateAvUrl;
@@ -267,7 +267,7 @@ export function updateMateSidebarProfile(mateData) {
   if (!columnEl || !mateData) return;
   var profile = mateData.profile || mateData || {};
   var displayName = profile.displayName || mateData.displayName || mateData.name || "Mate";
-  var mateColor = profile.avatarColor || mateData.avatarColor || "#7c3aed";
+  var mateColor = profile.avatarColor || mateData.avatarColor || "#5857fc";
 
   if (avatarEl) {
     avatarEl.src = mateAvatarUrl(mateData, 32);

--- a/lib/public/modules/mention.js
+++ b/lib/public/modules/mention.js
@@ -112,7 +112,7 @@ function buildMentionCandidates() {
         kind: "mate",
         id: m.id,
         name: (m.profile && m.profile.displayName) || m.name || "Mate",
-        color: (m.profile && m.profile.avatarColor) || "#6c5ce7",
+        color: (m.profile && m.profile.avatarColor) || "#5857fc",
         avatarSrc: mateAvatarUrl(m, 24),
         vendor: m.vendor || "claude",
         bio: m.bio || (m.profile && m.profile.bio) || "",
@@ -134,9 +134,8 @@ function buildMentionCandidates() {
       kind: "user",
       id: u.id,
       name: u.displayName || u.username || "User",
-      color: u.avatarColor || "#7c3aed",
-      // Build dicebear url from style+seed; matches userAvatarUrl shape.
-      avatarSrc: "https://api.dicebear.com/7.x/" + (u.avatarStyle || "thumbs") + "/svg?seed=" + encodeURIComponent(u.avatarSeed || u.username || u.id),
+      color: u.avatarColor || "#5857fc",
+      avatarSrc: userAvatarUrl(u, 24),
       vendor: null,
       bio: u.username ? "@" + u.username : "",
       primary: false,
@@ -424,7 +423,7 @@ export function stickyReapplyMention() {
   var kind = selectedMateKind;
   var id = selectedMateId;
   var name = selectedMateName;
-  var color = selectedMateColor || "#6c5ce7";
+  var color = selectedMateColor || "#5857fc";
   var avatarSrc = selectedMateAvatar || "";
   // Reset index but keep selection
   mentionAtIdx = -1;
@@ -516,7 +515,7 @@ export function handleMentionStart(msg) {
     header.className = "dm-bubble-header";
     var nameSpan = document.createElement("span");
     nameSpan.className = "dm-bubble-name";
-    nameSpan.style.color = msg.avatarColor || "#6c5ce7";
+    nameSpan.style.color = msg.avatarColor || "#5857fc";
     nameSpan.textContent = msg.mateName || "Mate";
     header.appendChild(nameSpan);
 
@@ -556,7 +555,7 @@ export function handleMentionStart(msg) {
     // Project chat: mention block style
     currentMentionEl = document.createElement("div");
     currentMentionEl.className = "msg-mention";
-    currentMentionEl.style.setProperty("--mention-color", msg.avatarColor || "#6c5ce7");
+    currentMentionEl.style.setProperty("--mention-color", msg.avatarColor || "#5857fc");
 
     var header = document.createElement("div");
     header.className = "mention-header";
@@ -754,15 +753,13 @@ function isDmLayout() {
 
 function getMyAvatarSrc() {
   if (document.body.dataset.myAvatarUrl) return document.body.dataset.myAvatarUrl;
-  var myUser = null;
-  try { myUser = JSON.parse(localStorage.getItem("clay_my_user") || "null"); } catch (e) {}
+  var myUser = (store.get('cachedAllUsers') || []).find(function (u) { return u.id === store.get('myUserId'); });
   return userAvatarUrl(myUser || {}, 36);
 }
 
 function getMyDisplayName() {
   if (document.body.dataset.myDisplayName) return document.body.dataset.myDisplayName;
-  var myUser = null;
-  try { myUser = JSON.parse(localStorage.getItem("clay_my_user") || "null"); } catch (e) {}
+  var myUser = (store.get('cachedAllUsers') || []).find(function (u) { return u.id === store.get('myUserId'); });
   return (myUser && (myUser.displayName || myUser.username)) || "Me";
 }
 
@@ -772,14 +769,27 @@ function timeStr() {
 }
 
 function buildMentionAvatarUrl(meta) {
-  return "https://api.dicebear.com/7.x/" + (meta.avatarStyle || "bottts") + "/svg?seed=" + encodeURIComponent(meta.avatarSeed || meta.mateId);
+  return mateAvatarUrl({
+    id: meta.mateId,
+    profile: {
+      avatarStyle: meta.avatarStyle || "imprint",
+      avatarSeed: meta.avatarSeed || meta.mateId,
+      avatarColor: meta.avatarColor || "#5857fc",
+      avatarCustom: meta.avatarCustom || "",
+    },
+  }, 36);
 }
 
 function buildUserAvatarUrlFromEntry(entry, who) {
   // who = "from" | "target"
-  var style = entry[who + "AvatarStyle"] || "thumbs";
   var seed = entry[who + "AvatarSeed"] || entry[who === "from" ? "fromName" : "targetName"] || entry[who === "from" ? "from" : "targetUserId"];
-  return "https://api.dicebear.com/7.x/" + style + "/svg?seed=" + encodeURIComponent(seed || "user");
+  return userAvatarUrl({
+    id: entry[who === "from" ? "from" : "targetUserId"],
+    avatarStyle: entry[who + "AvatarStyle"] || "imprint",
+    avatarSeed: seed || "user",
+    avatarColor: entry[who + "AvatarColor"] || "#5857fc",
+    avatarCustom: entry[who + "AvatarCustom"] || "",
+  }, 36);
 }
 
 // Render a user-to-user @mention bubble (live receive AND history replay).
@@ -1021,7 +1031,7 @@ export function renderMentionResponse(entry) {
     header.className = "dm-bubble-header";
     var nameSpan = document.createElement("span");
     nameSpan.className = "dm-bubble-name";
-    nameSpan.style.color = entry.avatarColor || "#6c5ce7";
+    nameSpan.style.color = entry.avatarColor || "#5857fc";
     nameSpan.textContent = entry.mateName || "Mate";
     header.appendChild(nameSpan);
 
@@ -1050,7 +1060,7 @@ export function renderMentionResponse(entry) {
     // Project chat: use mention block style
     var el = document.createElement("div");
     el.className = "msg-mention";
-    el.style.setProperty("--mention-color", entry.avatarColor || "#6c5ce7");
+    el.style.setProperty("--mention-color", entry.avatarColor || "#5857fc");
 
     var mheader = document.createElement("div");
     mheader.className = "mention-header";

--- a/lib/public/modules/profile.js
+++ b/lib/public/modules/profile.js
@@ -1,31 +1,18 @@
-// User profile module — Discord-style popover for name, language, avatar
+// User profile module — profile popovers for people and Mates
 // Stores profile server-side in ~/.clay/profile.json
-// Avatar generated via DiceBear API (deterministic SVG from seed)
+// Generated identities use deterministic Clay Imprints.
 
 import { iconHtml, refreshIcons } from './icons.js';
 import { setSTTLang } from './stt.js';
-import { avatarUrl, mateAvatarUrl, AVATAR_STYLES } from './avatar.js';
+import { avatarUrl, mateAvatarUrl, mateMarkUrl } from './avatar.js';
 import { store } from './store.js';
 import { applyTerminalFont } from './terminal-prefs.js';
 
 var ctx;
-var profile = { name: '', lang: 'en-US', avatarStyle: 'thumbs', avatarSeed: '', avatarColor: '#7c3aed', avatarCustom: '' };
+var profile = { name: '', lang: 'en-US', avatarStyle: 'imprint', avatarSeed: '', avatarColor: '#5857fc', avatarCustom: '' };
 var profileUsername = '';
 var popoverEl = null;
 var saveTimer = null;
-var previewSeed = '';
-
-// AVATAR_STYLES imported from avatar.js
-
-var COLORS = [
-  '#7c3aed', '#4f46e5', '#2563eb', '#0891b2',
-  '#059669', '#65a30d', '#d97706', '#dc2626',
-  '#db2777', '#6366f1', '#0d9488', '#ea580c',
-  '#475569', '#1e293b', '#be123c', '#a21caf',
-  '#0369a1', '#15803d',
-];
-
-// avatarUrl imported from avatar.js
 
 function getAvatarSeed() {
   return profile.avatarSeed || 'anonymous';
@@ -68,7 +55,7 @@ export function applyToIsland() {
   var existingLetter = avatarWrap.querySelector('.user-island-avatar-letter');
   var url = profile.avatarCustom
     ? profile.avatarCustom
-    : avatarUrl(profile.avatarStyle || 'thumbs', getAvatarSeed(), 32);
+    : avatarUrl(profile.avatarStyle || 'imprint', getAvatarSeed(), 32);
 
   if (existingImg) {
     existingImg.src = url;
@@ -81,6 +68,12 @@ export function applyToIsland() {
   }
 
   nameEl.textContent = displayName;
+  document.body.dataset.myAvatarUrl = url;
+  document.body.dataset.myDisplayName = displayName;
+  var messageAvatars = document.querySelectorAll('.dm-bubble-avatar-me, .icon-strip-me-avatar');
+  for (var avatarIndex = 0; avatarIndex < messageAvatars.length; avatarIndex++) {
+    messageAvatars[avatarIndex].src = url;
+  }
 
   // Show CTA if user hasn't personalized their name
   var ctaEl = document.querySelector('.user-island-cta');
@@ -104,7 +97,7 @@ export function showAvatarPositioner(img, objectUrl, onDone) {
   var offsetX = 0;
   var offsetY = 0;
 
-  // Fit image so shorter side fills the circle
+  // Fit image so the shorter side fills the imprint frame.
   var baseScale = Math.max(viewSize / img.width, viewSize / img.height);
 
   function clampOffsets() {
@@ -287,22 +280,20 @@ function showPopover() {
   popoverEl.className = 'profile-popover';
 
   var displayName = profile.name || '';
-  var currentColor = profile.avatarColor || '#7c3aed';
-  var currentStyle = profile.avatarStyle || 'thumbs';
+  var currentStyle = profile.avatarStyle || 'imprint';
   var seed = getAvatarSeed();
-  previewSeed = seed;
 
   var html = '';
 
   // Banner + close
-  html += '<div class="profile-banner" style="background:' + currentColor + '">';
+  html += '<div class="profile-banner">';
   html += '<button class="profile-close-btn">&times;</button>';
   html += '</div>';
 
   // Avatar row (overlapping banner)
   html += '<div class="profile-avatar-row">';
   html += '<div class="profile-popover-avatar">';
-  html += '<img class="profile-popover-avatar-img" src="' + (profile.avatarCustom || avatarUrl(currentStyle, seed, 80)) + '" alt="avatar">';
+  html += '<img class="profile-popover-avatar-img" src="' + (profile.avatarCustom || avatarUrl(currentStyle, seed, 80)) + '" alt="' + escapeAttr(displayName || 'Clay user') + '">';
   html += '</div>';
   html += '<div class="profile-name-display">' + escapeAttr(displayName || 'Awesome Clay User') + '</div>';
   html += '</div>';
@@ -316,40 +307,18 @@ function showPopover() {
   html += '<input type="text" class="profile-field-input" id="profile-name-input" value="' + escapeAttr(displayName) + '" placeholder="Enter your name..." maxlength="50" spellcheck="false" autocomplete="off">';
   html += '</div>';
 
-  // Avatar picker
+  // Clay Imprint or custom photo
   html += '<div class="profile-field">';
-  html += '<label class="profile-field-label">Avatar <button class="profile-shuffle-btn" title="Shuffle">' + iconHtml('shuffle') + '</button></label>';
-  html += '<div class="profile-avatar-grid">';
-  // Upload button as first cell
-  var uploadActive = profile.avatarCustom ? ' profile-avatar-option-active' : '';
-  html += '<button class="profile-avatar-option profile-avatar-upload' + uploadActive + '" title="Upload photo">';
-  if (profile.avatarCustom) {
-    html += '<img src="' + profile.avatarCustom + '" alt="Custom" class="profile-avatar-custom-preview">';
-  } else {
-    html += '<span class="profile-avatar-upload-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>';
-  }
-  html += '</button>';
+  html += '<label class="profile-field-label">Identity</label>';
+  html += '<div class="profile-imprint-panel">';
+  html += '<div class="profile-imprint-preview"><img src="' + avatarUrl(currentStyle, seed, 72) + '" alt="Generated Clay Imprint"><span><strong>Clay Imprint</strong><small>Unique to this identity</small></span></div>';
+  html += '<div class="profile-imprint-actions">';
+  html += '<button class="profile-use-imprint' + (!profile.avatarCustom ? ' is-active' : '') + '" type="button">Use imprint</button>';
+  html += '<button class="profile-regenerate-imprint" type="button" title="Generate another imprint">' + iconHtml('shuffle') + ' New imprint</button>';
+  html += '<button class="profile-avatar-upload' + (profile.avatarCustom ? ' is-active' : '') + '" type="button">Upload photo</button>';
+  html += '</div>';
+  html += '</div>';
   html += '<input type="file" id="profile-avatar-file" accept="image/*" style="display:none">';
-  for (var j = 0; j < AVATAR_STYLES.length; j++) {
-    var st = AVATAR_STYLES[j];
-    var activeS = (!profile.avatarCustom && currentStyle === st.id) ? ' profile-avatar-option-active' : '';
-    html += '<button class="profile-avatar-option' + activeS + '" data-style="' + st.id + '" title="' + st.name + '">';
-    html += '<img src="' + avatarUrl(st.id, seed, 40) + '" alt="' + st.name + '">';
-    html += '</button>';
-  }
-  html += '</div>';
-  html += '</div>';
-
-  // Color
-  html += '<div class="profile-field">';
-  html += '<label class="profile-field-label">Color</label>';
-  html += '<div class="profile-color-grid">';
-  for (var k = 0; k < COLORS.length; k++) {
-    var c = COLORS[k];
-    var activeC = (currentColor === c) ? ' profile-color-active' : '';
-    html += '<button class="profile-color-swatch' + activeC + '" data-color="' + c + '" style="background:' + c + '"></button>';
-  }
-  html += '</div>';
   html += '</div>';
 
   html += '</div>'; // close body
@@ -403,15 +372,11 @@ function showPopover() {
               profile.avatarCustom = data.avatar;
               applyToIsland();
               updatePopoverHeader();
-              if (popoverEl) {
-                popoverEl.querySelectorAll('.profile-avatar-option').forEach(function(b) {
-                  b.classList.remove('profile-avatar-option-active');
-                });
-              }
               if (uploadBtn) {
-                uploadBtn.classList.add('profile-avatar-option-active');
-                uploadBtn.innerHTML = '<img src="' + data.avatar + '" alt="Custom" class="profile-avatar-custom-preview">';
+                uploadBtn.classList.add('is-active');
               }
+              var imprintButton = popoverEl && popoverEl.querySelector('.profile-use-imprint');
+              if (imprintButton) imprintButton.classList.remove('is-active');
               debouncedSave();
             }
           });
@@ -431,45 +396,25 @@ function showPopover() {
     });
   }
 
-  // Avatar style — clicking confirms both the style and the current previewSeed
-  popoverEl.querySelectorAll('.profile-avatar-option[data-style]').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      profile.avatarCustom = '';
-      profile.avatarStyle = btn.dataset.style;
-      profile.avatarSeed = previewSeed;
-      applyToIsland();
-      updatePopoverHeader();
-      popoverEl.querySelectorAll('.profile-avatar-option').forEach(function(b) {
-        b.classList.remove('profile-avatar-option-active');
-      });
-      btn.classList.add('profile-avatar-option-active');
-      // Reset upload button to + icon
-      var upBtn = popoverEl.querySelector('.profile-avatar-upload');
-      if (upBtn) upBtn.innerHTML = '<span class="profile-avatar-upload-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>';
-      debouncedSave();
-    });
+  popoverEl.querySelector('.profile-use-imprint').addEventListener('click', function() {
+    profile.avatarCustom = '';
+    applyToIsland();
+    updatePopoverHeader();
+    popoverEl.querySelector('.profile-use-imprint').classList.add('is-active');
+    popoverEl.querySelector('.profile-avatar-upload').classList.remove('is-active');
+    debouncedSave();
   });
 
-  // Shuffle button — only changes preview candidates, not the actual profile
-  popoverEl.querySelector('.profile-shuffle-btn').addEventListener('click', function(e) {
-    e.stopPropagation();
-    previewSeed = Math.random().toString(36).substring(2, 10);
-    refreshAvatarPreviews();
-  });
-
-  // Color swatches
-  popoverEl.querySelectorAll('.profile-color-swatch').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      profile.avatarColor = btn.dataset.color;
-      applyToIsland();
-      var bannerEl = popoverEl.querySelector('.profile-banner');
-      if (bannerEl) bannerEl.style.background = profile.avatarColor;
-      popoverEl.querySelectorAll('.profile-color-swatch').forEach(function(b) {
-        b.classList.remove('profile-color-active');
-      });
-      btn.classList.add('profile-color-active');
-      debouncedSave();
-    });
+  popoverEl.querySelector('.profile-regenerate-imprint').addEventListener('click', function() {
+    profile.avatarCustom = '';
+    profile.avatarStyle = 'imprint';
+    profile.avatarSeed = Math.random().toString(36).substring(2, 10);
+    applyToIsland();
+    updatePopoverHeader();
+    refreshImprintPreview(popoverEl, profile.avatarStyle, profile.avatarSeed);
+    popoverEl.querySelector('.profile-use-imprint').classList.add('is-active');
+    popoverEl.querySelector('.profile-avatar-upload').classList.remove('is-active');
+    debouncedSave();
   });
 
   // Prevent clicks inside popover from closing it
@@ -497,17 +442,15 @@ function updatePopoverHeader() {
   var nd = popoverEl.querySelector('.profile-name-display');
   if (img) img.src = profile.avatarCustom
     ? profile.avatarCustom
-    : avatarUrl(profile.avatarStyle || 'thumbs', getAvatarSeed(), 80);
+    : avatarUrl(profile.avatarStyle || 'imprint', getAvatarSeed(), 80);
   if (nd) nd.textContent = profile.name || 'Awesome Clay User';
 }
 
 
-function refreshAvatarPreviews() {
-  if (!popoverEl) return;
-  popoverEl.querySelectorAll('.profile-avatar-option[data-style] img').forEach(function(img) {
-    var style = img.closest('.profile-avatar-option').dataset.style;
-    img.src = avatarUrl(style, previewSeed, 40);
-  });
+function refreshImprintPreview(root, style, seed) {
+  if (!root) return;
+  var img = root.querySelector('.profile-imprint-preview img');
+  if (img) img.src = avatarUrl(style || 'imprint', seed || 'anonymous', 72);
 }
 
 function closeOnOutside(e) {
@@ -610,7 +553,6 @@ export function getProfileLang() {
 // --- Mate profile popover (reuses same UI minus language) ---
 var matePopoverEl = null;
 var mateSaveTimer = null;
-var matePreviewSeed = '';
 
 export function showMateProfilePopover(anchorEl, mateData, onUpdate) {
   if (matePopoverEl) {
@@ -620,11 +562,10 @@ export function showMateProfilePopover(anchorEl, mateData, onUpdate) {
 
   var mp = mateData.profile || {};
   var mateName = mp.displayName || mateData.name || '';
-  var mateColor = mp.avatarColor || '#7c3aed';
-  var mateStyle = mp.avatarStyle || 'bottts';
+  var mateColor = mp.avatarColor || '#5857fc';
+  var mateStyle = mp.avatarStyle || 'imprint';
   var mateSeed = mp.avatarSeed || mateData.id || 'mate';
   var mateCustom = mp.avatarCustom || '';
-  matePreviewSeed = mateSeed;
 
   matePopoverEl = document.createElement('div');
   matePopoverEl.className = 'profile-popover mate-profile-popover';
@@ -632,15 +573,15 @@ export function showMateProfilePopover(anchorEl, mateData, onUpdate) {
   var html = '';
 
   // Banner + close
-  html += '<div class="profile-banner" style="background:' + mateColor + '">';
+  html += '<div class="profile-banner">';
   html += '<button class="profile-close-btn">&times;</button>';
   html += '</div>';
 
   // Avatar row
-  var mateAvatarSrc = mateCustom ? mateCustom : avatarUrl(mateStyle, mateSeed, 80);
+  var mateAvatarSrc = mateCustom ? mateCustom : mateMarkUrl(mateName || 'Mate', 80);
   html += '<div class="profile-avatar-row">';
   html += '<div class="profile-popover-avatar">';
-  html += '<img class="profile-popover-avatar-img" src="' + mateAvatarSrc + '" alt="avatar">';
+  html += '<img class="profile-popover-avatar-img" src="' + mateAvatarSrc + '" alt="' + escapeAttr(mateName || 'Clay Mate') + '">';
   html += '</div>';
   html += '<div class="profile-name-display">' + escapeAttr(mateName || 'New Mate') + '</div>';
   html += '</div>';
@@ -658,40 +599,17 @@ export function showMateProfilePopover(anchorEl, mateData, onUpdate) {
   var mateAvatarLocked = mp.avatarLocked || false;
   if (!mateAvatarLocked) {
   html += '<div class="profile-field">';
-  html += '<label class="profile-field-label">Avatar <button class="profile-shuffle-btn" title="Shuffle">' + iconHtml('shuffle') + '</button></label>';
-  html += '<div class="profile-avatar-grid">';
-  // Upload button as first cell
-  var mateUploadActive = mateCustom ? ' profile-avatar-option-active' : '';
-  html += '<button class="profile-avatar-option profile-avatar-upload' + mateUploadActive + '" title="Upload photo">';
-  if (mateCustom) {
-    html += '<img src="' + mateCustom + '" alt="Custom" class="profile-avatar-custom-preview">';
-  } else {
-    html += '<span class="profile-avatar-upload-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>';
-  }
-  html += '</button>';
+  html += '<label class="profile-field-label">Identity</label>';
+  html += '<div class="profile-imprint-panel">';
+  html += '<div class="profile-imprint-preview"><img src="' + mateMarkUrl(mateName || 'Mate', 72) + '" alt="Clay Mate initial"><span><strong>Mate initial</strong><small>Based on display name</small></span></div>';
+  html += '<div class="profile-imprint-actions profile-mate-mark-actions">';
+  html += '<button class="profile-use-imprint' + (!mateCustom ? ' is-active' : '') + '" type="button">Use initial</button>';
+  html += '<button class="profile-avatar-upload' + (mateCustom ? ' is-active' : '') + '" type="button">Upload image</button>';
+  html += '</div>';
+  html += '</div>';
   html += '<input type="file" id="mate-profile-avatar-file" accept="image/*" style="display:none">';
-  for (var j = 0; j < AVATAR_STYLES.length; j++) {
-    var st = AVATAR_STYLES[j];
-    var activeS = (!mateCustom && mateStyle === st.id) ? ' profile-avatar-option-active' : '';
-    html += '<button class="profile-avatar-option' + activeS + '" data-style="' + st.id + '" title="' + st.name + '">';
-    html += '<img src="' + avatarUrl(st.id, mateSeed, 40) + '" alt="' + st.name + '">';
-    html += '</button>';
-  }
-  html += '</div>';
   html += '</div>';
   }
-
-  // Color
-  html += '<div class="profile-field">';
-  html += '<label class="profile-field-label">Color</label>';
-  html += '<div class="profile-color-grid">';
-  for (var k = 0; k < COLORS.length; k++) {
-    var c = COLORS[k];
-    var activeC = (mateColor === c) ? ' profile-color-active' : '';
-    html += '<button class="profile-color-swatch' + activeC + '" data-color="' + c + '" style="background:' + c + '"></button>';
-  }
-  html += '</div>';
-  html += '</div>';
 
   html += '</div>'; // close body
 
@@ -746,7 +664,9 @@ export function showMateProfilePopover(anchorEl, mateData, onUpdate) {
     var nd = matePopoverEl.querySelector('.profile-name-display');
     if (img) img.src = mateProfile.avatarCustom
       ? mateProfile.avatarCustom
-      : avatarUrl(mateProfile.avatarStyle, mateProfile.avatarSeed, 80);
+      : mateMarkUrl(mateProfile.displayName || 'Mate', 80);
+    var preview = matePopoverEl.querySelector('.profile-imprint-preview img');
+    if (preview) preview.src = mateMarkUrl(mateProfile.displayName || 'Mate', 72);
     if (nd) nd.textContent = mateProfile.displayName || 'New Mate';
   }
 
@@ -791,15 +711,11 @@ export function showMateProfilePopover(anchorEl, mateData, onUpdate) {
             if (data.ok) {
               mateProfile.avatarCustom = data.avatar;
               updateMatePopoverHeader();
-              if (matePopoverEl) {
-                matePopoverEl.querySelectorAll('.profile-avatar-option').forEach(function(b) {
-                  b.classList.remove('profile-avatar-option-active');
-                });
-              }
               if (mateUploadBtn) {
-                mateUploadBtn.classList.add('profile-avatar-option-active');
-                mateUploadBtn.innerHTML = '<img src="' + data.avatar + '" alt="Custom" class="profile-avatar-custom-preview">';
+                mateUploadBtn.classList.add('is-active');
               }
+              var imprintButton = matePopoverEl && matePopoverEl.querySelector('.profile-use-imprint');
+              if (imprintButton) imprintButton.classList.remove('is-active');
               debouncedMateUpdate();
             }
           });
@@ -819,48 +735,15 @@ export function showMateProfilePopover(anchorEl, mateData, onUpdate) {
     });
   }
 
-  // Avatar style
-  matePopoverEl.querySelectorAll('.profile-avatar-option[data-style]').forEach(function(btn) {
-    btn.addEventListener('click', function() {
+  if (!mateAvatarLocked) {
+    matePopoverEl.querySelector('.profile-use-imprint').addEventListener('click', function() {
       mateProfile.avatarCustom = '';
-      mateProfile.avatarStyle = btn.dataset.style;
-      mateProfile.avatarSeed = matePreviewSeed;
       updateMatePopoverHeader();
-      matePopoverEl.querySelectorAll('.profile-avatar-option').forEach(function(b) {
-        b.classList.remove('profile-avatar-option-active');
-      });
-      btn.classList.add('profile-avatar-option-active');
-      // Reset upload button to + icon
-      var upBtn = matePopoverEl.querySelector('.profile-avatar-upload');
-      if (upBtn) upBtn.innerHTML = '<span class="profile-avatar-upload-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>';
+      matePopoverEl.querySelector('.profile-use-imprint').classList.add('is-active');
+      matePopoverEl.querySelector('.profile-avatar-upload').classList.remove('is-active');
       debouncedMateUpdate();
     });
-  });
-
-  // Shuffle
-  matePopoverEl.querySelector('.profile-shuffle-btn').addEventListener('click', function(e) {
-    e.stopPropagation();
-    matePreviewSeed = Math.random().toString(36).substring(2, 10);
-    if (!matePopoverEl) return;
-    matePopoverEl.querySelectorAll('.profile-avatar-option[data-style] img').forEach(function(img) {
-      var style = img.closest('.profile-avatar-option').dataset.style;
-      img.src = avatarUrl(style, matePreviewSeed, 40);
-    });
-  });
-
-  // Color swatches
-  matePopoverEl.querySelectorAll('.profile-color-swatch').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-      mateProfile.avatarColor = btn.dataset.color;
-      var bannerEl = matePopoverEl.querySelector('.profile-banner');
-      if (bannerEl) bannerEl.style.background = mateProfile.avatarColor;
-      matePopoverEl.querySelectorAll('.profile-color-swatch').forEach(function(b) {
-        b.classList.remove('profile-color-active');
-      });
-      btn.classList.add('profile-color-active');
-      debouncedMateUpdate();
-    });
-  });
+  }
 
   matePopoverEl.addEventListener('click', function(e) { e.stopPropagation(); });
 

--- a/lib/public/modules/session-actions.js
+++ b/lib/public/modules/session-actions.js
@@ -29,13 +29,14 @@ function positionMenu() {
   var rect = button.getBoundingClientRect();
   var width = menu.offsetWidth;
   menu.style.top = Math.round(rect.bottom + 6) + "px";
-  menu.style.left = Math.max(8, Math.round(rect.right - width)) + "px";
+  menu.style.left = Math.max(8, Math.min(window.innerWidth - width - 8, Math.round(rect.right - width))) + "px";
 }
 
 function actionRow(icon, label, description) {
   var row = document.createElement("button");
   row.type = "button";
   row.className = "session-actions-row";
+  row.setAttribute("role", "menuitem");
   row.innerHTML = iconHtml(icon, "session-actions-row-icon") +
     '<span class="session-actions-row-copy"><strong></strong><span></span></span>' +
     iconHtml("chevron-right", "session-actions-row-chevron");
@@ -217,7 +218,8 @@ function showHandoffDialog(options) {
 function showMainMenu() {
   closeMenu();
   var el = menuShell("Session actions");
-  var addWorker = actionRow("bot", "Add AI Worker", "Open a second agent beside this session.");
+  var addWorker = actionRow("bot", "Add AI worker", "Open a second agent beside this session.");
+  addWorker.classList.add("is-primary");
   addWorker.addEventListener("click", function () {
     var sessionId = store.get('activeSessionId');
     if (!sessionId) return;
@@ -228,7 +230,7 @@ function showMainMenu() {
       vendor: store.get('currentVendor') || "claude",
     });
   });
-  var handoff = actionRow("forward", "Continue in another agent", "Carry this conversation into a new session.");
+  var handoff = actionRow("send", "Send context to another agent", "Start a new session with this conversation's context.");
   var unavailable = !store.get('sessionHasHistory') || store.get('sessionIsProcessing');
   handoff.disabled = unavailable;
   handoff.title = unavailable ? "Available after the current turn is complete" : "";

--- a/lib/public/modules/sidebar-mates.js
+++ b/lib/public/modules/sidebar-mates.js
@@ -262,7 +262,7 @@ export function renderSidebarPresence(onlineUsers) {
 // Presence avatar URL helper
 function presenceAvatarUrl(userOrStyle) {
   if (userOrStyle && typeof userOrStyle === "object") return userAvatarUrl(userOrStyle, 24);
-  return userAvatarUrl({ avatarStyle: userOrStyle || "thumbs" }, 24);
+  return userAvatarUrl({ avatarStyle: userOrStyle || "imprint" }, 24);
 }
 
 // renderUserStrip: call with no args to read from store (subscriber pattern),
@@ -424,7 +424,7 @@ export function renderUserStrip(allUsers, onlineUserIds, myUserId, dmFavorites, 
       avatar.className = "icon-strip-user-avatar" + (mate.primary ? " icon-strip-primary-mate" : "");
       avatar.src = mateAvatarUrl(mate, 34);
       avatar.alt = mp.displayName || mate.name || "Mate";
-      var mateColor = (mp.avatarColor) || mate.avatarColor || "#7c3aed";
+      var mateColor = (mp.avatarColor) || mate.avatarColor || "#5857fc";
       avatar.style.background = mateColor + "30";
       el.appendChild(avatar);
 
@@ -679,7 +679,7 @@ function toggleDmUserPicker(anchorEl) {
           bItem.style.opacity = "0.7";
           var bAv = document.createElement("img");
           bAv.className = "dm-user-picker-avatar";
-          bAv.src = mateAvatarUrl({ avatarCustom: b.avatarCustom, avatarStyle: b.avatarStyle || "bottts", avatarSeed: b.displayName, id: b.key }, 28);
+          bAv.src = mateAvatarUrl({ avatarCustom: b.avatarCustom, avatarStyle: b.avatarStyle || "imprint", avatarSeed: b.displayName, id: b.key, avatarColor: b.avatarColor }, 28);
           bAv.alt = b.displayName;
           bItem.appendChild(bAv);
           var bNameWrap = document.createElement("div");
@@ -866,7 +866,8 @@ function toggleDmUserPicker(anchorEl) {
         } else {
           avEl.src = mateAvatarUrl({
             avatarCustom: src.avatarCustom,
-            avatarStyle: src.avatarStyle || "bottts",
+            avatarStyle: src.avatarStyle || "imprint",
+            avatarColor: src.avatarColor,
             avatarSeed: src.displayName,
             id: src.key,
           }, 32);

--- a/lib/public/modules/sidebar-sessions.js
+++ b/lib/public/modules/sidebar-sessions.js
@@ -1543,7 +1543,7 @@ export function updateSessionPresence(presence) {
 
 function presenceAvatarUrl(userOrStyle, seed) {
   if (userOrStyle && typeof userOrStyle === "object") return userAvatarUrl(userOrStyle, 24);
-  return avatarUrl(userOrStyle || "thumbs", seed, 24);
+  return avatarUrl(userOrStyle || "imprint", seed, 24);
 }
 
 function renderPresenceAvatars(el, sessionId) {

--- a/lib/public/style.css
+++ b/lib/public/style.css
@@ -38,3 +38,4 @@
 @import url("css/notifications-center.css");
 @import url("css/tui-attention.css?v=20260829-terminal-canvas1");
 @import url("css/pwa-mobile.css?v=20260824f");
+@import url("css/avatar-imprints.css?v=20260829-imprints1");

--- a/lib/server-auth.js
+++ b/lib/server-auth.js
@@ -414,8 +414,8 @@ function attachAuth(ctx) {
             adminProfile = {
               name: data.displayName || data.username,
               lang: existingProfile.lang || "en-US",
-              avatarColor: existingProfile.avatarColor || "#7c3aed",
-              avatarStyle: existingProfile.avatarStyle || "thumbs",
+              avatarColor: existingProfile.avatarColor || "#5857fc",
+              avatarStyle: existingProfile.avatarStyle || "imprint",
               avatarSeed: existingProfile.avatarSeed || crypto.randomBytes(4).toString("hex"),
             };
           } catch (e) {}

--- a/lib/server-dm.js
+++ b/lib/server-dm.js
@@ -28,9 +28,9 @@ function attachDm(ctx) {
             id: otherUser.id,
             displayName: p.name || otherUser.displayName || otherUser.username,
             username: otherUser.username,
-            avatarStyle: p.avatarStyle || "thumbs",
+            avatarStyle: p.avatarStyle || "imprint",
             avatarSeed: p.avatarSeed || otherUser.username,
-            avatarColor: p.avatarColor || "#7c3aed",
+            avatarColor: p.avatarColor || "#5857fc",
             avatarCustom: p.avatarCustom || "",
           };
         }
@@ -69,9 +69,9 @@ function attachDm(ctx) {
             id: mate.id,
             displayName: mp.displayName || mate.name || "New Mate",
             username: mate.id,
-            avatarStyle: mp.avatarStyle || "bottts",
+            avatarStyle: mp.avatarStyle || "imprint",
             avatarSeed: mp.avatarSeed || mate.id,
-            avatarColor: mp.avatarColor || "#6c5ce7",
+            avatarColor: mp.avatarColor || "#5857fc",
             avatarCustom: mp.avatarCustom || "",
             isMate: true,
             primary: !!mate.primary,
@@ -94,9 +94,9 @@ function attachDm(ctx) {
           id: targetUser.id,
           displayName: tp.name || targetUser.displayName || targetUser.username,
           username: targetUser.username,
-          avatarStyle: tp.avatarStyle || "thumbs",
+          avatarStyle: tp.avatarStyle || "imprint",
           avatarSeed: tp.avatarSeed || targetUser.username,
-          avatarColor: tp.avatarColor || "#7c3aed",
+          avatarColor: tp.avatarColor || "#5857fc",
           avatarCustom: tp.avatarCustom || "",
         } : null,
       }));
@@ -191,9 +191,9 @@ function attachDm(ctx) {
           displayName: p.name || u.displayName || u.username,
           username: u.username,
           role: u.role,
-          avatarStyle: p.avatarStyle || "thumbs",
+          avatarStyle: p.avatarStyle || "imprint",
           avatarSeed: p.avatarSeed || u.username,
-          avatarColor: p.avatarColor || "#7c3aed",
+          avatarColor: p.avatarColor || "#5857fc",
           avatarCustom: p.avatarCustom || "",
         };
       });

--- a/lib/server-mates.js
+++ b/lib/server-mates.js
@@ -152,7 +152,7 @@ function attachMates(ctx) {
             displayName: bDef2.displayName,
             bio: bDef2.bio,
             avatarCustom: bDef2.avatarCustom || "",
-            avatarStyle: bDef2.avatarStyle || "bottts",
+            avatarStyle: bDef2.avatarStyle || "imprint",
             avatarColor: bDef2.avatarColor || "",
           });
         }
@@ -186,7 +186,7 @@ function attachMates(ctx) {
               displayName: bDef3.displayName,
               bio: bDef3.bio,
               avatarCustom: bDef3.avatarCustom || "",
-              avatarStyle: bDef3.avatarStyle || "bottts",
+              avatarStyle: bDef3.avatarStyle || "imprint",
               avatarColor: bDef3.avatarColor || "",
             });
           }
@@ -227,7 +227,7 @@ function attachMates(ctx) {
         for (var abkR = 0; abkR < missingKeysR.length; abkR++) {
           var bDefR = builtinDefsR.getBuiltinByKey(missingKeysR[abkR]);
           if (bDefR) {
-            availableBuiltinsR.push({ key: bDefR.key, displayName: bDefR.displayName, bio: bDefR.bio, avatarCustom: bDefR.avatarCustom || "", avatarStyle: bDefR.avatarStyle || "bottts", avatarColor: bDefR.avatarColor || "" });
+            availableBuiltinsR.push({ key: bDefR.key, displayName: bDefR.displayName, bio: bDefR.bio, avatarCustom: bDefR.avatarCustom || "", avatarStyle: bDefR.avatarStyle || "imprint", avatarColor: bDefR.avatarColor || "" });
           }
         }
         ws.send(JSON.stringify({ type: "mate_created", mate: newMate, projectSlug: readdSlug, availableBuiltins: availableBuiltinsR, dmFavorites: updatedFavsR }));

--- a/lib/server-settings.js
+++ b/lib/server-settings.js
@@ -21,7 +21,7 @@ function attachSettings(ctx) {
           res.end('{"error":"unauthorized"}');
           return true;
         }
-        var profile = mu.profile || { name: "", lang: "en-US", avatarColor: "#7c3aed", avatarStyle: "thumbs", avatarSeed: "", avatarCustom: "" };
+        var profile = mu.profile || { name: "", lang: "en-US", avatarColor: "#5857fc", avatarStyle: "imprint", avatarSeed: "", avatarCustom: "" };
         profile.username = mu.username;
         profile.userId = mu.id;
         profile.role = mu.role;
@@ -35,7 +35,7 @@ function attachSettings(ctx) {
         res.end(JSON.stringify(profile));
         return true;
       }
-      var profile = { name: "", lang: "en-US", avatarColor: "#7c3aed", avatarStyle: "thumbs", avatarSeed: "", avatarCustom: "" };
+      var profile = { name: "", lang: "en-US", avatarColor: "#5857fc", avatarStyle: "imprint", avatarSeed: "", avatarCustom: "" };
       try {
         var raw = fs.readFileSync(profilePath, "utf8");
         var saved = JSON.parse(raw);

--- a/lib/server.js
+++ b/lib/server.js
@@ -355,7 +355,7 @@ function createServer(opts) {
     // origin. External sites still cannot frame Clay; frame-ancestors below
     // is the modern equivalent for browsers that honor CSP.
     "X-Frame-Options": "SAMEORIGIN",
-    "Content-Security-Policy": "default-src 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; img-src * data: blob:; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://esm.sh https://api.dicebear.com https://api.open-meteo.com https://ipapi.co; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net;",
+    "Content-Security-Policy": "default-src 'self'; frame-ancestors 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://esm.sh; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net; img-src * data: blob:; connect-src 'self' ws: wss: https://cdn.jsdelivr.net https://esm.sh https://api.open-meteo.com https://ipapi.co; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net;",
   };
   if (tlsOptions) {
     securityHeaders["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
@@ -1418,8 +1418,9 @@ function createServer(opts) {
           id: u.id,
           displayName: p.name || u.displayName || u.username,
           username: u.username,
-          avatarStyle: p.avatarStyle || "thumbs",
+          avatarStyle: p.avatarStyle || "imprint",
           avatarSeed: p.avatarSeed || u.username,
+          avatarColor: p.avatarColor || "#5857fc",
           avatarCustom: p.avatarCustom || "",
         });
       });
@@ -1451,9 +1452,9 @@ function createServer(opts) {
           displayName: p.name || u.displayName || u.username,
           username: u.username,
           role: u.role,
-          avatarStyle: p.avatarStyle || "thumbs",
+          avatarStyle: p.avatarStyle || "imprint",
           avatarSeed: p.avatarSeed || u.username,
-          avatarColor: p.avatarColor || "#7c3aed",
+          avatarColor: p.avatarColor || "#5857fc",
           avatarCustom: p.avatarCustom || "",
         };
       });

--- a/lib/users.js
+++ b/lib/users.js
@@ -81,8 +81,8 @@ function createUser(opts) {
     profile: opts.profile || {
       name: opts.displayName || opts.username,
       lang: "en-US",
-      avatarColor: "#7c3aed",
-      avatarStyle: "thumbs",
+      avatarColor: "#5857fc",
+      avatarStyle: "imprint",
       avatarSeed: crypto.randomBytes(4).toString("hex"),
     },
   };
@@ -315,8 +315,8 @@ function createUserWithoutPin(opts) {
     profile: opts.profile || {
       name: opts.displayName || opts.username,
       lang: "en-US",
-      avatarColor: "#7c3aed",
-      avatarStyle: "thumbs",
+      avatarColor: "#5857fc",
+      avatarStyle: "imprint",
       avatarSeed: crypto.randomBytes(4).toString("hex"),
     },
   };

--- a/test/avatar-imprint.test.js
+++ b/test/avatar-imprint.test.js
@@ -1,0 +1,70 @@
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var path = require("node:path");
+var test = require("node:test");
+var url = require("node:url");
+
+var sourcePath = path.join(__dirname, "..", "lib", "public", "modules", "avatar-imprint.js");
+
+function loadModule() {
+  var source = fs.readFileSync(sourcePath, "utf8");
+  return import("data:text/javascript;base64," + Buffer.from(source).toString("base64"));
+}
+
+test("Clay Imprints are deterministic and preserve the requested size", async function () {
+  var module = await loadModule();
+  var first = module.imprintSvg({ style: "thumbs", seed: "sample-user", size: 24, color: "#7c3aed" });
+  var second = module.imprintSvg({ style: "thumbs", seed: "sample-user", size: 24, color: "#7c3aed" });
+  assert.equal(first, second);
+  assert.match(first, /width="24" height="24"/);
+  assert.match(first, /<clipPath/);
+});
+
+test("legacy avatar choices remain part of the identity hash", async function () {
+  var module = await loadModule();
+  var thumbs = module.imprintSvg({ style: "thumbs", seed: "same-user", size: 64, color: "#5857fc" });
+  var bots = module.imprintSvg({ style: "bottts", seed: "same-user", size: 64, color: "#5857fc" });
+  var imprint = module.imprintSvg({ style: "imprint", seed: "same-user", size: 64, color: "#5857fc" });
+  assert.notEqual(thumbs, bots);
+  assert.notEqual(thumbs, imprint);
+});
+
+test("every identity uses the same official graphite, paper, and indigo palette", async function () {
+  var module = await loadModule();
+  var purple = module.imprintSvg({ style: "imprint", seed: "sample-user", size: 64, color: "#7c3aed" });
+  var green = module.imprintSvg({ style: "imprint", seed: "sample-user", size: 64, color: "#07e5a3" });
+  assert.equal(purple, green);
+  assert.match(purple, /#5857fc/);
+});
+
+test("generated avatars are local SVG data URLs with no remote dependency", async function () {
+  var module = await loadModule();
+  var result = module.imprintDataUrl({ style: "imprint", seed: "local-user", size: 32, color: "#466bd6" });
+  assert.match(result, /^data:image\/svg\+xml;charset=utf-8,/);
+  assert.doesNotMatch(result, /dicebear|https?:/i);
+});
+
+test("Clay Mate marks use a conventional display-name initial", async function () {
+  var module = await loadModule();
+  var arch = module.mateMarkSvg({ seed: "Arch", size: 64 });
+  var ada = module.mateMarkSvg({ seed: "Ada", size: 64 });
+  var buzz = module.mateMarkSvg({ seed: "Buzz", size: 64 });
+  var archAgain = module.mateMarkSvg({ seed: "Arch", size: 64 });
+  assert.equal(arch, archAgain);
+  assert.equal(arch, ada);
+  assert.notEqual(arch, buzz);
+  assert.match(arch, />A<\/text>/);
+  assert.match(buzz, />B<\/text>/);
+  assert.doesNotMatch(arch, /fill="#333330"/);
+  assert.doesNotMatch(buzz, /fill="#333330"/);
+  assert.notEqual(arch, module.imprintSvg({ seed: "Arch", size: 64 }));
+});
+
+test("Clay Mate marks are deterministic local SVG data URLs", async function () {
+  var module = await loadModule();
+  var first = module.mateMarkDataUrl({ seed: "reviewer", size: 32 });
+  var second = module.mateMarkDataUrl({ seed: "reviewer", size: 32 });
+  assert.equal(first, second);
+  assert.match(first, /^data:image\/svg\+xml;charset=utf-8,/);
+  assert.doesNotMatch(first, /https?:/i);
+});

--- a/test/icon-strip-ui.test.js
+++ b/test/icon-strip-ui.test.js
@@ -8,7 +8,8 @@ var css = fs.readFileSync(path.join(__dirname, "../lib/public/css/icon-strip.css
 test("project strip icons use defined surfaces without obscuring brand artwork", function () {
   assert.match(css, /\.icon-strip-item::before\s*\{[^}]*background:\s*var\(--bg\)[^}]*box-shadow:/s);
   assert.doesNotMatch(css, /\.icon-strip-item::before\s*\{[^}]*border:/s);
-  assert.match(css, /\.icon-strip-item\.active::before\s*\{[^}]*0 0 0 1px color-mix\(in srgb, var\(--link\) 62%, var\(--border\)\)/s);
+  assert.match(css, /\.icon-strip-item\.active::before\s*\{[^}]*0 5px 14px color-mix\(in srgb, var\(--brand-indigo\) 28%, transparent\)/s);
+  assert.doesNotMatch(css, /\.icon-strip-item\.active::before\s*\{[^}]*0 0 0 1px/s);
   assert.match(css, /\.icon-strip-home:hover::before\s*\{[^}]*background:\s*var\(--bg\)/s);
   assert.doesNotMatch(css, /\.icon-strip-home::before\s*\{[^}]*border:/s);
   assert.doesNotMatch(css, /\.icon-strip-home:hover::before\s*\{[^}]*background:\s*var\(--accent\)/s);

--- a/test/split-view.test.js
+++ b/test/split-view.test.js
@@ -128,8 +128,8 @@ test("session actions replace the dedicated worker button and stay out of split 
   assert.doesNotMatch(html, /id="header-add-worker-btn"/);
   assert.match(actionsSource, /!!state\.splitPanes/);
   assert.match(actionsSource, /state\.paneMode/);
-  assert.match(actionsSource, /Add AI Worker/);
-  assert.match(actionsSource, /Continue in another agent/);
+  assert.match(actionsSource, /Add AI worker/);
+  assert.match(actionsSource, /Send context to another agent/);
   assert.match(actionsSource, /handoff_session_options/);
   assert.match(actionsSource, /Reasoning effort/);
   assert.match(actionsSource, /model: modelSelect\.value/);

--- a/test/worker-proposal-ui.test.js
+++ b/test/worker-proposal-ui.test.js
@@ -40,11 +40,11 @@ test("title bar moves Worker creation into the labeled session actions menu", fu
   var actions = fs.readFileSync(path.join(root, "lib/public/modules/session-actions.js"), "utf8");
   assert.match(html, /id="header-session-actions-btn"[^>]*aria-label="Session actions"/);
   assert.doesNotMatch(html, /id="header-add-worker-btn"/);
-  assert.match(actions, /actionRow\("bot", "Add AI Worker"/);
+  assert.match(actions, /actionRow\("bot", "Add AI worker"/);
   assert.match(actions, /openPairDialog/);
 });
 
-test("title bar groups session controls and places context usage before session actions", function () {
+test("title bar presents a labeled session actions button in the status area", function () {
   var html = fs.readFileSync(path.join(root, "lib/public/index.html"), "utf8");
   var panels = fs.readFileSync(path.join(root, "lib/public/modules/app-panels.js"), "utf8");
   var renameAt = html.indexOf('id="header-rename-btn"');
@@ -54,5 +54,6 @@ test("title bar groups session controls and places context usage before session 
 
   assert.ok(renameAt > 0 && renameAt < fullAccessAt);
   assert.ok(actionsAt > statusAt);
+  assert.match(html, /id="header-session-actions-btn"[^>]*>[\s\S]*Add AI worker[\s\S]*session-actions-trigger-chevron/);
   assert.match(panels, /statusArea\.insertBefore\(hCtxEl, statusArea\.firstChild\)/);
 });


### PR DESCRIPTION
## Summary

- replace remote random avatar generators with deterministic local Clay Imprints
- use conventional brand-colored initials for Mates while preserving custom uploads
- apply the unified identity system across user, presence, mention, debate, and session surfaces
- refine selected project feedback with an indigo shadow
- replace the ambiguous session overflow control with a labeled Add AI worker menu

## Tests

- `npm test` — 397 passed
- targeted avatar and UI tests — 29 passed
- `git diff --check`