### PR TITLE
chore(release): sync 3.8.1 back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.8.1](https://github.com/chadbyte/clay/compare/v3.8.0...v3.8.1) (2026-08-30)
+
+
+### Bug Fixes
+
+* **worktree:** skip stale worktree directories ([5ae299f](https://github.com/chadbyte/clay/commit/5ae299f17090ab787956ee92120d1ea5e6e99ad6))
+
 # [3.8.0](https://github.com/chadbyte/clay/compare/v3.7.0...v3.8.0) (2026-08-30)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clay-server",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Self-hosted team workspace for Claude Code and Codex. Multi-user, browser-based, with persistent AI mates.",
   "bin": {
     "clay-server": "./bin/cli.js",


### PR DESCRIPTION
## Summary
- merge the published 3.8.1 release commit back into main
- resolve the concurrent beta/stable release race in favor of stable metadata
- preserve both release histories with a merge commit

## Context
The stable release succeeded, but its final push to main was rejected because the beta workflow advanced main concurrently.