### PR TITLE
feat(codex): request detailed reasoning summaries so thinking renders

### DIFF
--- a/docs/guides/CODEX-INTEGRATION.md
+++ b/docs/guides/CODEX-INTEGRATION.md
@@ -203,6 +203,21 @@ Consequences to preserve:
 
 `findCodexPath()` honors `CLAY_CODEX_PATH`: if it points at an existing file, that binary is used and logged; otherwise resolution falls back to the bundled `@openai/codex` platform package. Bundled remains the default - use the override for a local build or a pinned release, not as normal configuration.
 
+### 15. Thinking requires reasoning summaries to be requested
+
+The adapter maps `item/reasoning/summaryTextDelta`, `item/reasoning/textDelta`, and `item/reasoning/summaryPartAdded` onto `thinking_start` / `thinking_delta`. Those notifications only carry text when the app-server is *asked* for reasoning summaries: a reasoning item's own content is encrypted for ChatGPT-authenticated models, so the summary stream is the only readable channel.
+
+Left alone, the app-server inherits `~/.codex/config.toml`, where `model_reasoning_summary` defaults to `"auto"` and often yields nothing. Clay therefore injects, in `CODEX_REASONING_DEFAULTS` (`yoke/adapters/codex.js`):
+
+```toml
+model_reasoning_summary = "detailed"
+model_supports_reasoning_summaries = true
+```
+
+These are merged **before** `adapterOptions.CODEX.config`, so a user config key of the same name wins. `show_raw_agent_reasoning` is intentionally not set - it is encrypted on ChatGPT-auth models and noisy elsewhere, so it stays a user opt-in.
+
+This is server-level `--config`, not a `thread/start` parameter, so it applies to every thread on the shared app-server, including one-shot capsule calls (`complete-once.js` spawns nothing of its own). Do not try to vary it per query without accepting a second app-server process.
+
 ---
 
 ## Common Gotchas

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -12,6 +12,23 @@ var { resolveOsUserInfo } = require("../../os-users");
 var backgroundTasks = require("../codex-background-tasks");
 var codexUserInput = require("../codex-user-input");
 
+// --- Reasoning defaults ---
+// Reasoning summaries are the only readable thinking channel Codex offers:
+// raw reasoning content is encrypted for ChatGPT-authenticated models, so the
+// item/reasoning/* events this adapter already maps to thinking only carry
+// text when the app-server is asked for summaries. The CLI default
+// (`model_reasoning_summary = "auto"`) frequently produces none at all, and the
+// app-server otherwise inherits whatever is in the user's ~/.codex/config.toml,
+// so Clay asks for detailed summaries explicitly.
+//
+// `show_raw_agent_reasoning` is deliberately absent: it is encrypted on
+// ChatGPT-auth models and noisy elsewhere, so it stays a user opt-in.
+// Everything here is overridable via adapterOptions.CODEX.config.
+var CODEX_REASONING_DEFAULTS = {
+  model_reasoning_summary: "detailed",
+  model_supports_reasoning_summaries: true,
+};
+
 // --- Event flattening ---
 // Converts app-server JSON-RPC notifications into flat objects with a yokeType field.
 //
@@ -1567,12 +1584,16 @@ function createCodexAdapter(opts) {
           serverOpts.osUserInfo = _resolveOsUserInfo(_runtimeLinuxUser);
         }
 
+        // Clay's config defaults go in first so any user-supplied
+        // adapterOptions.CODEX.config key of the same name overrides them.
+        serverOpts.config = Object.assign({}, CODEX_REASONING_DEFAULTS);
+
         // Extract adapter options
         if (effectiveInitOpts && effectiveInitOpts.adapterOptions && effectiveInitOpts.adapterOptions.CODEX) {
           var co = effectiveInitOpts.adapterOptions.CODEX;
           if (co.apiKey) serverOpts.env = Object.assign({}, serverOpts.env || {}, { OPENAI_API_KEY: co.apiKey });
           if (co.baseUrl) serverOpts.env = Object.assign({}, serverOpts.env || {}, { OPENAI_BASE_URL: co.baseUrl });
-          if (co.config) serverOpts.config = co.config;
+          if (co.config) serverOpts.config = Object.assign(serverOpts.config, co.config);
         }
 
         // Track 1: Read local MCP server definitions from ~/.clay/mcp.json

