### PR TITLE
fix(worktree): skip stale worktree directories

### DIFF
--- a/lib/worktree.js
+++ b/lib/worktree.js
@@ -1,4 +1,5 @@
 var { execFileSync } = require("child_process");
+var fs = require("fs");
 var path = require("path");
 
 // Parse `git worktree list --porcelain` output into structured objects
@@ -68,6 +69,9 @@ function scanWorktrees(projectPath) {
       if (wt.bare) continue;
       var resolvedWt = path.resolve(wt.path);
       if (resolvedWt === resolvedParent) continue;
+      // Git retains removed worktrees until `git worktree prune` runs. Do not
+      // register those stale paths as Clay projects.
+      if (!fs.existsSync(resolvedWt)) continue;
       wt.external = !isPathInside(resolvedParent, resolvedWt);
       wt.dirName = path.basename(wt.path);
       results.push(wt);

--- a/test/worktree.test.js
+++ b/test/worktree.test.js
@@ -1,0 +1,37 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var { execFileSync } = require("child_process");
+var { scanWorktrees } = require("../lib/worktree");
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd: cwd, encoding: "utf8" });
+}
+
+function createRepository(t) {
+  var repo = fs.mkdtempSync(path.join(os.tmpdir(), "clay-worktree-"));
+  t.after(function () { fs.rmSync(repo, { recursive: true, force: true }); });
+  git(repo, ["init", "-q"]);
+  git(repo, ["config", "user.name", "Clay Test"]);
+  git(repo, ["config", "user.email", "clay@example.test"]);
+  fs.writeFileSync(path.join(repo, "tracked.txt"), "initial\n");
+  git(repo, ["add", "tracked.txt"]);
+  git(repo, ["commit", "-qm", "initial"]);
+  return repo;
+}
+
+test("worktree scan ignores Git entries whose directories were removed", function (t) {
+  var repo = createRepository(t);
+  var staleWorktree = path.join(os.tmpdir(), "clay-stale-worktree-" + Date.now());
+  t.after(function () { fs.rmSync(staleWorktree, { recursive: true, force: true }); });
+
+  git(repo, ["worktree", "add", "-q", "-b", "stale-branch", staleWorktree]);
+  fs.rmSync(staleWorktree, { recursive: true, force: true });
+
+  var discovered = scanWorktrees(repo);
+  assert.equal(discovered.some(function (worktree) {
+    return worktree.path === staleWorktree;
+  }), false);
+});


### PR DESCRIPTION
## Summary
- skip Git worktree entries whose directories no longer exist
- prevent stale worktree metadata from crashing daemon startup
- add a regression test for a removed worktree directory

## Testing
- npm test