### PR TITLE
fix(login): stop vendor login loop and update Codex to 0.152.1

### DIFF
--- a/docs/guides/CODEX-INTEGRATION.md
+++ b/docs/guides/CODEX-INTEGRATION.md
@@ -187,6 +187,22 @@ Stored in `lib/codex-defaults.js`. Do not scatter defaults across multiple files
 
 `danger-full-access` + `approval_policy: "never"` is a combination the user chose explicitly. Do not auto-upgrade to it from code. It completely disables the sandbox.
 
+### 13. Login does not reach a running app-server
+
+`codex app-server` reads `~/.codex/auth.json` **once, at spawn**. One app-server is shared by every Codex session in a project (`_appServer` in the adapter), so running `codex login` in a terminal changes nothing for sessions that are already up: every query keeps getting 401 -> `auth_required`, and the client keeps re-opening the login flow.
+
+The fix is a restart, not a re-read. `lib/project-vendor-login.js` owns the login terminal, watches its output for the vendor's success line, and then calls `adapter.shutdown()` (which fans out to `shutdownUserRuntimes`, so per-OS-user runtimes are covered too). The next query re-inits and spawns a process that reads the new credentials.
+
+Consequences to preserve:
+
+- **One login terminal per vendor per project.** The server holds the record; `auto` requests (driven by `auth_required`) never open a second prompt while a flow is live. Client-side flags are not a substitute - they reset on banner dismiss.
+- **The login terminal must spawn with the identity the adapter will use.** The adapter only gets `osUserInfo` when `_runtimeLinuxUser` is set, which comes from the *session owner*, not the connected client. `resolveLoginIdentity()` prefers the session identity so credentials land in the HOME the app-server reads.
+- **Split panes forward, they do not start.** A pane has no banner surface, so it posts `clay-pane-auth-required` to the parent shell (`pane-bridge.js` -> `split-view.js`) rather than running its own flow.
+
+### 14. Choosing a different codex binary
+
+`findCodexPath()` honors `CLAY_CODEX_PATH`: if it points at an existing file, that binary is used and logged; otherwise resolution falls back to the bundled `@openai/codex` platform package. Bundled remains the default - use the override for a local build or a pinned release, not as normal configuration.
+
 ---
 
 ## Common Gotchas
@@ -230,6 +246,10 @@ When changing Codex adapter code:
 - [ ] Stop button during generation: typing clears, "interrupted" message appears, send button restored
 - [ ] Server restart does not break MCP (extension state resends)
 - [ ] Second project using Codex routes through global `/api/mcp-bridge` (not per-slug)
+- [ ] `auth_required` opens exactly one login terminal, no matter how many sessions or panes report it
+- [ ] Finishing `codex login --device-auth` closes the login terminal, drops it from the sidebar list, and shows "Signed in to Codex"
+- [ ] The next message in the *same* session succeeds without opening a new session
+- [ ] Dismissing the login modal kills its terminal instead of leaving it in the sidebar
 
 ---
 

--- a/docs/guides/MODULE_MAP.md
+++ b/docs/guides/MODULE_MAP.md
@@ -41,6 +41,7 @@ Wires all modules, sets up session manager and SDK bridge, dispatches messages.
 | `project-user-mention.js` | (called from project.js) `user_mention` | User-to-user @mention side conversations within a session. Records to history, broadcasts to other session viewers, queues transcript into `pendingMentionContexts` for the next coding-agent turn, fires alarm-center notification + push for the target user (push only when offline) |
 | `project-memory.js` | `memory_list`, `memory_search`, `memory_delete` | Session digest memory |
 | `project-mcp.js` | `mcp_servers_available`, `mcp_tool_result`, `mcp_tool_error`, `mcp_toggle_server` | Remote MCP server bridge via Chrome Extension |
+| `project-vendor-login.js` | `vendor_login_start`, `vendor_login_cancel`, `vendor_login_state_request` | Vendor `auth_required` recovery. One login terminal per vendor per project (server-tracked), success detection on PTY output, adapter restart so the new credentials are read, `auth_refreshed` broadcast, terminal cleanup |
 
 ### Infrastructure Modules
 
@@ -171,6 +172,7 @@ Bootstraps UI, initializes store, wires remaining Tier 3 modules. All business l
 | `app-loop-ui.js` | Ralph Loop UI: bars, banners, preview modal, execution modal |
 | `app-loop-wizard.js` | Ralph Loop wizard: step navigation, mode/authorship selection, data collection |
 | `app-notifications.js` | Notification center panel, badge, rendering, click-to-navigate |
+| `vendor-login.js` | Client half of the vendor login flow: requests the server-owned login terminal, opens/re-attaches the modal, login banners, split-pane forwarding. `app-notifications.js` depends on this module, never the reverse |
 | `app-debate-ui.js` | Debate sticky banner, floor/conclude/ended modes, bottom bar, hand raise |
 | `background-tasks-ui.js` | Active background-task indicator and task stop controls |
 | `app-skills-install.js` | Skill install dialog, requireSkills, requireClayMateInterview |

