### PR TITLE
feat(session): add complete Driver control for visible Workers

### DIFF
--- a/lib/project-session-pair.js
+++ b/lib/project-session-pair.js
@@ -203,9 +203,13 @@ function attachSessionPair(ctx) {
   async function sendToPartner(args, caller) {
     try {
       if (caller && caller._delegatedBy) throw new Error("delegated turns cannot delegate to another session");
-      var resolved = groupAndPartner(caller);
       var message = typeof args.message === "string" ? args.message.trim() : "";
       if (!message) throw new Error("message is required");
+      var created = null;
+      if (caller && !store.groupForMember(caller.localId)) {
+        created = createWorkerForDriver(caller, args);
+      }
+      var resolved = groupAndPartner(caller);
       var wait = args.wait !== false;
       var timeout = Number.isFinite(args.timeoutSeconds) ? Math.floor(args.timeoutSeconds) : 300;
       timeout = Math.max(1, Math.min(900, timeout));
@@ -243,9 +247,14 @@ function attachSessionPair(ctx) {
       if (!wait) {
         token.detached = true;
         monitorPartner(resolved.group, caller, partner, token);
-        return toolResult({ status: "running", partnerId: partner.localId, hint: "The completed result will be pushed back automatically. Use read_partner only for an interim status check." });
+        return toolResult({ status: "running", partnerId: partner.localId, workerCreated: !!created, hint: "The completed result will be pushed back automatically. Use read_partner only for an interim status check." });
       }
-      return toolResult(await waitForPartner(resolved.group, caller, partner, token, timeout));
+      var completed = await waitForPartner(resolved.group, caller, partner, token, timeout);
+      if (created) {
+        completed.workerCreated = true;
+        completed.partnerId = partner.localId;
+      }
+      return toolResult(completed);
     } catch (e) {
       if (caller) {
         var group = store.groupForMember(caller.localId);
@@ -277,10 +286,46 @@ function attachSessionPair(ctx) {
     }
   }
 
+  function interruptPartner(args, caller) {
+    try {
+      var resolved = groupAndPartner(caller);
+      var partner = resolved.partner;
+      if (!partner.isProcessing && !partner._queryStarting) {
+        return toolResult({ status: "idle", partnerId: partner.localId, title: partner.title || "New Session" });
+      }
+      partner.taskStopRequested = true;
+      if (partner.abortController) partner.abortController.abort();
+      return toolResult({ status: "interrupting", partnerId: partner.localId, title: partner.title || "New Session" });
+    } catch (e) {
+      return toolError(e);
+    }
+  }
+
+  function closePartner(args, caller) {
+    try {
+      var resolved = groupAndPartner(caller);
+      var partner = resolved.partner;
+      var interrupted = !!(partner.isProcessing || partner._queryStarting);
+      if (interrupted) {
+        partner.taskStopRequested = true;
+        if (partner.abortController) partner.abortController.abort();
+      }
+      if (partner._pairDelegation) finishDelegation(resolved.group, caller, partner, partner._pairDelegation);
+      var ws = { _clayUser: caller.ownerId ? { id: caller.ownerId } : null };
+      var result = store.dissolve(ws, { id: resolved.group.id });
+      if (!result.ok) throw new Error(result.error || "could not close the Worker pair");
+      return toolResult({ status: "closed", partnerId: partner.localId, interrupted: interrupted, historyPreserved: true });
+    } catch (e) {
+      return toolError(e);
+    }
+  }
+
   function getToolDefs(boundSession) {
     if (!boundSession) return pairMcp.getToolDefs({
       send: function () { return toolError(new Error("send_to_partner requires a session-bound tool server")); },
       read: function () { return toolError(new Error("read_partner requires a session-bound tool server")); },
+      interrupt: function () { return toolError(new Error("interrupt_partner requires a session-bound tool server")); },
+      close: function () { return toolError(new Error("close_partner requires a session-bound tool server")); },
     });
     // Mount whenever we have a bound session: MCP servers are fixed for the
     // lifetime of a query, and Claude queries live across turns, so gating on
@@ -295,6 +340,8 @@ function attachSessionPair(ctx) {
     var tools = pairMcp.getToolDefs({
       send: function (args) { return sendToPartner(args, boundSession); },
       read: function (args) { return readPartner(args, boundSession); },
+      interrupt: function (args) { return interruptPartner(args, boundSession); },
+      close: function (args) { return closePartner(args, boundSession); },
     });
     return tools.concat(workerProposal.getToolDefs(boundSession));
   }
@@ -341,6 +388,37 @@ function attachSessionPair(ctx) {
     if (!result.ok) throw new Error(result.error);
     sm.broadcastSessionList();
     return { driver: driver, worker: worker, group: result.group };
+  }
+
+  function createWorkerForDriver(driver, args) {
+    if (ctx.isMate) throw new Error("Pair sessions are only available in projects");
+    var installed = sm.installedVendors || [];
+    if (installed.length === 0) throw new Error("no coding agent is installed for a Worker session");
+    var vendor = typeof args.workerVendor === "string" ? args.workerVendor.trim() : "";
+    if (vendor) validateVendor(vendor);
+    if (!vendor) {
+      if (installed.indexOf("codex") !== -1 && driver.vendor !== "codex") vendor = "codex";
+      else {
+        vendor = installed[0];
+        for (var i = 0; i < installed.length; i++) {
+          if (installed[i] !== driver.vendor) { vendor = installed[i]; break; }
+        }
+      }
+    }
+    var ws = {
+      _clayActiveSession: driver.localId,
+      _clayUser: driver.ownerId ? { id: driver.ownerId } : null,
+    };
+    var created = createPairRecord(ws, {
+      driver: { sessionId: driver.localId },
+      worker: {
+        vendor: vendor,
+        model: typeof args.workerModel === "string" ? args.workerModel : "",
+        effort: typeof args.workerEffort === "string" ? args.workerEffort : "",
+      },
+    });
+    sm.sendToSession(driver, { type: "pair_session_created", ok: true, group: created.group });
+    return created;
   }
 
   function createPair(ws, msg) {
@@ -390,7 +468,9 @@ function attachSessionPair(ctx) {
     var group = store.groupForMember(session.localId);
     var pairPrompt = "";
     if (group && group.pair && group.pair.driverId === session.localId) {
-      pairPrompt = "You are the Driver in a two-agent pair. The tools send_to_partner and read_partner are provided directly to you. Use send_to_partner to delegate concrete bounded work to the Worker. A completed Worker turn leaves the Worker session available for more work. If a Worker turn is interrupted, its work is partial and unverified; review it and decide next steps with the user. If review or user feedback requires corrections to the Worker's implementation, delegate a follow-up turn to that Worker instead of editing the Worker-owned files yourself. If send_to_partner reports that the Worker is no longer available, create a replacement with spawn_sessions and delegate the remaining implementation rather than taking it over. If a non-waiting delegation finishes later, Clay pushes the result back and resumes you automatically; use read_partner only when you need an interim status check. Integrate and verify the final outcome. Do not search the project for implementations of these tools, and do not delegate work that must be performed sequentially in this same session.";
+      pairPrompt = "You are the Driver in a two-agent pair. The tools send_to_partner, read_partner, interrupt_partner, and close_partner are provided directly to you. Use send_to_partner to delegate concrete bounded work to the Worker. The human may also message or stop the Worker directly; treat that intervention as authoritative. Use close_partner immediately when the human asks to close, dismiss, or remove the Worker pane; it preserves the session history. A completed Worker turn leaves the Worker session available for more work. Use interrupt_partner when execution must stop or change direction but the pair should remain open; its work is partial and unverified until you review it. If review or user feedback requires corrections to the Worker's implementation, delegate a follow-up turn to that Worker instead of editing the Worker-owned files yourself. If the Worker is no longer available, keep the work in the visible Worker flow and use send_to_partner again after the stale pair is removed; never substitute a background session. If a non-waiting delegation finishes later, Clay pushes the result back and resumes you automatically; use read_partner only when you need an interim status check. Integrate and verify the final outcome. Do not search the project for implementations of these tools, and do not delegate work that must be performed sequentially in this same session.";
+    } else if (!group && !ctx.isMate) {
+      pairPrompt = "When the user asks you to open or use a visible Worker, call send_to_partner directly. Clay will create the paired Worker session and open it in the right pane automatically before delivering the task. Do not ask the user to start split mode and do not use a background sub-agent as a substitute for a visible Worker.";
     }
     return [pairPrompt, workerProposal.getSystemPrompt(session)].filter(Boolean).join("\n\n");
   }

--- a/lib/project-worker-proposal.js
+++ b/lib/project-worker-proposal.js
@@ -247,7 +247,7 @@ function attachWorkerProposal(ctx) {
     });
     var followup;
     if (result.status === "complete") {
-      followup = "[Worker execution completed]\nReview and verify the Worker's result. The Worker session remains available: if the implementation needs corrections or additional edits, send a follow-up with send_to_partner instead of taking over the Worker-owned files yourself. If that Worker is no longer available, create a replacement with spawn_sessions for the remaining implementation.\n\n" + (result.response || "The Worker completed without a text summary.");
+      followup = "[Worker execution completed]\nReview and verify the Worker's result. The Worker session remains available: if the implementation needs corrections or additional edits, send a follow-up with send_to_partner instead of taking over the Worker-owned files yourself. If that Worker is no longer available, keep the work in the visible Worker flow and use send_to_partner again after the stale pair is removed; never substitute a background session.\n\n" + (result.response || "The Worker completed without a text summary.");
     } else if (result.status === "interrupted") {
       followup = "[Worker execution interrupted]\nThe user interrupted the Worker mid-turn. Its work is PARTIAL and unverified — do not treat it as finished. Review what was done and decide next steps with the user.";
     } else if (result.status === "running") {

--- a/lib/public/css/pane.css
+++ b/lib/public/css/pane.css
@@ -137,13 +137,7 @@ body.pane-mode #input-area {
 .split-pair-role-driver { color: var(--accent); background: color-mix(in srgb, var(--accent) 13%, transparent); }
 .split-pair-role-worker { color: var(--text-secondary); background: var(--bg-alt); }
 
-/* Role badges are buttons: Driver click clears roles, Worker click takes over. */
-button.split-pair-role {
-  border: 0;
-  cursor: pointer;
-  font-family: inherit;
-}
-button.split-pair-role:hover { filter: brightness(1.25); }
+/* Pair roles are status labels. Control remains with the Driver through MCP. */
 
 /* Ad-hoc splits: role assignment in each pane header. ALWAYS fully
    visible; hover/opacity gating made the control undiscoverable. */

--- a/lib/public/modules/split-pair-ui.js
+++ b/lib/public/modules/split-pair-ui.js
@@ -265,16 +265,10 @@ export function syncPairChrome(host, split) {
     (function (sessionId, header) {
       var isDriver = sessionId === group.pair.driverId;
       var role = isDriver ? "Driver" : "Worker";
-      var badge = document.createElement("button");
-      badge.type = "button";
+      var badge = document.createElement("span");
       badge.className = "split-pair-role split-pair-role-" + role.toLowerCase();
       badge.textContent = role;
-      badge.title = isDriver
-        ? "Driver — click to clear the Driver/Worker roles"
-        : "Worker — click to make this session the Driver instead";
-      badge.addEventListener("click", function () {
-        sendSetPair(group.id, isDriver ? null : sessionId);
-      });
+      badge.title = isDriver ? "Driver controls this Worker" : "Worker controlled by the Driver";
       var title = header.querySelector(".split-pane-title");
       var access = header.querySelector(".split-pane-full-access");
       header.insertBefore(badge, access ? access.nextSibling : (title ? title.nextSibling : null));

--- a/lib/session-pair-mcp-server.js
+++ b/lib/session-pair-mcp-server.js
@@ -6,11 +6,14 @@ function getToolDefs(handlers) {
   return [
     {
       name: "send_to_partner",
-      description: "Delegate one concrete task to the other session in this split. The partner works visibly in its own pane. A completed turn does not end the Worker session: reuse the same Worker for follow-up implementation and corrections instead of taking over its work. Detached completions are pushed back automatically. A delegated turn cannot delegate back, so keep orchestration one hop deep.",
+      description: "Delegate one concrete task to the Worker. If this session has no pair yet, Clay creates a real Worker session and opens it visibly in the right pane before starting the task. A completed turn does not end the Worker session: reuse the same Worker for follow-up implementation and corrections instead of taking over its work. Detached completions are pushed back automatically. A delegated turn cannot delegate back, so keep orchestration one hop deep.",
       inputSchema: buildShape({
         message: { type: "string", description: "The complete task or question for the partner." },
         wait: { type: "boolean", description: "Wait for the partner's turn to finish. Defaults to true." },
         timeoutSeconds: { type: "number", description: "Maximum wait in seconds, from 1 to 900. Defaults to 300." },
+        workerVendor: { type: "string", description: "Optional Worker vendor to use only when creating a new pair. Defaults to a suitable installed vendor." },
+        workerModel: { type: "string", description: "Optional Worker model to use only when creating a new pair." },
+        workerEffort: { type: "string", description: "Optional Worker reasoning effort to use only when creating a new pair." },
       }, ["message"]),
       handler: function (args) { return handlers.send(args || {}); },
     },
@@ -21,6 +24,18 @@ function getToolDefs(handlers) {
         lastTurns: { type: "number", description: "Number of recent user-message-delimited turns, from 1 to 5. Defaults to 1." },
       }),
       handler: function (args) { return handlers.read(args || {}); },
+    },
+    {
+      name: "interrupt_partner",
+      description: "Interrupt the Worker's current task. Use this when the task is going in the wrong direction, needs to be reprioritized, or must stop before the next instruction. The Worker returns any partial result to you for review.",
+      inputSchema: buildShape({}),
+      handler: function (args) { return handlers.interrupt(args || {}); },
+    },
+    {
+      name: "close_partner",
+      description: "Close the visible Worker pane and dissolve the Driver/Worker pair while preserving both session histories. If the Worker is still running, Clay interrupts it before closing the pair.",
+      inputSchema: buildShape({}),
+      handler: function (args) { return handlers.close(args || {}); },
     },
   ];
 }

--- a/test/session-pair.test.js
+++ b/test/session-pair.test.js
@@ -11,11 +11,12 @@ function fixture(configured, options) {
   var driver = { localId: 1, ownerId: null, title: "Planner", vendor: "claude", history: [], isProcessing: false };
   var worker = { localId: 2, ownerId: null, title: "Builder", vendor: "codex", history: [], isProcessing: false };
   var sessions = new Map([[1, driver], [2, worker]]);
-  var group = { id: "sg_pair", members: [1, 2] };
-  if (configured) group.pair = { driverId: 1, workerId: 2 };
+  var group = options.ungrouped ? null : { id: "sg_pair", members: [1, 2] };
+  if (configured && group) group.pair = { driverId: 1, workerId: 2 };
   var events = [];
   var starts = [];
   var driverPushes = [];
+  var pairMessages = [];
   var attached;
   var sm = {
     sessions: sessions,
@@ -23,8 +24,16 @@ function fixture(configured, options) {
     modelsByVendor: {},
     capabilitiesByVendor: {},
     sendAndRecord: function (session, message) { session.history.push(message); },
-    sendToSession: function () {},
+    sendToSession: function (session, message) { if (message.type === "pair_session_created") pairMessages.push(message); },
     broadcastSessionList: function () {},
+    createSessionRaw: function (spec) {
+      worker.ownerId = spec.ownerId || null;
+      worker.vendor = spec.vendor;
+      worker.model = spec.model || null;
+      worker.effort = spec.effort || null;
+      sessions.set(worker.localId, worker);
+      return worker;
+    },
   };
   var sdk = {
     pushMessage: function (session, text) {
@@ -57,7 +66,19 @@ function fixture(configured, options) {
   };
   attached = pairModule.attachSessionPair({
     sm: sm,
-    splitStore: { groupForMember: function (id) { return group.members.indexOf(id) === -1 ? null : group; }, create: function () {} },
+    splitStore: {
+      groupForMember: function (id) { return !group || group.members.indexOf(id) === -1 ? null : group; },
+      create: function (ws, msg) {
+        group = { id: "sg_created", members: msg.members.slice(), pair: msg.pair };
+        return { ok: true, group: group };
+      },
+      dissolve: function (ws, msg) {
+        if (!group || group.id !== msg.id) return { ok: false, error: "Split group not found" };
+        var removed = group;
+        group = null;
+        return { ok: true, group: removed };
+      },
+    },
     getSdk: function () { return sdk; },
     send: function (message) { events.push(message); },
     sendTo: function () {},
@@ -65,24 +86,26 @@ function fixture(configured, options) {
     getLinuxUserForSession: function () { return null; },
     onProcessingChanged: function () {},
   });
-  return { attached: attached, driver: driver, worker: worker, group: group, events: events, starts: starts, driverPushes: driverPushes };
+  return { attached: attached, driver: driver, worker: worker, group: group, getGroup: function () { return group; }, events: events, starts: starts, driverPushes: driverPushes, pairMessages: pairMessages };
 }
 
 test("configured pairs expose partner tools only to the Driver", function () {
   var f = fixture(true);
-  assert.deepStrictEqual(f.attached.getToolDefs(f.driver).map(function (tool) { return tool.name; }), ["send_to_partner", "read_partner"]);
+  assert.deepStrictEqual(f.attached.getToolDefs(f.driver).map(function (tool) { return tool.name; }), ["send_to_partner", "read_partner", "interrupt_partner", "close_partner"]);
   assert.deepStrictEqual(f.attached.getToolDefs(f.worker), []);
   assert.match(f.attached.getSystemPrompt(f.driver), /Driver/);
   assert.match(f.attached.getSystemPrompt(f.driver), /completed Worker turn leaves the Worker session available/);
-  assert.match(f.attached.getSystemPrompt(f.driver), /create a replacement with spawn_sessions/);
+  assert.match(f.attached.getSystemPrompt(f.driver), /human may also message or stop the Worker directly/);
+  assert.match(f.attached.getSystemPrompt(f.driver), /Use close_partner immediately/);
+  assert.match(f.attached.getSystemPrompt(f.driver), /never substitute a background session/);
   assert.match(f.attached.getToolDefs(f.driver)[0].description, /reuse the same Worker for follow-up implementation/);
   assert.strictEqual(f.attached.getSystemPrompt(f.worker), "");
 });
 
 test("ad-hoc splits expose partner tools to both sessions", function () {
   var f = fixture(false);
-  assert.strictEqual(f.attached.getToolDefs(f.driver).length, 2);
-  assert.strictEqual(f.attached.getToolDefs(f.worker).length, 2);
+  assert.strictEqual(f.attached.getToolDefs(f.driver).length, 4);
+  assert.strictEqual(f.attached.getToolDefs(f.worker).length, 4);
 });
 
 test("send_to_partner records attribution and returns the response", async function () {
@@ -97,6 +120,30 @@ test("send_to_partner records attribution and returns the response", async funct
   assert.deepStrictEqual(f.events.map(function (event) { return event.active; }), [true, false]);
   assert.strictEqual(f.worker._delegatedBy, undefined);
   assert.deepStrictEqual(f.driverPushes, []);
+});
+
+test("send_to_partner creates and opens a visible Worker when the Driver is unpaired", async function () {
+  var f = fixture(false, { ungrouped: true });
+  assert.match(f.attached.getSystemPrompt(f.driver), /open it in the right pane automatically/);
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  var result = parseToolResult(await tool.handler({ message: "Build the feature", timeoutSeconds: 2 }));
+
+  assert.deepStrictEqual(result, { status: "complete", response: "Partner result", workerCreated: true, partnerId: 2 });
+  assert.deepStrictEqual(f.getGroup().pair, { driverId: 1, workerId: 2 });
+  assert.strictEqual(f.worker.vendor, "codex");
+  assert.strictEqual(f.pairMessages.length, 1);
+  assert.strictEqual(f.pairMessages[0].group.id, "sg_created");
+});
+
+test("send_to_partner validates its task before creating a Worker", async function () {
+  var f = fixture(false, { ungrouped: true });
+  var tool = f.attached.getToolDefs(f.driver)[0];
+  var result = await tool.handler({ message: "  " });
+
+  assert.strictEqual(result.isError, true);
+  assert.match(result.content[0].text, /message is required/);
+  assert.strictEqual(f.getGroup(), null);
+  assert.strictEqual(f.pairMessages.length, 0);
 });
 
 test("a detached delegated turn pushes its result to the Driver once", async function () {
@@ -172,6 +219,46 @@ test("a user-started Worker turn never pushes to the Driver", function () {
   assert.strictEqual(f.attached.handleTurnDone(f.worker), false);
   assert.deepStrictEqual(f.driverPushes, []);
   assert.deepStrictEqual(f.driver.history, []);
+});
+
+test("only the Driver can interrupt a configured Worker's active task", async function () {
+  var f = fixture(true);
+  var stopped = false;
+  f.worker.isProcessing = true;
+  f.worker.abortController = { abort: function () { stopped = true; } };
+  var tool = f.attached.getToolDefs(f.driver)[2];
+  var result = parseToolResult(await tool.handler({}));
+
+  assert.deepStrictEqual(result, { status: "interrupting", partnerId: 2, title: "Builder" });
+  assert.strictEqual(stopped, true);
+  assert.strictEqual(f.worker.taskStopRequested, true);
+  var workerTool = f.attached.getToolDefs(f.worker).find(function (item) { return item.name === "interrupt_partner"; });
+  assert.strictEqual(workerTool, undefined);
+});
+
+test("the Driver can close an idle Worker while preserving its session", async function () {
+  var f = fixture(true);
+  var tool = f.attached.getToolDefs(f.driver)[3];
+  var result = parseToolResult(await tool.handler({}));
+
+  assert.deepStrictEqual(result, { status: "closed", partnerId: 2, interrupted: false, historyPreserved: true });
+  assert.strictEqual(f.getGroup(), null);
+  assert.strictEqual(f.attached.getToolDefs(f.worker).length, 4);
+});
+
+test("closing a running Worker interrupts it before dissolving the pair", async function () {
+  var f = fixture(true);
+  var stopped = false;
+  f.worker.isProcessing = true;
+  f.worker.abortController = { abort: function () { stopped = true; } };
+  var tool = f.attached.getToolDefs(f.driver)[3];
+  var result = parseToolResult(await tool.handler({}));
+
+  assert.strictEqual(result.status, "closed");
+  assert.strictEqual(result.interrupted, true);
+  assert.strictEqual(stopped, true);
+  assert.strictEqual(f.worker.taskStopRequested, true);
+  assert.strictEqual(f.getGroup(), null);
 });
 
 test("a role change invalidates a detached Worker completion", async function () {

--- a/test/split-view.test.js
+++ b/test/split-view.test.js
@@ -135,6 +135,32 @@ test("session actions replace the dedicated worker button and stay out of split 
   assert.match(actionsSource, /model: modelSelect\.value/);
 });
 
+test("configured pair roles are status labels rather than role-transfer controls", function () {
+  var pairSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/split-pair-ui.js"), "utf8");
+  var paneCss = fs.readFileSync(path.join(__dirname, "../lib/public/css/pane.css"), "utf8");
+
+  assert.match(pairSource, /document\.createElement\("span"\)/);
+  assert.match(pairSource, /Worker controlled by the Driver/);
+  assert.doesNotMatch(pairSource, /Worker — click to make this session the Driver instead/);
+  assert.doesNotMatch(paneCss, /button\.split-pair-role/);
+});
+
+test("configured Workers preserve direct human messaging and stopping", function () {
+  var pairSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/split-pair-ui.js"), "utf8");
+  var messageSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-messages.js"), "utf8");
+  var paneCss = fs.readFileSync(path.join(__dirname, "../lib/public/css/pane.css"), "utf8");
+
+  assert.doesNotMatch(pairSource, /syncWorkerComposerLock/);
+  assert.doesNotMatch(messageSource, /syncWorkerComposerLock/);
+  assert.doesNotMatch(paneCss, /worker-controlled/);
+});
+
+test("dissolving a pair closes the split UI back to the Driver session", function () {
+  var splitSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/split-view.js"), "utf8");
+
+  assert.match(splitSource, /if \(!stillExists\) switchNativeSession\(split\.panes\[0\]\.sessionId\)/);
+});
+
 test("split pane permission control is anchored beside the session title", function () {
   var splitSource = fs.readFileSync(path.join(__dirname, "../lib/public/modules/split-view.js"), "utf8");
   var paneCss = fs.readFileSync(path.join(__dirname, "../lib/public/css/pane.css"), "utf8");

--- a/test/worker-proposal.test.js
+++ b/test/worker-proposal.test.js
@@ -217,7 +217,7 @@ test("accepting a Worker suggestion creates the split, delegates, and returns th
   assert.strictEqual(proposal.resultPreview, "Implemented and tested.");
   assert.match(f.starts[0].text, /Worker execution completed/);
   assert.match(f.starts[0].text, /send a follow-up with send_to_partner/);
-  assert.match(f.starts[0].text, /create a replacement with spawn_sessions/);
+  assert.match(f.starts[0].text, /never substitute a background session/);
   assert.match(f.starts[0].text, /Implemented and tested/);
   assert.ok(f.updates.some(function (message) { return message.status === "running"; }));
   assert.ok(f.updates.some(function (message) { return message.status === "completed"; }));


### PR DESCRIPTION
## Summary

- let Driver MCP calls create and reveal a paired Worker automatically
- add Driver controls to inspect, interrupt, and close the Worker while preserving session history
- keep direct human messaging and manual stop available in the Worker pane
- make configured Driver and Worker badges passive status labels

## Testing

- Node 22 focused suite: 46 tests passed
- full project test suite passed before rebasing onto the release metadata-only update
- git diff check passed