### PR TITLE
fix(terminal): preserve panel header on desktop resize

### DIFF
--- a/lib/public/modules/terminal.js
+++ b/lib/public/modules/terminal.js
@@ -332,8 +332,11 @@ function activateTab(termId) {
     if (tab.xterm) keyToolbar.bindXterm(tab.xterm);
   }
 
-  // Mobile viewport handling
-  if (window.visualViewport && !viewportHandler) {
+  // Mobile viewport handling. Desktop browsers also expose visualViewport,
+  // but applying the full viewport height there makes this panel taller than
+  // #main-panels. Because the desktop panel is vertically centered, its top
+  // edge (including the header) is then clipped when the browser is resized.
+  if (isTouchDevice && window.visualViewport && !viewportHandler) {
     viewportHandler = function () {
       ctx.terminalContainerEl.style.height = window.visualViewport.height + "px";
       fitTerminal();

--- a/test/terminal-resize.test.js
+++ b/test/terminal-resize.test.js
@@ -1,0 +1,13 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var root = path.join(__dirname, "..");
+
+test("desktop terminal resize preserves the Clay panel header", function () {
+  var source = fs.readFileSync(path.join(root, "lib/public/modules/terminal.js"), "utf8");
+
+  assert.match(source, /if \(isTouchDevice && window\.visualViewport && !viewportHandler\)/);
+  assert.match(source, /terminalContainerEl\.style\.height = window\.visualViewport\.height/);
+});


### PR DESCRIPTION
## Summary

- limit visual viewport height overrides to touch devices
- preserve Clay terminal tabs and header controls during desktop browser resizing
- add regression coverage for the desktop resize guard

## Testing

- full Node 22 test suite passed
- git diff check passed