--- a/test/codex-reasoning-config.test.js
+++ b/test/codex-reasoning-config.test.js
@@ -1,0 +1,170 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+
+var { createCodexAdapter } = require("../lib/yoke/adapters/codex");
+
+function createFakeServer(options) {
+  return {
+    options: options,
+    started: false,
+    proc: null,
+    start: function () { this.started = true; return Promise.resolve(); },
+    send: function (method) {
+      if (method === "skills/list") return Promise.resolve({ data: [] });
+      return Promise.resolve({});
+    },
+    notify: function () {},
+    stop: function () { this.started = false; },
+  };
+}
+
+// Initializes an adapter against a fake app-server and returns the config the
+// adapter would have handed to the real spawn.
+async function spawnedConfig(initOpts) {
+  var spawned = [];
+  var adapter = createCodexAdapter({
+    cwd: process.cwd(),
+    createAppServer: function (options) {
+      var server = createFakeServer(options);
+      spawned.push(server);
+      return server;
+    },
+  });
+  await adapter.init(initOpts || {});
+  assert.strictEqual(spawned.length, 1, "exactly one app-server is spawned");
+  return spawned[0].options.config || {};
+}
+
+test("the spawned app-server asks for detailed reasoning summaries", async function () {
+  var config = await spawnedConfig({});
+  assert.strictEqual(config.model_reasoning_summary, "detailed");
+  assert.strictEqual(config.model_supports_reasoning_summaries, true);
+});
+
+test("raw agent reasoning is left to the user and never forced on", async function () {
+  var config = await spawnedConfig({});
+  assert.ok(
+    !Object.prototype.hasOwnProperty.call(config, "show_raw_agent_reasoning"),
+    "show_raw_agent_reasoning must stay a user opt-in: it is encrypted on ChatGPT-auth models"
+  );
+});
+
+test("user-supplied Codex config overrides the reasoning defaults", async function () {
+  var config = await spawnedConfig({
+    adapterOptions: { CODEX: { config: { model_reasoning_summary: "none" } } },
+  });
+  assert.strictEqual(config.model_reasoning_summary, "none", "the user's choice wins");
+  assert.strictEqual(
+    config.model_supports_reasoning_summaries, true,
+    "defaults the user did not mention survive"
+  );
+});
+
+test("a user can turn summary forcing off entirely", async function () {
+  var config = await spawnedConfig({
+    adapterOptions: {
+      CODEX: { config: { model_reasoning_summary: "concise", model_supports_reasoning_summaries: false } },
+    },
+  });
+  assert.strictEqual(config.model_reasoning_summary, "concise");
+  assert.strictEqual(config.model_supports_reasoning_summaries, false);
+});
+
+test("user config can enable raw reasoning explicitly", async function () {
+  var config = await spawnedConfig({
+    adapterOptions: { CODEX: { config: { show_raw_agent_reasoning: true } } },
+  });
+  assert.strictEqual(config.show_raw_agent_reasoning, true);
+  assert.strictEqual(config.model_reasoning_summary, "detailed", "defaults still apply alongside");
+});
+
+test("unrelated user config keys are carried through with the defaults", async function () {
+  var config = await spawnedConfig({
+    adapterOptions: { CODEX: { config: { model_verbosity: "low" } } },
+  });
+  assert.strictEqual(config.model_verbosity, "low");
+  assert.strictEqual(config.model_reasoning_summary, "detailed");
+  assert.strictEqual(config.model_supports_reasoning_summaries, true);
+});
+
+test("reasoning defaults survive the MCP server config merge", async function () {
+  // MCP servers are merged into the same config object after the defaults are
+  // applied, so a regression there would silently drop the reasoning keys.
+  var config = await spawnedConfig({});
+  assert.strictEqual(config.model_reasoning_summary, "detailed");
+  if (config.mcp_servers) {
+    assert.strictEqual(typeof config.mcp_servers, "object", "mcp_servers coexists with reasoning keys");
+  }
+});
+
+test("the reasoning defaults serialize to valid TOML --config flags", function () {
+  // serializeConfig is module-private; evaluate it from source so the test
+  // asserts the exact flags the app-server receives on argv.
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "yoke", "codex-app-server.js"),
+    "utf8"
+  );
+  var start = source.indexOf("function serializeConfig");
+  var end = source.indexOf("// --- CodexAppServer ---");
+  assert.ok(start !== -1 && end > start, "serializeConfig and toTomlValue must be present");
+  var helpers = new Function(
+    source.slice(start, end) + "\nreturn { serializeConfig: serializeConfig };"
+  )();
+
+  var args = helpers.serializeConfig({
+    model_reasoning_summary: "detailed",
+    model_supports_reasoning_summaries: true,
+  }, "");
+  assert.deepStrictEqual(args, [
+    'model_reasoning_summary="detailed"',
+    "model_supports_reasoning_summaries=true",
+  ]);
+});
+
+test("the adapter still maps every reasoning event to thinking", function () {
+  // The config change is only useful because these mappings already exist;
+  // pin them so a rename on either side cannot silently blank out thinking.
+  var kit = require("../lib/yoke/adapters/codex").contractTestKit;
+  var state = kit.createEventState("gpt-5.6-terra");
+  state.threadId = "t1";
+  // The first summary delta opens a thinking block and streams its text.
+  var summaryDelta = kit.normalizeEvent({
+    method: "item/reasoning/summaryTextDelta",
+    params: { threadId: "t1", itemId: "i1", delta: "Weighing options" },
+  }, state);
+  assert.deepStrictEqual(summaryDelta, [
+    { yokeType: "thinking_start", blockId: "blk_1" },
+    { yokeType: "thinking_delta", blockId: "blk_1", text: "Weighing options" },
+  ]);
+
+  // Later deltas append to the block that is already open.
+  var more = kit.normalizeEvent({
+    method: "item/reasoning/summaryTextDelta",
+    params: { threadId: "t1", itemId: "i1", delta: " carefully" },
+  }, state);
+  assert.deepStrictEqual(more, [
+    { yokeType: "thinking_delta", blockId: "blk_1", text: " carefully" },
+  ]);
+
+  // summaryPartAdded separates sections within the same block.
+  var partAdded = kit.normalizeEvent({
+    method: "item/reasoning/summaryPartAdded",
+    params: { threadId: "t1", itemId: "i1" },
+  }, state);
+  assert.deepStrictEqual(partAdded, [
+    { yokeType: "thinking_delta", blockId: "blk_1", text: "\n\n" },
+  ]);
+
+  // Raw reasoning text (only present when the user opts into
+  // show_raw_agent_reasoning) streams into the same thinking channel.
+  var textDelta = kit.normalizeEvent({
+    method: "item/reasoning/textDelta",
+    params: { threadId: "t1", itemId: "i2", delta: "raw" },
+  }, state);
+  assert.deepStrictEqual(textDelta, [
+    { yokeType: "thinking_start", blockId: "blk_2" },
+    { yokeType: "thinking_delta", blockId: "blk_2", text: "raw" },
+  ]);
+});