--- a/lib/project-connection.js
+++ b/lib/project-connection.js
@@ -78,6 +78,7 @@ function attachConnection(ctx) {
   var _mcp = ctx._mcp;
   var _notifications = ctx._notifications;
   var _splitGroups = ctx._splitGroups;
+  var _vendorLogin = ctx._vendorLogin;
   var hydrateImageRefs = ctx.hydrateImageRefs;
   var resolveSessionForView = ctx.resolveSessionForView;
   var broadcastClientCount = ctx.broadcastClientCount;
@@ -191,6 +192,9 @@ function attachConnection(ctx) {
     sendTo(ws, { type: "last_vendor", vendor: sm.lastVendor || "" });
     sendTo(ws, Object.assign({ type: "codex_config" }, getCodexConfig(sm)));
     sendTo(ws, { type: "term_list", terminals: tm.list() });
+    // Any login flow already running in this project, so a reconnecting client
+    // re-attaches to the existing login terminal instead of starting another.
+    if (_vendorLogin) _vendorLogin.sendStateTo(ws);
     // Context sources sent after session is resolved (per-session storage)
     // Send email accounts list for context sources picker
     var emailUserId = (wsUser && wsUser.id) || "default";

--- a/lib/project-vendor-login.js
+++ b/lib/project-vendor-login.js
@@ -1,0 +1,397 @@
+// Vendor login flow coordinator.
+//
+// Owns the "the vendor CLI is not logged in" recovery path end to end so the
+// client never has to guess. One login terminal per vendor per project is the
+// single source of truth: repeated auth_required events (other sessions, split
+// panes, a burst of 401 retries) re-use that record instead of spawning more
+// terminals.
+//
+// Lifecycle:
+//   vendor_login_start  -> create (or re-use) a PTY running the vendor login
+//                          command, reply with vendor_login_ready
+//   PTY output/exit     -> detect a successful login, restart the vendor's
+//                          YOKE adapter so it re-reads the credential file,
+//                          broadcast auth_refreshed, close the terminal
+//   vendor_login_cancel -> user dismissed the flow; kill the terminal
+//
+// The adapter restart is the actual bug fix: a Codex app-server is a long-lived
+// child process that reads ~/.codex/auth.json once at spawn, so without a
+// restart every query after a successful login keeps hitting 401 and re-arms
+// auth_required forever.
+
+var vendorRegistry = require("./yoke/vendor-registry");
+
+// Login CLIs print a success line and then hand the shell back, so the PTY
+// itself does not exit. Watch the output stream instead. Deliberately narrow:
+// "Successfully logged out" and MCP-server logins must not match.
+var LOGIN_SUCCESS_PATTERNS = [
+  /successfully logged in(?![ \t]+to[ \t]+mcp)/i,
+  /logged in successfully/i,
+  /login successful/i,
+  /successfully authenticated/i,
+  /authentication successful/i,
+  /signed in successfully/i,
+  /signed in with your [a-z ]+ account/i,
+  /you(?:'re| are) (?:now )?(?:logged|signed) in/i,
+];
+
+// Rolling window kept per flow so a success line split across PTY chunks is
+// still matched, without buffering the whole login transcript.
+var OUTPUT_TAIL_MAX = 4096;
+
+// Grace period between detecting success and killing the terminal, so the user
+// actually sees the confirmation line before the modal closes.
+var CLOSE_AFTER_SUCCESS_MS = 2000;
+
+var ANSI_PATTERN = /\x1b\[[0-9;?]*[ -\/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\r/g;
+
+function stripAnsi(text) {
+  return String(text).replace(ANSI_PATTERN, "");
+}
+
+function looksLikeLoginSuccess(text) {
+  for (var i = 0; i < LOGIN_SUCCESS_PATTERNS.length; i++) {
+    if (LOGIN_SUCCESS_PATTERNS[i].test(text)) return true;
+  }
+  return false;
+}
+
+/**
+ * ctx fields:
+ *   slug, osUsers,
+ *   sm, tm, adapters,
+ *   send, sendTo,
+ *   usersModule,
+ *   getOsUserInfoForWs, getOsUserInfoForLinuxUser, getLinuxUserForSession
+ */
+function attachVendorLogin(ctx) {
+  var slug = ctx.slug;
+  var osUsers = ctx.osUsers;
+
+  var sm = ctx.sm;
+  var tm = ctx.tm;
+  var adapters = ctx.adapters || {};
+
+  var send = ctx.send;
+  var sendTo = ctx.sendTo;
+
+  var usersModule = ctx.usersModule;
+
+  var getOsUserInfoForWs = ctx.getOsUserInfoForWs;
+  var getOsUserInfoForLinuxUser = ctx.getOsUserInfoForLinuxUser;
+  var getLinuxUserForSession = ctx.getLinuxUserForSession;
+
+  // vendor -> flow record. At most one live login terminal per vendor.
+  var _flows = Object.create(null);
+
+  function loginCommandFor(vendor) {
+    var info = vendorRegistry.getVendorInfo(vendor);
+    return (info && info.loginCommand) || "claude login";
+  }
+
+  function vendorDisplayName(vendor) {
+    var info = vendorRegistry.getVendorInfo(vendor);
+    return (info && info.displayName) || vendor || "Vendor";
+  }
+
+  function listFlows() {
+    var result = [];
+    var vendors = Object.keys(_flows);
+    for (var i = 0; i < vendors.length; i++) {
+      var flow = _flows[vendors[i]];
+      result.push({
+        vendor: flow.vendor,
+        terminalId: flow.terminalId,
+        startedAt: flow.startedAt,
+        completed: !!flow.completed,
+      });
+    }
+    return result;
+  }
+
+  function broadcastState() {
+    send({ type: "vendor_login_state", slug: slug, flows: listFlows() });
+  }
+
+  function sendStateTo(ws) {
+    sendTo(ws, { type: "vendor_login_state", slug: slug, flows: listFlows() });
+  }
+
+  function hasTerminalPermission(ws) {
+    if (!ws || !ws._clayUser) return true;
+    if (!usersModule || typeof usersModule.getEffectivePermissions !== "function") return true;
+    var perms = usersModule.getEffectivePermissions(ws._clayUser, osUsers);
+    return !!(perms && perms.terminal);
+  }
+
+  // The login terminal must write credentials to the same HOME the adapter
+  // will read them from. With OS-user isolation the adapter runs as the
+  // *session owner's* Linux user, which is not necessarily the connected
+  // client, so prefer the session identity when the requester is entitled to
+  // it. Without isolation both sides run as the daemon user and this resolves
+  // to null on both paths.
+  function resolveLoginIdentity(ws, msg) {
+    if (!osUsers) return { linuxUser: null, osUserInfo: null };
+
+    var sessionLinuxUser = null;
+    var sessionId = msg && msg.sessionId;
+    if (sessionId && sm && sm.sessions && typeof getLinuxUserForSession === "function") {
+      var session = sm.sessions.get(sessionId);
+      if (session) {
+        var requesterId = ws && ws._clayUser ? ws._clayUser.id : null;
+        var isOwner = !session.ownerId || (requesterId && String(session.ownerId) === String(requesterId));
+        var isAdmin = !!(ws && ws._clayUser && ws._clayUser.role === "admin");
+        if (isOwner || isAdmin) sessionLinuxUser = getLinuxUserForSession(session);
+      }
+    }
+
+    if (sessionLinuxUser && typeof getOsUserInfoForLinuxUser === "function") {
+      return { linuxUser: sessionLinuxUser, osUserInfo: getOsUserInfoForLinuxUser(sessionLinuxUser) };
+    }
+
+    var wsInfo = typeof getOsUserInfoForWs === "function" ? getOsUserInfoForWs(ws) : null;
+    return { linuxUser: wsInfo ? wsInfo.user : null, osUserInfo: wsInfo };
+  }
+
+  function isFlowTerminalAlive(flow) {
+    return !!(flow && typeof flow.terminalId === "number" && tm.has(flow.terminalId));
+  }
+
+  function discardFlow(vendor) {
+    var flow = _flows[vendor];
+    if (!flow) return null;
+    delete _flows[vendor];
+    if (flow.closeTimer) {
+      clearTimeout(flow.closeTimer);
+      flow.closeTimer = null;
+    }
+    return flow;
+  }
+
+  // Kill the PTY and drop it from the sidebar list. `flow.closing` keeps the
+  // terminal's own exit hook from re-entering finalization.
+  function closeFlowTerminal(flow) {
+    if (!flow || typeof flow.terminalId !== "number") return;
+    flow.closing = true;
+    try { tm.close(flow.terminalId); } catch (e) {}
+    send({ type: "term_list", terminals: tm.list() });
+  }
+
+  // Restart the vendor adapter so the next query spawns a process that reads
+  // the credentials the login just wrote. Shared adapter instances (Claude) are
+  // reused by every project, so tearing one down here would kill unrelated
+  // sessions; those runtimes pick up new credentials on their own.
+  function refreshVendorAuth(vendor) {
+    var adapter = adapters[vendor];
+    if (!adapter || typeof adapter.shutdown !== "function") return Promise.resolve(false);
+    if (adapter.shared) {
+      console.log("[vendor-login] " + vendor + " adapter is shared; skipping restart for " + slug);
+      return Promise.resolve(false);
+    }
+    // adapter.shutdown() already fans out to every per-OS-user runtime it
+    // created (shutdownUserRuntimes), so one call covers isolated setups too.
+    return Promise.resolve()
+      .then(function () { return adapter.shutdown(); })
+      .then(function () {
+        console.log("[vendor-login] Restarted " + vendor + " adapter for " + slug + " after login");
+        return true;
+      })
+      .catch(function (err) {
+        console.error("[vendor-login] " + vendor + " adapter restart failed for " + slug + ":",
+          err && err.message ? err.message : err);
+        return false;
+      });
+  }
+
+  function finishFlow(vendor, succeeded) {
+    var flow = _flows[vendor];
+    if (!flow || flow.finishing) return;
+    flow.finishing = true;
+    flow.completed = !!succeeded;
+
+    var refresh = succeeded ? refreshVendorAuth(vendor) : Promise.resolve(false);
+    refresh.then(function (restarted) {
+      discardFlow(vendor);
+      closeFlowTerminal(flow);
+      if (succeeded) {
+        send({ type: "auth_refreshed", slug: slug, vendor: vendor, adapterRestarted: !!restarted });
+      }
+      broadcastState();
+    });
+  }
+
+  function handleFlowOutput(vendor, chunk) {
+    var flow = _flows[vendor];
+    if (!flow || flow.finishing || flow.succeeded) return;
+    flow.outputTail = (flow.outputTail + stripAnsi(chunk)).slice(-OUTPUT_TAIL_MAX);
+    if (!looksLikeLoginSuccess(flow.outputTail)) return;
+
+    flow.succeeded = true;
+    console.log("[vendor-login] Detected successful " + vendor + " login in " + slug);
+    // Let the success line land on screen before the terminal disappears.
+    flow.closeTimer = setTimeout(function () {
+      finishFlow(vendor, true);
+    }, CLOSE_AFTER_SUCCESS_MS);
+    if (flow.closeTimer && typeof flow.closeTimer.unref === "function") flow.closeTimer.unref();
+  }
+
+  // Fires for both a PTY that exited on its own and one the user closed from
+  // the sidebar. Either way the flow is over; refresh auth if the command had
+  // already reported success.
+  function handleFlowExit(vendor) {
+    var flow = _flows[vendor];
+    if (!flow || flow.closing || flow.finishing) return;
+    finishFlow(vendor, !!flow.succeeded);
+  }
+
+  function startFlow(ws, vendor, msg) {
+    var identity = resolveLoginIdentity(ws, msg);
+    var command = loginCommandFor(vendor);
+    var flow = {
+      vendor: vendor,
+      terminalId: null,
+      startedAt: Date.now(),
+      linuxUser: identity.linuxUser,
+      outputTail: "",
+      succeeded: false,
+      finishing: false,
+      closing: false,
+      completed: false,
+      closeTimer: null,
+    };
+    // Registered before create() so the PTY's first output chunk (hooks fire
+    // synchronously from spawn) already finds the record.
+    _flows[vendor] = flow;
+
+    var terminal = null;
+    try {
+      terminal = tm.create(100, 30, identity.osUserInfo, ws, {
+        initialInput: command + "\n",
+        title: vendorDisplayName(vendor) + " login",
+        kind: "vendor-login",
+        onData: function (data) { handleFlowOutput(vendor, data); },
+        onExit: function () { handleFlowExit(vendor); },
+      });
+    } catch (e) {
+      console.error("[vendor-login] Failed to spawn " + vendor + " login terminal in " + slug + ":",
+        e && e.message ? e.message : e);
+    }
+
+    if (!terminal) {
+      delete _flows[vendor];
+      return null;
+    }
+
+    flow.terminalId = terminal.id;
+    tm.attach(terminal.id, ws);
+    send({ type: "term_list", terminals: tm.list() });
+    return flow;
+  }
+
+  function handleVendorLoginMessage(ws, msg) {
+    if (msg.type === "vendor_login_state_request") {
+      sendStateTo(ws);
+      return true;
+    }
+
+    if (msg.type === "vendor_login_cancel") {
+      var cancelVendor = String(msg.vendor || "");
+      var cancelled = discardFlow(cancelVendor);
+      if (cancelled) closeFlowTerminal(cancelled);
+      broadcastState();
+      return true;
+    }
+
+    if (msg.type === "vendor_login_start") {
+      var vendor = String(msg.vendor || "claude");
+      if (!vendorRegistry.getVendorInfo(vendor)) {
+        sendTo(ws, { type: "vendor_login_error", vendor: vendor, error: "Unknown vendor: " + vendor });
+        return true;
+      }
+      if (!hasTerminalPermission(ws)) {
+        sendTo(ws, { type: "vendor_login_error", vendor: vendor, error: "Terminal access is not permitted" });
+        return true;
+      }
+
+      var existing = _flows[vendor];
+      if (existing && !isFlowTerminalAlive(existing)) {
+        // Terminal died without its exit hook clearing the record.
+        discardFlow(vendor);
+        existing = null;
+      }
+
+      if (existing) {
+        // An auto-triggered request (a fresh auth_required from another
+        // session or split pane) must not pop a second prompt; it only learns
+        // that a flow is already running. A deliberate request re-attaches.
+        if (!msg.auto) {
+          tm.attach(existing.terminalId, ws);
+          sendTo(ws, {
+            type: "vendor_login_ready",
+            slug: slug,
+            vendor: vendor,
+            terminalId: existing.terminalId,
+            reused: true,
+          });
+        }
+        sendStateTo(ws);
+        return true;
+      }
+
+      var started = startFlow(ws, vendor, msg);
+      if (!started) {
+        sendTo(ws, {
+          type: "vendor_login_error",
+          vendor: vendor,
+          error: "Cannot create terminal (node-pty not available or limit reached)",
+        });
+        return true;
+      }
+
+      console.log("[vendor-login] Started " + vendor + " login terminal " + started.terminalId + " in " + slug);
+      sendTo(ws, {
+        type: "vendor_login_ready",
+        slug: slug,
+        vendor: vendor,
+        terminalId: started.terminalId,
+        reused: false,
+      });
+      broadcastState();
+      return true;
+    }
+
+    return false;
+  }
+
+  // The sidebar "close terminal" path goes through tm.close() directly, which
+  // fires our exit hook. This is the explicit entry point for callers that
+  // remove a terminal without going through the PTY.
+  function forgetTerminal(terminalId) {
+    var vendors = Object.keys(_flows);
+    for (var i = 0; i < vendors.length; i++) {
+      if (_flows[vendors[i]].terminalId === terminalId) {
+        handleFlowExit(vendors[i]);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function isLoginTerminal(terminalId) {
+    var vendors = Object.keys(_flows);
+    for (var i = 0; i < vendors.length; i++) {
+      if (_flows[vendors[i]].terminalId === terminalId) return true;
+    }
+    return false;
+  }
+
+  return {
+    handleVendorLoginMessage: handleVendorLoginMessage,
+    sendStateTo: sendStateTo,
+    listFlows: listFlows,
+    forgetTerminal: forgetTerminal,
+    isLoginTerminal: isLoginTerminal,
+  };
+}
+
+module.exports = { attachVendorLogin: attachVendorLogin };

--- a/lib/project.js
+++ b/lib/project.js
@@ -34,6 +34,7 @@ var { attachSessions } = require("./project-sessions");
 var { attachModels } = require("./project-models");
 var { attachUserMessage } = require("./project-user-message");
 var { attachShellCommand } = require("./project-shell-command");
+var { attachVendorLogin } = require("./project-vendor-login");
 var { attachConnection } = require("./project-connection");
 var { attachMcp } = require("./project-mcp");
 var { createLocalMcp } = require("./mcp-local");
@@ -1286,6 +1287,9 @@ function createProjectContext(opts) {
     // --- Shell command context ---
     if (_shellCommand.handleShellCommand(ws, msg)) return;
 
+    // --- Vendor login flow (delegated to project-vendor-login.js) ---
+    if (_vendorLogin.handleVendorLoginMessage(ws, msg)) return;
+
     // --- Notes, terminals, context, user message (delegated to project-user-message.js) ---
     if (_userMessage.handleUserMessage(ws, msg)) return;
   }
@@ -1593,6 +1597,21 @@ function createProjectContext(opts) {
     getOsUserInfoForWs: getOsUserInfoForWs,
   });
 
+  // --- Vendor login flow (delegated to project-vendor-login.js) ---
+  var _vendorLogin = attachVendorLogin({
+    slug: slug,
+    osUsers: osUsers,
+    sm: sm,
+    tm: tm,
+    adapters: adapters,
+    send: send,
+    sendTo: sendTo,
+    usersModule: usersModule,
+    getOsUserInfoForWs: getOsUserInfoForWs,
+    getOsUserInfoForLinuxUser: getOsUserInfoForLinuxUser,
+    getLinuxUserForSession: getLinuxUserForSession,
+  });
+
   // --- Filesystem handler (delegated to project-filesystem.js) ---
   var _filesystem = attachFilesystem({
     cwd: cwd,
@@ -1866,6 +1885,7 @@ function createProjectContext(opts) {
     _mcp: _mcp,
     _notifications: _notifications,
     _splitGroups: _splitGroups,
+    _vendorLogin: _vendorLogin,
     resolveSessionForView: _sessions.resolveSessionForView,
     hydrateImageRefs: hydrateImageRefs,
     broadcastClientCount: broadcastClientCount,

--- a/lib/public/modules/app-messages.js
+++ b/lib/public/modules/app-messages.js
@@ -37,7 +37,7 @@ import { updateSettingsStats, updateDaemonConfig, handleSetPinResult, handleKeep
 import { handleTermList, handleTermCreated, sendTerminalCommand, handleTermOutput, handleTermResized, handleTermExited, handleTermClosed } from './terminal.js';
 import { attachTuiView, detachTuiView, setTuiSuspendedView, tuiHandleTermOutput, tuiHandleTermResized, tuiHandleTermExited, tuiHandleTermClosed } from './session-tui-view.js';
 import { handleTuiTranscriptState } from './tui-grab.js';
-import { tuiModalHandleTermOutput, tuiModalHandleTermResized, tuiModalHandleTermExited, tuiModalHandleTermClosed, openTuiModal } from './tui-attention.js';
+import { tuiModalHandleTermOutput, tuiModalHandleTermResized, tuiModalHandleTermExited, tuiModalHandleTermClosed } from './tui-attention.js';
 import { updateTerminalList, handleContextSourcesState, updateEmailAccountList, updateEmailUnreadCounts, handleEmailTestResult, handleEmailAddResult, handleEmailRemoveResult } from './context-sources.js';
 import { refreshEmailSettings } from './user-settings.js';
 import { handleNotesList, handleNoteCreated, handleNoteUpdated, handleNoteDeleted, handleNoteWritten } from './sticky-notes.js';
@@ -72,7 +72,8 @@ import { handleRemoteCursorMove, handleRemoteCursorLeave, handleRemoteSelection,
 import { showLoopBanner, updateLoopBanner, updateLoopInputVisibility, showRalphApprovalBar, updateRalphApprovalStatus, openRalphPreviewModal, showExecModal, updateExecModalStatus } from './app-loop-ui.js';
 import { showDebateSticky, showDebateConcludeConfirm, showDebateUserFloor, exitDebateFloorMode, exitDebateConcludeMode, exitDebateEndedMode, updateDebateRound, renderDebateUserFloorDone } from './app-debate-ui.js';
 import { handleSkillInstallWs } from './app-skills-install.js';
-import { handleNotificationsState, handleNotificationCreated, handleNotificationDismissed, handleNotificationDismissedAll, showUpdateBanner, autoStartLoginIfNeeded } from './app-notifications.js';
+import { handleNotificationsState, handleNotificationCreated, handleNotificationDismissed, handleNotificationDismissedAll, showUpdateBanner } from './app-notifications.js';
+import { autoStartLoginIfNeeded, handleVendorLoginReady, handleVendorLoginState, handleVendorLoginError, handleAuthRefreshed } from './vendor-login.js';
 import { handleDebatePreparing, handleDebateBriefReady, renderDebateBriefReady, handleDebateStarted, renderDebateStarted, handleDebateTurn, handleDebateActivity, handleDebateStream, handleDebateTurnDone, handleDebateCommentQueued, handleDebateCommentInjected, renderDebateCommentInjected, handleDebateResumed, handleDebateEnded, renderDebateEnded, handleDebateError, isDebateActive, renderMcpDebateProposal, renderDebateUserResume } from './debate.js';
 import { handleMentionStart, handleMentionActivity, handleMentionStream, handleMentionDone, handleMentionError, renderMentionUser, renderMentionResponse, renderUserMention } from './mention.js';
 
@@ -1299,9 +1300,26 @@ export function processMessage(msg) {
         appendDelta((msg.text || "Authentication required.") + "\n");
         setStatus("connected");
         if (!store.get('loopActive')) enableMainInput();
-        // Auto-open the login modal terminal when the session can self-login.
-        // No-op otherwise (the auth_required banner remains the manual path).
+        // Open the login flow for this vendor. The server keeps exactly one
+        // login terminal per vendor, so repeat auth_required events (other
+        // sessions, split panes, a 401 retry burst) do not stack up.
         autoStartLoginIfNeeded(msg);
+        break;
+
+      case "vendor_login_ready":
+        handleVendorLoginReady(msg);
+        break;
+
+      case "vendor_login_state":
+        handleVendorLoginState(msg);
+        break;
+
+      case "vendor_login_error":
+        handleVendorLoginError(msg);
+        break;
+
+      case "auth_refreshed":
+        handleAuthRefreshed(msg);
         break;
 
       case "rate_limit":
@@ -1492,19 +1510,8 @@ export function processMessage(msg) {
         break;
 
       case "term_created":
-        // Login-modal path: the terminal was created with the login command as
-        // its initial input; attach the modal dialog to it (replays scrollback
-        // so the login URL is visible) instead of the sidebar terminal.
-        if (store.get('pendingLoginModal')) {
-          var _lm = store.get('pendingLoginModal');
-          store.set({ pendingLoginModal: null });
-          openTuiModal(msg.id, _lm.slug, {
-            sessionTitle: (VENDOR_NAMES[_lm.vendor] || "Claude Code") + " login",
-            projectName: _lm.slug,
-            compact: true,
-          });
-          break;
-        }
+        // Login terminals never come through here: they are created by the
+        // server-owned flow and announced with vendor_login_ready instead.
         handleTermCreated(msg);
         if (store.get('pendingTermCommand')) {
           var cmd = store.get('pendingTermCommand');

--- a/lib/public/modules/app-notifications.js
+++ b/lib/public/modules/app-notifications.js
@@ -10,8 +10,8 @@ import { showHomeHub } from './app-home-hub.js';
 import { openHomeChat } from './home-mate-chat.js';
 import { getCachedProjects, switchProject, renderProjectList } from './app-projects.js';
 import { mateAvatarUrl, userAvatarUrl } from './avatar.js';
-import { openTerminal } from './terminal.js';
 import { openTuiModal } from './tui-attention.js';
+import { requestVendorLogin } from './vendor-login.js';
 import { startUrgentBlink, stopUrgentBlink } from './app-favicon.js';
 import { playDoneSound, isNotifSoundEnabled } from './notifications.js';
 var notifications = [];
@@ -47,7 +47,6 @@ var pendingTuiTotal = 0;
 // (next hour) acts as a fresh ping.
 var pendingUpdateMsg = null;
 var activeAuthRequiredMsg = null;
-var authReminderVisible = false;
 
 // ========================================================
 // Init
@@ -91,7 +90,6 @@ function showAllBanners() {
   }
 
   if (activeAuthRequiredMsg) showAuthRequiredBanner(activeAuthRequiredMsg);
-  if (authReminderVisible) showLoginReminderBanner();
 
   // Check if any banner actually got rendered (update/auth banners can be suppressed)
   var hasVisibleBanner = bannerContainer.children.length > 0;
@@ -266,8 +264,9 @@ function showBanner(notif, autoDismissMs) {
           removeBanner(banner);
           dismissNotif(notif.id);
           var authMeta = notif.meta || {};
-          startLoginInModal(authMeta.loginCommand || getVendorLoginCommand(authMeta.vendor || "claude"), authMeta.vendor || "claude");
-          showLoginReminderBanner();
+          // Deliberate click: re-attach to a live login terminal instead of
+          // spawning a second one (the server dedups per vendor).
+          requestVendorLogin(authMeta.vendor || "claude", { sessionId: notif.sessionId || null });
         });
       }
     }
@@ -322,118 +321,6 @@ function showBanner(notif, autoDismissMs) {
     setTimeout(function () { removeBanner(banner); }, autoDismissMs);
   } else if (autoDismissMs === true) {
     setTimeout(function () { removeBanner(banner); }, 3000);
-  }
-}
-
-// Open the login terminal as a modal dialog (the same modal used for TUI
-// attention), running the vendor login command. The terminal is created with
-// the command as its initial input, so when the modal attaches it replays the
-// scrollback and the user sees the login URL / prompts immediately.
-// Falls back to the sidebar terminal if the current project slug is unknown
-// (the modal needs a slug to open its own WS to the project).
-function currentProjectSlug() {
-  var slug = store.get('currentSlug') || "";
-  if (slug) return slug;
-  // Fallback: derive from the URL (/p/<slug>/...).
-  try {
-    var m = (window.location.pathname || "").match(/^\/p\/([a-z0-9_-]+)/);
-    if (m) return m[1];
-  } catch (e) {}
-  return "";
-}
-
-function startLoginInModal(loginCommand, vendor) {
-  if (authReminderVisible) return;
-  var ws = getWs();
-  if (!ws || ws.readyState !== 1) return;
-  var cmd = loginCommand || getVendorLoginCommand(vendor);
-  var slug = currentProjectSlug();
-  if (!slug) { startLoginCommand(cmd); return; }
-  store.set({ pendingLoginModal: { slug: slug, vendor: vendor || "claude" } });
-  ws.send(JSON.stringify({
-    type: "term_create",
-    cols: 100,
-    rows: 30,
-    initialCommand: cmd + "\n",
-  }));
-}
-
-// Sidebar-terminal fallback (used when no slug is available for the modal).
-function startLoginCommand(loginCommand) {
-  if (authReminderVisible) return;
-  var ws = getWs();
-  if (!ws || ws.readyState !== 1) return;
-  var termCommand = (loginCommand || "claude login") + "\n";
-  store.set({ pendingTermCommand: termCommand });
-  ws.send(JSON.stringify({ type: "term_create", cols: 80, rows: 24 }));
-  openTerminal();
-}
-
-// Auto-open the login modal and run the login command when the server reports
-// the vendor isn't logged in. The popup terminal runs as the connected user's
-// own OS identity (term_create -> getOsUserInfoForWs), so login always targets
-// the right account — we pop it unconditionally rather than gating on
-// canAutoLogin. Idempotent: startLoginInModal is guarded by authReminderVisible
-// so repeat auth_required events no-op.
-export function autoStartLoginIfNeeded(msg) {
-  if (!msg) return false;
-  if (authReminderVisible) return false;
-  var vendor = msg.vendor || "claude";
-  var cmd = msg.loginCommand
-    || getVendorLoginCommand(vendor);
-  startLoginInModal(cmd, vendor);
-  showLoginReminderBanner();
-  return true;
-}
-
-function showLoginReminderBanner() {
-  if (!bannerContainer) return;
-  authReminderVisible = true;
-  var existing = bannerContainer.querySelector('[data-auth-reminder="true"]');
-  if (existing) removeBanner(existing);
-  var banner = document.createElement("div");
-  banner.className = "notif-banner notif-banner-update";
-  banner.setAttribute("data-notif-id", "_auth_reminder");
-  banner.setAttribute("data-auth-reminder", "true");
-  banner.innerHTML =
-    '<div class="notif-banner-icon">' + iconHtml("check-circle") + '</div>' +
-    '<div class="notif-banner-body">' +
-      '<div class="notif-banner-project">CLAY</div>' +
-      '<div class="notif-banner-title">Login started</div>' +
-      '<div class="notif-banner-text">After the login completes, open a new session so Clay picks up the fresh auth state.</div>' +
-      '<div class="notif-banner-actions">' +
-        '<button class="notif-banner-new-session notif-banner-update-now">Open new session</button>' +
-      '</div>' +
-    '</div>' +
-    '<button class="notif-banner-close">' + iconHtml("x") + '</button>';
-
-  bannerContainer.appendChild(banner);
-  refreshIcons();
-
-  requestAnimationFrame(function () {
-    banner.classList.add("show");
-  });
-
-  var newSessionBtn = banner.querySelector(".notif-banner-new-session");
-  if (newSessionBtn) {
-    newSessionBtn.addEventListener("click", function (e) {
-      e.stopPropagation();
-      authReminderVisible = false;
-      var ws = getWs();
-      if (ws && ws.readyState === 1) {
-        ws.send(JSON.stringify({ type: "new_session" }));
-      }
-      removeBanner(banner);
-    });
-  }
-
-  var closeBtn = banner.querySelector(".notif-banner-close");
-  if (closeBtn) {
-    closeBtn.addEventListener("click", function (e) {
-      e.stopPropagation();
-      authReminderVisible = false;
-      removeBanner(banner);
-    });
   }
 }
 

--- a/lib/public/modules/pane-bridge.js
+++ b/lib/public/modules/pane-bridge.js
@@ -23,6 +23,15 @@ export function reportPaneContext(data) {
   }, window.location.origin);
 }
 
+// A pane has no banner surface and no login modal of its own, so both panes
+// hitting auth_required would otherwise race to start their own login flow.
+// Hand the event to the parent shell, which owns the single flow.
+export function forwardPaneAuthRequired(message) {
+  if (!store.get('paneMode') || window.parent === window) return false;
+  window.parent.postMessage({ type: "clay-pane-auth-required", message: message }, window.location.origin);
+  return true;
+}
+
 export function forwardPaneMarkdownPresentation(message) {
   if (!store.get('paneMode') || window.parent === window) return false;
   window.parent.postMessage({ type: "clay-pane-present-markdown", message: message }, window.location.origin);

--- a/lib/public/modules/split-view.js
+++ b/lib/public/modules/split-view.js
@@ -11,6 +11,7 @@ import { groupedSessionIds, findSplitGroup } from './split-group-helpers.js';
 import { showConfirm } from './app-misc.js';
 import { syncPairChrome } from './split-pair-ui.js';
 import { presentMarkdownEdit } from './filebrowser.js';
+import { autoStartLoginIfNeeded } from './vendor-login.js';
 
 var host = null;
 var nativeApp = null;
@@ -274,6 +275,12 @@ function handlePaneMessage(event) {
   if (msg.type === "clay-pane-present-markdown") {
     var present = msg.message;
     if (present) presentMarkdownEdit(present);
+    return;
+  }
+  // Both panes can report auth_required for their own sessions. The shell runs
+  // one login flow for the project; repeat events are no-ops there.
+  if (msg.type === "clay-pane-auth-required") {
+    if (msg.message) autoStartLoginIfNeeded(msg.message);
     return;
   }
   if (msg.type !== "clay-pane-context") return;

--- a/lib/public/modules/tui-attention.js
+++ b/lib/public/modules/tui-attention.js
@@ -29,6 +29,10 @@ var modalWs = null;
 var modalResizeObserver = null;
 var modalKeyHandler = null;
 var modalResizeDebounce = null;
+// Optional per-open callback fired once the modal is torn down, whatever
+// dismissed it (Esc, backdrop click, term_closed). The login flow uses it to
+// cancel a login the user walked away from.
+var modalCloseHook = null;
 // Debounced fit+redraw for the modal xterm. Same rationale as
 // session-tui-view.js: collapses rapid resize events into a single
 // SIGWINCH so claude can redraw cleanly without mid-resize corruption.
@@ -139,6 +143,7 @@ export function openTuiModal(terminalId, sourceSlug, info) {
   modalTerminalId = terminalId;
   modalSourceSlug = sourceSlug;
   var infoObj = info || {};
+  modalCloseHook = typeof infoObj.onClose === "function" ? infoObj.onClose : null;
   setModalBreadcrumb({
     projectIcon: infoObj.projectIcon || null,
     projectName: infoObj.projectName || sourceSlug,
@@ -232,6 +237,8 @@ export function openTuiModal(terminalId, sourceSlug, info) {
 
 export function closeTuiModal() {
   if (!modalEl) return;
+  var closeHook = modalCloseHook;
+  modalCloseHook = null;
   if (modalTerminalId != null && modalWs && modalWs.readyState === 1) {
     try { modalWs.send(JSON.stringify({ type: "term_detach", id: modalTerminalId })); } catch (e) {}
   }
@@ -246,6 +253,9 @@ export function closeTuiModal() {
   if (modalKeyHandler) {
     document.removeEventListener("keydown", modalKeyHandler);
     modalKeyHandler = null;
+  }
+  if (closeHook) {
+    try { closeHook(); } catch (e) {}
   }
 }
 

--- a/lib/public/modules/vendor-login.js
+++ b/lib/public/modules/vendor-login.js
@@ -1,0 +1,287 @@
+// vendor-login.js - Vendor login (auth_required) recovery flow.
+//
+// The server owns the login terminal (see lib/project-vendor-login.js): exactly
+// one per vendor per project, tracked server-side, killed once the login lands.
+// This module is the client half of that contract - it asks for the flow, opens
+// the modal on whatever terminal the server hands back, and reflects the flow's
+// state in a banner.
+//
+// Nothing here spawns a terminal speculatively. Every auth_required after the
+// first is a no-op while a flow is live, which is what stops the login-terminal
+// pile-up and the endless auth_required -> login -> 401 loop.
+
+import { store } from './store.js';
+import { getWs } from './ws-ref.js';
+import { refreshIcons, iconHtml } from './icons.js';
+import { openTuiModal, closeTuiModal, getTuiModalTerminalId } from './tui-attention.js';
+import { forwardPaneAuthRequired } from './pane-bridge.js';
+
+// vendor -> { terminalId, startedAt } as last broadcast by the server.
+var activeFlows = Object.create(null);
+// vendor -> true between sending vendor_login_start and hearing back.
+var pendingStarts = Object.create(null);
+// Vendor whose login terminal the modal is currently showing.
+var modalVendor = null;
+// Set while this module tears the modal down itself, so the modal's close hook
+// does not read a programmatic close as "the user gave up".
+var closingModalInternally = false;
+
+function vendorDisplayName(vendor) {
+  var vendors = store.get('vendorInfo') || {};
+  var info = vendors[vendor];
+  if (info && info.displayName) return info.displayName;
+  return vendor === "codex" ? "Codex" : "Claude Code";
+}
+
+function currentProjectSlug() {
+  var slug = store.get('currentSlug') || "";
+  if (slug) return slug;
+  // Fallback: derive from the URL (/p/<slug>/...).
+  try {
+    var m = (window.location.pathname || "").match(/^\/p\/([a-z0-9_-]+)/);
+    if (m) return m[1];
+  } catch (e) {}
+  return "";
+}
+
+// The banner surface belongs to the notification center. Query it rather than
+// importing app-notifications so the dependency stays one-directional
+// (app-notifications -> vendor-login).
+function bannerContainer() {
+  return document.querySelector(".notif-banner-container");
+}
+
+function removeBannerEl(el) {
+  if (!el) return;
+  el.classList.remove("show");
+  setTimeout(function () {
+    if (el.parentNode) el.parentNode.removeChild(el);
+  }, 300);
+}
+
+function clearLoginBanners() {
+  var container = bannerContainer();
+  if (!container) return;
+  var existing = container.querySelectorAll('[data-vendor-login="true"]');
+  for (var i = 0; i < existing.length; i++) removeBannerEl(existing[i]);
+}
+
+function showLoginBanner(opts) {
+  var container = bannerContainer();
+  if (!container) return null;
+  clearLoginBanners();
+
+  var banner = document.createElement("div");
+  banner.className = "notif-banner notif-banner-update";
+  banner.setAttribute("data-notif-id", "_vendor_login");
+  banner.setAttribute("data-vendor-login", "true");
+  banner.innerHTML =
+    '<div class="notif-banner-icon">' + iconHtml(opts.icon || "check-circle") + '</div>' +
+    '<div class="notif-banner-body">' +
+      '<div class="notif-banner-project">CLAY</div>' +
+      '<div class="notif-banner-title">' + opts.title + '</div>' +
+      '<div class="notif-banner-text">' + opts.text + '</div>' +
+    '</div>' +
+    '<button class="notif-banner-close">' + iconHtml("x") + '</button>';
+
+  container.appendChild(banner);
+  refreshIcons();
+  requestAnimationFrame(function () { banner.classList.add("show"); });
+
+  var closeBtn = banner.querySelector(".notif-banner-close");
+  if (closeBtn) {
+    closeBtn.addEventListener("click", function (e) {
+      e.stopPropagation();
+      removeBannerEl(banner);
+      if (opts.onDismiss) opts.onDismiss();
+    });
+  }
+  if (typeof opts.autoDismissMs === "number") {
+    setTimeout(function () { removeBannerEl(banner); }, opts.autoDismissMs);
+  }
+  return banner;
+}
+
+function showLoginStartedBanner(vendor) {
+  showLoginBanner({
+    icon: "check-circle",
+    title: vendorDisplayName(vendor) + " login started",
+    text: "Finish the sign-in in the terminal. Clay reloads the credentials on its own, so your sessions keep working - no new session needed.",
+    onDismiss: function () { cancelVendorLogin(vendor); },
+  });
+}
+
+function showLoginCompleteBanner(vendor) {
+  showLoginBanner({
+    icon: "check-circle",
+    title: "Signed in to " + vendorDisplayName(vendor),
+    text: "Credentials reloaded. Send your next message to continue.",
+    autoDismissMs: 6000,
+  });
+}
+
+function showLoginErrorBanner(vendor, error) {
+  showLoginBanner({
+    icon: "alert-triangle",
+    title: vendorDisplayName(vendor) + " login could not start",
+    text: error || "The login terminal could not be created.",
+    autoDismissMs: 8000,
+  });
+}
+
+function closeModalInternally() {
+  modalVendor = null;
+  closingModalInternally = true;
+  try {
+    closeTuiModal();
+  } finally {
+    closingModalInternally = false;
+  }
+}
+
+function closeModalForVendor(vendor, terminalId) {
+  if (modalVendor !== vendor) return;
+  var openId = getTuiModalTerminalId();
+  if (typeof terminalId === "number" && openId != null && openId !== terminalId) return;
+  closeModalInternally();
+}
+
+// ========================================================
+// Outgoing
+// ========================================================
+
+/**
+ * Ask the server to start (or hand back) the login terminal for a vendor.
+ * opts.auto marks a request triggered by an auth_required event; those never
+ * open a second prompt while a flow is already running.
+ */
+export function requestVendorLogin(vendor, opts) {
+  var options = opts || {};
+  var target = vendor || "claude";
+  if (options.auto && (activeFlows[target] || pendingStarts[target])) return false;
+
+  var ws = getWs();
+  if (!ws || ws.readyState !== 1) return false;
+
+  pendingStarts[target] = true;
+  ws.send(JSON.stringify({
+    type: "vendor_login_start",
+    vendor: target,
+    auto: !!options.auto,
+    sessionId: options.sessionId || store.get('activeSessionId') || null,
+  }));
+  showLoginStartedBanner(target);
+  return true;
+}
+
+export function cancelVendorLogin(vendor) {
+  var target = vendor || modalVendor;
+  if (!target) return;
+  delete pendingStarts[target];
+  delete activeFlows[target];
+  clearLoginBanners();
+  if (modalVendor === target) closeModalInternally();
+  var ws = getWs();
+  if (ws && ws.readyState === 1) {
+    ws.send(JSON.stringify({ type: "vendor_login_cancel", vendor: target }));
+  }
+}
+
+/**
+ * Auto-open the login flow when the server reports the vendor isn't logged in.
+ *
+ * Split panes have no banner surface of their own (the parent shell owns the
+ * single visible one), so a pane hands the event up instead of running two
+ * competing flows.
+ */
+export function autoStartLoginIfNeeded(msg) {
+  if (!msg) return false;
+  if (store.get('paneMode')) {
+    return forwardPaneAuthRequired({
+      vendor: msg.vendor || "claude",
+      sessionId: store.get('activeSessionId') || null,
+    });
+  }
+  var vendor = msg.vendor || "claude";
+  if (activeFlows[vendor] || pendingStarts[vendor]) return false;
+  return requestVendorLogin(vendor, { auto: true, sessionId: msg.sessionId || null });
+}
+
+// ========================================================
+// Incoming
+// ========================================================
+
+export function handleVendorLoginReady(msg) {
+  if (!msg || typeof msg.terminalId !== "number") return;
+  var vendor = msg.vendor || "claude";
+  delete pendingStarts[vendor];
+  activeFlows[vendor] = { terminalId: msg.terminalId, startedAt: Date.now() };
+
+  var slug = msg.slug || currentProjectSlug();
+  if (!slug) return;
+  modalVendor = vendor;
+  openTuiModal(msg.terminalId, slug, {
+    sessionTitle: vendorDisplayName(vendor) + " login",
+    projectName: slug,
+    compact: true,
+    // Dismissing the modal abandons the login: kill the terminal server-side
+    // so it never lingers in the sidebar terminal list.
+    onClose: function () {
+      if (closingModalInternally) return;
+      modalVendor = null;
+      cancelVendorLogin(vendor);
+    },
+  });
+}
+
+export function handleVendorLoginState(msg) {
+  if (!msg) return;
+  var next = Object.create(null);
+  var flows = msg.flows || [];
+  for (var i = 0; i < flows.length; i++) {
+    next[flows[i].vendor] = { terminalId: flows[i].terminalId, startedAt: flows[i].startedAt };
+    delete pendingStarts[flows[i].vendor];
+  }
+
+  // A flow the server dropped without an auth_refreshed (cancelled elsewhere,
+  // terminal killed from the sidebar) must not leave a stale modal behind.
+  var previous = Object.keys(activeFlows);
+  for (var p = 0; p < previous.length; p++) {
+    if (!next[previous[p]] && modalVendor === previous[p]) {
+      closeModalInternally();
+      clearLoginBanners();
+    }
+  }
+  activeFlows = next;
+}
+
+export function handleAuthRefreshed(msg) {
+  if (!msg) return;
+  var vendor = msg.vendor || "claude";
+  var flow = activeFlows[vendor];
+  delete pendingStarts[vendor];
+  delete activeFlows[vendor];
+  closeModalForVendor(vendor, flow ? flow.terminalId : undefined);
+  clearLoginBanners();
+  showLoginCompleteBanner(vendor);
+}
+
+export function handleVendorLoginError(msg) {
+  if (!msg) return;
+  var vendor = msg.vendor || "claude";
+  delete pendingStarts[vendor];
+  delete activeFlows[vendor];
+  if (modalVendor === vendor) closeModalInternally();
+  clearLoginBanners();
+  showLoginErrorBanner(vendor, msg.error);
+}
+
+export function requestVendorLoginState() {
+  var ws = getWs();
+  if (!ws || ws.readyState !== 1) return;
+  ws.send(JSON.stringify({ type: "vendor_login_state_request" }));
+}
+
+export function getActiveLoginFlow(vendor) {
+  return activeFlows[vendor] || null;
+}

--- a/lib/tools-registry.js
+++ b/lib/tools-registry.js
@@ -137,7 +137,17 @@ function seedBuiltInCapsules(ctx) {
   for (var ri = 0; ri < REMOVED_BUILTIN_IDS.length; ri++) {
     fs.rmSync(path.join(root, REMOVED_BUILTIN_IDS[ri]), { recursive: true, force: true });
   }
-  var entries = fs.readdirSync(CAPSULES_ROOT, { withFileTypes: true });
+  // Clay ships no built-in Capsules any more, so lib/capsules/ is absent from a
+  // fresh checkout and from the npm tarball (neither git nor npm carries an
+  // empty directory). Seeding still owns the removed-built-in migration above
+  // and the marker below, so an absent root means "nothing to copy" rather than
+  // a failure. Anything other than a missing root is still a real error.
+  var entries = [];
+  try {
+    entries = fs.readdirSync(CAPSULES_ROOT, { withFileTypes: true });
+  } catch (e) {
+    if (e.code !== "ENOENT") throw e;
+  }
   var seeded = [];
   for (var i = 0; i < entries.length; i++) {
     if (!entries[i].isDirectory()) continue;

--- a/lib/ws-schema.js
+++ b/lib/ws-schema.js
@@ -171,6 +171,13 @@ var schema = {
   // Auth
   // -----------------------------------------------------------------------
   "auth_required":            { direction: "s2c", handler: "lib/public/modules/app-messages.js", description: "Authentication required (e.g. API key needed)" },
+  "vendor_login_start":       { direction: "c2s", handler: "lib/project-vendor-login.js", description: "Start (or re-attach to) the per-vendor login terminal" },
+  "vendor_login_cancel":      { direction: "c2s", handler: "lib/project-vendor-login.js", description: "Dismiss the login flow and kill its terminal" },
+  "vendor_login_state_request": { direction: "c2s", handler: "lib/project-vendor-login.js", description: "Ask for the project's active login flows" },
+  "vendor_login_ready":       { direction: "s2c", handler: "lib/public/modules/vendor-login.js", description: "Login terminal is available; open/re-attach the modal to it" },
+  "vendor_login_state":       { direction: "s2c", handler: "lib/public/modules/vendor-login.js", description: "Active login flows for this project (one per vendor)" },
+  "vendor_login_error":       { direction: "s2c", handler: "lib/public/modules/vendor-login.js", description: "The login flow could not be started" },
+  "auth_refreshed":           { direction: "s2c", handler: "lib/public/modules/vendor-login.js", description: "Login completed and the vendor adapter was restarted" },
 
   // -----------------------------------------------------------------------
   // Rate limiting / scheduling

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -1312,15 +1312,14 @@ function createCodexAdapter(opts) {
   // model listing must not depend on a successful app-server init — otherwise a
   // slow/failed `initialize` leaves the picker empty and the chip shows the
   // previous vendor's model.
+  // Kept in sync with what `model/list` reports for the bundled codex build
+  // (0.152.1). Models the CLI no longer offers are rejected at turn/start, so
+  // listing them would only surface a runtime failure in the model picker.
   var CODEX_MODELS = [
     "gpt-5.6-terra",
     "gpt-5.6-sol",
     "gpt-5.6-luna",
     "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.3-codex",
-    "gpt-5.3-codex-spark",
     "gpt-5.2",
   ];
   var _cachedModels = CODEX_MODELS.slice();

--- a/lib/yoke/codex-app-server.js
+++ b/lib/yoke/codex-app-server.js
@@ -13,7 +13,13 @@ var { buildUserEnv } = require("../build-user-env");
 var { wrapSpawnAsUser } = require("../os-users");
 
 // --- Find the codex binary path ---
-// Mirrors the logic from @openai/codex-sdk findCodexPath()
+// Mirrors the logic from @openai/codex-sdk findCodexPath().
+//
+// The bundled @openai/codex platform package is the default. Set the
+// CLAY_CODEX_PATH env var to an existing executable to run a different codex
+// build (local dev build, system install, pinned older release); the chosen
+// binary is logged on every resolution. An unset or non-existent
+// CLAY_CODEX_PATH silently falls back to the bundled resolution.
 
 var PLATFORM_PACKAGE_BY_TARGET = {
   "aarch64-apple-darwin": "@openai/codex-darwin-arm64",
@@ -39,6 +45,15 @@ function getTargetTriple() {
 }
 
 function findCodexPath() {
+  var override = process.env.CLAY_CODEX_PATH;
+  if (override) {
+    if (fs.existsSync(override)) {
+      console.log("[codex-app-server] Using CLAY_CODEX_PATH binary:", override);
+      return override;
+    }
+    console.warn("[codex-app-server] CLAY_CODEX_PATH does not exist, falling back to bundled codex:", override);
+  }
+
   var triple = getTargetTriple();
   if (!triple) throw new Error("Unsupported platform: " + process.platform + "/" + process.arch);
 
@@ -59,7 +74,10 @@ function findCodexPath() {
       path.join(vendorRoot, triple, "codex", binaryName),
     ];
     for (var i = 0; i < candidates.length; i++) {
-      if (fs.existsSync(candidates[i])) return candidates[i];
+      if (fs.existsSync(candidates[i])) {
+        console.log("[codex-app-server] Using bundled codex binary:", candidates[i]);
+        return candidates[i];
+      }
     }
     throw new Error("codex binary not found in any known layout under " + path.join(vendorRoot, triple));
   } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "clay-server",
-  "version": "3.8.0-beta.2",
+  "version": "4.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clay-server",
-      "version": "3.8.0-beta.2",
+      "version": "4.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.241",
         "@lydell/node-pty": "^1.2.0-beta.3",
-        "@openai/codex": "^0.147.0",
+        "@openai/codex": "^0.152.1",
         "@seald-io/nedb": "^4.1.2",
         "imapflow": "^1.3.1",
         "nodemailer": "^9.0.5",
@@ -588,9 +588,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.147.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0.tgz",
-      "integrity": "sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==",
+      "version": "0.152.1",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1.tgz",
+      "integrity": "sha512-dSwQzl6JgsFe8L9i8xUnwRz9Vy8gn4UvXFU9xq2IJ1eC7zsSttqQ2SGq49ZZIjEyZQ0LZjCs6Bvtxort2Iyebg==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -599,19 +599,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.147.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.147.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.147.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.147.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.147.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.147.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.152.1-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.152.1-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.152.1-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.152.1-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.152.1-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.152.1-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.147.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
-      "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
+      "version": "0.152.1-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-darwin-arm64.tgz",
+      "integrity": "sha512-H8i0uZHILM0Z2Ep+MryCF5rGXmXjmXTzXf5ZK6bobKtZc2yfomi42ZrQWuYQ5P02H0oLG7B5jLaSWZQ+VFgjbA==",
       "cpu": [
         "arm64"
       ],
@@ -626,9 +626,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.147.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
-      "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
+      "version": "0.152.1-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-darwin-x64.tgz",
+      "integrity": "sha512-M2qW7YkRx+JeSFoZQsrjgA5yNglowuNAFOwRJoIjlgeP8bsyOqPtbSolu3w4Us7IyCH8f/yuKtlt/v/MdDqbfA==",
       "cpu": [
         "x64"
       ],
@@ -643,9 +643,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.147.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
-      "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
+      "version": "0.152.1-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-linux-arm64.tgz",
+      "integrity": "sha512-qZXqf7fxn/SCmaJW6tYrzWqwcDo0gMDJjj1Pm4OtrWXR7Oc0Y2e8ngAh/Mep9iFhVbsqntY1eGLaQaXssGvFgA==",
       "cpu": [
         "arm64"
       ],
@@ -660,9 +660,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.147.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
-      "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
+      "version": "0.152.1-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-linux-x64.tgz",
+      "integrity": "sha512-ar59rr3CX5j4MLMnRcHqcE0eHZPsZlmXlz37ZS2yP3BsV5pNhO+wFXTOzXFdaYmg2cALX7a3Eqv+vB2jQlXnjQ==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +677,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.147.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
-      "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==",
+      "version": "0.152.1-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-win32-arm64.tgz",
+      "integrity": "sha512-YZjWCcArfSLlqG/4r2Ox5ZZhz1FAFQBZisz8U8r5JLxeLk0tXwZHleu8RjNjly++0S5zsgPtAuF0viSIj7NyRA==",
       "cpu": [
         "arm64"
       ],
@@ -694,9 +694,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.147.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
-      "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
+      "version": "0.152.1-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.152.1-win32-x64.tgz",
+      "integrity": "sha512-B8h0/2Kt+rKQv2+vqBhlhWkMEdhf4dsn46FNKMEBTXj3YC5hwSioOcTX2hMgJxMEMtKIMH6Ire1eNrQPvaL9og==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.241",
     "@lydell/node-pty": "^1.2.0-beta.3",
-    "@openai/codex": "^0.147.0",
+    "@openai/codex": "^0.152.1",
     "@seald-io/nedb": "^4.1.2",
     "imapflow": "^1.3.1",
     "nodemailer": "^9.0.5",

--- a/test/vendor-login-flow.test.js
+++ b/test/vendor-login-flow.test.js
@@ -1,0 +1,327 @@
+var test = require("node:test");
+var assert = require("node:assert");
+
+var { attachVendorLogin } = require("../lib/project-vendor-login");
+
+// Minimal terminal-manager stand-in with the surface project-vendor-login uses.
+function createFakeTerminalManager(opts) {
+  var options = opts || {};
+  var nextId = 1;
+  var terminals = new Map();
+
+  return {
+    created: [],
+    closed: [],
+    attached: [],
+    create: function (cols, rows, osUserInfo, ownerWs, createOpts) {
+      if (options.failCreate) return null;
+      var id = nextId++;
+      var session = { id: id, opts: createOpts || {}, osUserInfo: osUserInfo || null };
+      terminals.set(id, session);
+      this.created.push(session);
+      return session;
+    },
+    attach: function (id, ws) { this.attached.push({ id: id, ws: ws }); },
+    close: function (id) { terminals.delete(id); this.closed.push(id); },
+    has: function (id) { return terminals.has(id); },
+    list: function () {
+      var out = [];
+      terminals.forEach(function (s) { out.push({ id: s.id, title: (s.opts && s.opts.title) || "", kind: (s.opts && s.opts.kind) || "shell" }); });
+      return out;
+    },
+    emitData: function (id, chunk) {
+      var s = terminals.get(id);
+      if (s && s.opts && s.opts.onData) s.opts.onData(chunk);
+    },
+    emitExit: function (id) {
+      var s = terminals.get(id);
+      if (!s) return;
+      terminals.delete(id);
+      if (s.opts && s.opts.onExit) s.opts.onExit(s);
+    },
+  };
+}
+
+function createHarness(opts) {
+  var options = opts || {};
+  var broadcasts = [];
+  var direct = [];
+  var shutdowns = [];
+
+  var tm = createFakeTerminalManager(options.tm);
+  var adapters = options.adapters || {
+    codex: {
+      vendor: "codex",
+      shutdown: function () { shutdowns.push("codex"); return Promise.resolve(true); },
+    },
+  };
+
+  var login = attachVendorLogin({
+    slug: "demo",
+    osUsers: !!options.osUsers,
+    sm: options.sm || { sessions: new Map() },
+    tm: tm,
+    adapters: adapters,
+    send: function (msg) { broadcasts.push(msg); },
+    sendTo: function (ws, msg) { direct.push({ ws: ws, msg: msg }); },
+    usersModule: options.usersModule || null,
+    getOsUserInfoForWs: options.getOsUserInfoForWs || function () { return null; },
+    getOsUserInfoForLinuxUser: options.getOsUserInfoForLinuxUser || function () { return null; },
+    getLinuxUserForSession: options.getLinuxUserForSession || function () { return null; },
+  });
+
+  return {
+    login: login,
+    tm: tm,
+    broadcasts: broadcasts,
+    direct: direct,
+    shutdowns: shutdowns,
+    typesTo: function (ws) {
+      return direct.filter(function (e) { return e.ws === ws; }).map(function (e) { return e.msg.type; });
+    },
+    lastOf: function (type) {
+      var hits = broadcasts.filter(function (m) { return m.type === type; });
+      return hits.length ? hits[hits.length - 1] : null;
+    },
+  };
+}
+
+function flush() {
+  return new Promise(function (resolve) { setImmediate(resolve); });
+}
+
+test("first auth_required starts one login terminal running the vendor login command", function () {
+  var h = createHarness();
+  var ws = {};
+
+  var handled = h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "codex", auto: true });
+
+  assert.strictEqual(handled, true);
+  assert.strictEqual(h.tm.created.length, 1);
+  assert.strictEqual(h.tm.created[0].opts.initialInput, "codex login --device-auth\n");
+  assert.strictEqual(h.tm.created[0].opts.kind, "vendor-login");
+
+  var ready = h.direct.find(function (e) { return e.msg.type === "vendor_login_ready"; });
+  assert.ok(ready, "requester is told which terminal to attach to");
+  assert.strictEqual(ready.msg.vendor, "codex");
+  assert.strictEqual(ready.msg.reused, false);
+  assert.strictEqual(ready.msg.terminalId, h.tm.created[0].id);
+});
+
+test("further auto auth_required events never spawn a second login terminal or prompt", function () {
+  var h = createHarness();
+  var paneA = {};
+  var paneB = {};
+
+  h.login.handleVendorLoginMessage(paneA, { type: "vendor_login_start", vendor: "codex", auto: true });
+  h.login.handleVendorLoginMessage(paneB, { type: "vendor_login_start", vendor: "codex", auto: true });
+  h.login.handleVendorLoginMessage(paneA, { type: "vendor_login_start", vendor: "codex", auto: true });
+
+  assert.strictEqual(h.tm.created.length, 1, "one login terminal for the whole project");
+  assert.deepStrictEqual(
+    h.typesTo(paneB),
+    ["vendor_login_state"],
+    "the second pane only learns a flow is running; it gets no vendor_login_ready"
+  );
+  assert.strictEqual(h.login.listFlows().length, 1);
+});
+
+test("a deliberate login request re-attaches to the live terminal instead of creating one", function () {
+  var h = createHarness();
+  var first = {};
+  var second = {};
+
+  h.login.handleVendorLoginMessage(first, { type: "vendor_login_start", vendor: "codex", auto: true });
+  h.login.handleVendorLoginMessage(second, { type: "vendor_login_start", vendor: "codex" });
+
+  assert.strictEqual(h.tm.created.length, 1);
+  var ready = h.direct.filter(function (e) { return e.msg.type === "vendor_login_ready"; });
+  assert.strictEqual(ready.length, 2);
+  assert.strictEqual(ready[1].msg.reused, true);
+  assert.strictEqual(ready[1].msg.terminalId, h.tm.created[0].id);
+  assert.ok(h.tm.attached.some(function (a) { return a.ws === second; }), "re-attaches the requester to the existing PTY");
+});
+
+test("successful login restarts the vendor adapter, announces auth_refreshed and removes the terminal", async function () {
+  var h = createHarness();
+  var ws = {};
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "codex", auto: true });
+  var terminalId = h.tm.created[0].id;
+
+  // Split across chunks and wrapped in ANSI, the way a PTY actually delivers it.
+  h.tm.emitData(terminalId, "[32mSuccessfu");
+  h.tm.emitData(terminalId, "lly logged in.[0m\r\n");
+
+  await new Promise(function (resolve) { setTimeout(resolve, 2200); });
+  await flush();
+
+  assert.deepStrictEqual(h.shutdowns, ["codex"], "the app-server is torn down so the next query re-reads auth.json");
+  var refreshed = h.lastOf("auth_refreshed");
+  assert.ok(refreshed, "clients are told auth was reloaded");
+  assert.strictEqual(refreshed.vendor, "codex");
+  assert.strictEqual(refreshed.adapterRestarted, true);
+  assert.deepStrictEqual(h.tm.closed, [terminalId], "the login terminal does not linger in the sidebar");
+  assert.deepStrictEqual(h.login.listFlows(), [], "the flow record is cleared");
+  assert.deepStrictEqual(h.lastOf("vendor_login_state").flows, []);
+});
+
+test("logging out does not read as a successful login", async function () {
+  var h = createHarness();
+  h.login.handleVendorLoginMessage({}, { type: "vendor_login_start", vendor: "codex", auto: true });
+  h.tm.emitData(h.tm.created[0].id, "Successfully logged out\r\n");
+
+  await flush();
+
+  assert.deepStrictEqual(h.shutdowns, []);
+  assert.strictEqual(h.login.listFlows().length, 1, "the flow stays open");
+});
+
+test("cancelling the flow kills the terminal without restarting the adapter", function () {
+  var h = createHarness();
+  var ws = {};
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "codex", auto: true });
+  var terminalId = h.tm.created[0].id;
+
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_cancel", vendor: "codex" });
+
+  assert.deepStrictEqual(h.tm.closed, [terminalId]);
+  assert.deepStrictEqual(h.shutdowns, [], "an abandoned login must not bounce the app-server");
+  assert.deepStrictEqual(h.login.listFlows(), []);
+});
+
+test("a login terminal killed from the sidebar clears the flow so the next auth_required can retry", async function () {
+  var h = createHarness();
+  var ws = {};
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "codex", auto: true });
+  h.tm.emitExit(h.tm.created[0].id);
+  await flush();
+
+  assert.deepStrictEqual(h.login.listFlows(), []);
+  assert.deepStrictEqual(h.shutdowns, [], "an exit with no success line must not bounce the app-server");
+
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "codex", auto: true });
+  assert.strictEqual(h.tm.created.length, 2, "a fresh flow is allowed once the previous one is gone");
+});
+
+test("the login terminal spawns as the identity the adapter will read credentials from", function () {
+  var sessionOwner = { uid: 1201, gid: 1301, home: "/home/alice", user: "alice", shell: "/bin/bash" };
+  var connectedUser = { uid: 1202, gid: 1302, home: "/home/bob", user: "bob", shell: "/bin/bash" };
+  var sessions = new Map();
+  sessions.set("s1", { localId: "s1", ownerId: "u-alice", vendor: "codex" });
+
+  var h = createHarness({
+    osUsers: true,
+    sm: { sessions: sessions },
+    getLinuxUserForSession: function (session) { return session.ownerId === "u-alice" ? "alice" : null; },
+    getOsUserInfoForLinuxUser: function (name) { return name === "alice" ? sessionOwner : null; },
+    getOsUserInfoForWs: function () { return connectedUser; },
+  });
+
+  // An admin opening someone else's session must still log in as the session
+  // owner, because that is the HOME the adapter's app-server reads.
+  h.login.handleVendorLoginMessage(
+    { _clayUser: { id: "u-admin", role: "admin" } },
+    { type: "vendor_login_start", vendor: "codex", auto: true, sessionId: "s1" }
+  );
+
+  assert.strictEqual(h.tm.created[0].osUserInfo.home, "/home/alice");
+});
+
+test("an unrelated viewer falls back to their own identity rather than borrowing the owner's", function () {
+  var connectedUser = { uid: 1202, gid: 1302, home: "/home/bob", user: "bob", shell: "/bin/bash" };
+  var sessions = new Map();
+  sessions.set("s1", { localId: "s1", ownerId: "u-alice", vendor: "codex" });
+
+  var h = createHarness({
+    osUsers: true,
+    sm: { sessions: sessions },
+    getLinuxUserForSession: function () { return "alice"; },
+    getOsUserInfoForLinuxUser: function () { return { uid: 1201, gid: 1301, home: "/home/alice", user: "alice" }; },
+    getOsUserInfoForWs: function () { return connectedUser; },
+  });
+
+  h.login.handleVendorLoginMessage(
+    { _clayUser: { id: "u-bob", role: "user" } },
+    { type: "vendor_login_start", vendor: "codex", auto: true, sessionId: "s1" }
+  );
+
+  assert.strictEqual(h.tm.created[0].osUserInfo.home, "/home/bob");
+});
+
+test("shared adapters are not torn down on login, but auth_refreshed still fires", async function () {
+  var shutdowns = [];
+  var h = createHarness({
+    adapters: {
+      claude: {
+        vendor: "claude",
+        shared: true,
+        shutdown: function () { shutdowns.push("claude"); return Promise.resolve(true); },
+      },
+    },
+  });
+  h.login.handleVendorLoginMessage({}, { type: "vendor_login_start", vendor: "claude", auto: true });
+  h.tm.emitData(h.tm.created[0].id, "Login successful\r\n");
+
+  await new Promise(function (resolve) { setTimeout(resolve, 2200); });
+  await flush();
+
+  assert.deepStrictEqual(shutdowns, [], "a project must not kill the cross-project Claude adapter");
+  var refreshed = h.lastOf("auth_refreshed");
+  assert.ok(refreshed);
+  assert.strictEqual(refreshed.adapterRestarted, false);
+});
+
+test("terminal creation failure reports an error and leaves no flow behind", function () {
+  var h = createHarness({ tm: { failCreate: true } });
+  var ws = {};
+
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "codex", auto: true });
+
+  var err = h.direct.find(function (e) { return e.msg.type === "vendor_login_error"; });
+  assert.ok(err);
+  assert.deepStrictEqual(h.login.listFlows(), []);
+});
+
+test("terminal-less users cannot open a login flow", function () {
+  var h = createHarness({
+    usersModule: {
+      getEffectivePermissions: function () { return { terminal: false }; },
+    },
+  });
+  var ws = { _clayUser: { id: "u1", role: "user" } };
+
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "codex", auto: true });
+
+  assert.strictEqual(h.tm.created.length, 0);
+  var err = h.direct.find(function (e) { return e.msg.type === "vendor_login_error"; });
+  assert.ok(err);
+  assert.match(err.msg.error, /not permitted/);
+});
+
+test("a reconnecting client is handed the live flow so it re-attaches instead of restarting", function () {
+  var h = createHarness();
+  h.login.handleVendorLoginMessage({}, { type: "vendor_login_start", vendor: "codex", auto: true });
+
+  var reconnected = {};
+  h.login.handleVendorLoginMessage(reconnected, { type: "vendor_login_state_request" });
+
+  var state = h.direct.filter(function (e) { return e.ws === reconnected; })[0].msg;
+  assert.strictEqual(state.type, "vendor_login_state");
+  assert.strictEqual(state.flows.length, 1);
+  assert.strictEqual(state.flows[0].vendor, "codex");
+  assert.strictEqual(state.flows[0].terminalId, h.tm.created[0].id);
+});
+
+test("unknown vendors are rejected", function () {
+  var h = createHarness();
+  var ws = {};
+  h.login.handleVendorLoginMessage(ws, { type: "vendor_login_start", vendor: "not-a-vendor" });
+  assert.strictEqual(h.tm.created.length, 0);
+  var err = h.direct.find(function (e) { return e.msg.type === "vendor_login_error"; });
+  assert.ok(err);
+});
+
+test("unrelated messages fall through to the next handler", function () {
+  var h = createHarness();
+  assert.strictEqual(h.login.handleVendorLoginMessage({}, { type: "term_create" }), false);
+});


### PR DESCRIPTION
## Summary

Fixes the Codex login loop (login in a Clay terminal never propagated to sessions, login terminals piled up, and split mode opened duplicate prompts) and updates the bundled Codex to 0.152.1.

### Login loop fix
- New `lib/project-vendor-login.js` owns the auth recovery flow server-side: exactly one login terminal per vendor per project. Repeat `auth_required` events (other sessions, split panes, 401 retry bursts) reuse the existing flow instead of spawning more terminals.
- On login success (detected on PTY output, ANSI-stripped rolling window) the vendor adapter is shut down so the next query spawns a fresh app-server that reads the new `~/.codex/auth.json`. This is the actual bug: the shared long-lived app-server read credentials once at spawn and kept returning 401 forever.
- `auth_refreshed` is broadcast so clients clear the banner; existing sessions continue on the next message (the "open a new session" banner is gone). The login terminal is killed on success, cancel, or modal dismiss and no longer lingers in the sidebar.
- Split panes forward `auth_required` to the parent shell instead of each running a flow.
- Login terminals use the session owner's OS identity (with permission checks) so credentials land in the HOME the adapter actually reads under OS-user isolation.
- New client module `lib/public/modules/vendor-login.js`; `app-notifications.js` shrinks 931 -> 818 lines with a one-directional dependency.

### Codex 0.152.1
- Bump `@openai/codex` ^0.147.0 -> ^0.152.1. Protocol surface verified against a live 0.152.1 app-server (initialize, thread/turn, skills, `thread.ephemeral === true` contract) - no drift.
- Trim the model catalog to what 0.152.1 serves; gpt-5.4/5.4-mini/5.3-codex/5.3-codex-spark are rejected at `turn/start` now.
- Add `CLAY_CODEX_PATH` env override for running a system or custom codex build; bundled stays the default.

### Capsules seeding fix (was: 19 pre-existing failures on main)
- All 19 red Capsule/tool-registry tests on main shared one root cause: `seedBuiltInCapsules()` called `fs.readdirSync(lib/capsules)` unconditionally, but after the built-in Capsules were removed (0382fb7, e6ef64e) that directory no longer exists in a fresh checkout or npm tarball, so every `listTools()` call crashed with ENOENT. This was a real production bug for fresh installs, not just a test issue.
- Fixed in the module (no test was touched or weakened): a missing root now means "nothing to copy"; the removed-built-in cleanup and version marker still run, and any error other than ENOENT still throws.

## Test plan
- New `test/vendor-login-flow.test.js` (15 tests) covering singleton dedup, success detection, adapter restart wiring, cancel/cleanup, and identity resolution.
- Focused suites pass on Node v22.22.1: vendor-login-flow, yoke-complete-once, yoke-user-input, codex-os-user-isolation (41/41).
- Full suite: **842 tests, 842 pass, 0 fail** (the 19 Capsule/tool-registry failures that were pre-existing on main are fixed by the capsules seeding commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