### PR DESCRIPTION
## Summary

Codex sessions in Clay showed little or no thinking. The adapter's event mapping (`item/reasoning/summaryTextDelta` etc. → thinking blocks) was already in place; the problem was upstream — Clay never asked the app-server for reasoning summaries, so it inherited the CLI default `model_reasoning_summary = "auto"`, which frequently yields none. Raw reasoning content is encrypted for ChatGPT-authenticated models, so summaries are the only readable channel.

### Change
- Inject spawn-time `--config` defaults in the codex adapter init (`CODEX_REASONING_DEFAULTS`): `model_reasoning_summary = "detailed"` and `model_supports_reasoning_summaries = true`.
- Defaults are merged **before** `adapterOptions.CODEX.config`, so any user-supplied key of the same name wins (previously `serverOpts.config = co.config` was a plain assignment; it is now a merge).
- `show_raw_agent_reasoning` is intentionally NOT set (encrypted on ChatGPT-auth models, noisy elsewhere) and a test guards against adding it by default.
- One-shot capsule calls (`complete-once.js`) reuse the same adapter init/app-server, so no second config path exists; documented in `docs/guides/CODEX-INTEGRATION.md` §15 along with why this cannot vary per query without a second app-server process.

### Verification against the bundled 0.152.1 binary
- Both overrides accepted at spawn (no config rejections); `config/read` reads back `"detailed"`, and `show_raw_agent_reasoning` stays null.
- Negative control: same binary without the override resolves `model_reasoning_summary = null` — the change demonstrably alters the resolved config.
- End-to-end summary streaming could not be observed on this machine (codex not logged in; the live turn 401'd at the model endpoint). The event→thinking mapping is pinned by exact offline assertions instead; if Codex emits the events, Clay renders them.

Note: `"detailed"` maximizes visible thinking at some summary-token cost; if it feels heavy in practice, dialing the constant to `"concise"` is a one-line change.

## Test plan
- New `test/codex-reasoning-config.test.js` (9 tests): defaults present, user override wins, both keys overridable, raw-reasoning stays opt-in, unrelated keys coexist, defaults survive the MCP-server config merge, TOML serialization, and exact reasoning-event → thinking-event mapping.
- Full suite: **865 tests, 865 pass, 0 fail** (re-verified independently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)