### PR TITLE
feat(sdk): update claude-agent-sdk to 0.3.258 and adopt new capabilities

### DIFF
--- a/lib/background-task-timing.js
+++ b/lib/background-task-timing.js
@@ -1,4 +1,6 @@
-// Background task start-time tracking.
+// Background task list shaping shared by the server-side consumers:
+// start-time tracking, plus the ambient/user split every activity indicator
+// needs.
 //
 // Vendors report background tasks as a full replacement list on every change
 // and none of them carries a reliable start time today (see
@@ -66,7 +68,38 @@ function mergeStartTimes(previousTasks, nextTasks, now) {
   return merged;
 }
 
+// Ambient tasks are the CLI's own housekeeping (every skip_transcript task
+// plus auto-started live-update watchers). The SDK asks hosts to keep them out
+// of activity indicators, so every count that drives a badge, a summary, or a
+// change notification must go through here rather than reading `.length`.
+// Absent means false: vendors without an ambient concept (Codex terminals)
+// and older CLI builds report only real user work.
+function isAmbientTask(task) {
+  return !!(task && task.ambient === true);
+}
+
+function userTasks(tasks) {
+  if (!Array.isArray(tasks)) return [];
+  return tasks.filter(function (task) {
+    return task && !isAmbientTask(task);
+  });
+}
+
+function ambientTasks(tasks) {
+  if (!Array.isArray(tasks)) return [];
+  return tasks.filter(isAmbientTask);
+}
+
+// The count that represents "user-visible background work is running".
+function countUserTasks(tasks) {
+  return userTasks(tasks).length;
+}
+
 module.exports = {
   mergeStartTimes: mergeStartTimes,
   normalizeTimestamp: normalizeTimestamp,
+  isAmbientTask: isAmbientTask,
+  userTasks: userTasks,
+  ambientTasks: ambientTasks,
+  countUserTasks: countUserTasks,
 };

--- a/lib/public/css/input.css
+++ b/lib/public/css/input.css
@@ -742,6 +742,12 @@
 .background-task-icon { display: inline-flex; flex: none; color: var(--text-muted); }
 .background-task-icon i { width: 13px; height: 13px; }
 .background-task-description { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-secondary); }
+/* Housekeeping group: visible so the user can see what Clay runs on its own,
+   but subordinate to the work they actually asked for. */
+.background-tasks-section-label { padding: 9px 0 1px; border-top: 1px solid var(--border-subtle); color: var(--text-muted); font-size: 10px; font-weight: 600; letter-spacing: .07em; text-transform: uppercase; }
+.background-tasks-section-label + .background-task-row { border-top: 0; }
+.background-task-row.ambient .background-task-description { color: var(--text-muted); }
+.background-task-row.ambient .background-task-icon { opacity: .7; }
 .background-task-meta { display: inline-flex; align-items: center; gap: 7px; flex: none; color: var(--text-muted); }
 .background-task-type { font-size: 11px; }
 .background-task-elapsed { font-variant-numeric: tabular-nums; font-size: 11px; min-width: 44px; text-align: right; }

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -501,12 +501,14 @@
           <div class="usage-section-label">Session Tokens</div>
           <div class="usage-row"><span class="usage-label">Input</span><span id="context-input" class="usage-value">0</span></div>
           <div class="usage-row"><span class="usage-label">Output</span><span id="context-output" class="usage-value">0</span></div>
+          <div class="usage-row hidden" id="context-thinking-row" title="Extended thinking tokens, already counted inside Output"><span class="usage-label">Thinking</span><span id="context-thinking" class="usage-value">0</span></div>
           <div class="usage-row"><span class="usage-label">Cache read</span><span id="context-cache-read" class="usage-value">0</span></div>
           <div class="usage-row"><span class="usage-label">Cache write</span><span id="context-cache-write" class="usage-value">0</span></div>
           <div class="usage-divider"></div>
           <div class="usage-section-label">Model</div>
           <div class="usage-row"><span class="usage-label">Name</span><span id="context-model" class="usage-value">-</span></div>
           <div class="usage-row"><span class="usage-label">Cost</span><span id="context-cost" class="usage-value">$0.0000</span></div>
+          <div class="usage-row hidden" id="context-cost-basis-row" title="Which price table this cost was computed from"><span class="usage-label">Priced at</span><span id="context-cost-basis" class="usage-value">-</span></div>
           <div class="usage-row"><span class="usage-label">Turns</span><span id="context-turns" class="usage-value">0</span></div>
         </div>
       </div>

--- a/lib/public/modules/app-panels.js
+++ b/lib/public/modules/app-panels.js
@@ -10,7 +10,7 @@ import { setupModelPicker, renderModelPicker, requestVendorModels, prepareModelP
 
 // --- Module-owned state (not in store) ---
 var sessionUsage = { cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0 };
-var contextData = { contextWindow: 0, maxOutputTokens: 0, model: "-", cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0 };
+var contextData = { contextWindow: 0, maxOutputTokens: 0, model: "-", cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0, thinking: null, costBasis: null };
 var ctxPopoverEl = null;
 var ctxHoverTimer = null;
 var statusRefreshTimer = null;
@@ -72,6 +72,10 @@ var contextCacheReadEl = null;
 var contextCacheWriteEl = null;
 var contextModelEl = null;
 var contextCostEl = null;
+var contextThinkingEl = null;
+var contextThinkingRow = null;
+var contextCostBasisEl = null;
+var contextCostBasisRow = null;
 var contextTurnsEl = null;
 var contextMini = null;
 var contextMiniFill = null;
@@ -449,6 +453,10 @@ export function initPanels() {
   contextCacheWriteEl = $("context-cache-write");
   contextModelEl = $("context-model");
   contextCostEl = $("context-cost");
+  contextThinkingEl = $("context-thinking");
+  contextThinkingRow = $("context-thinking-row");
+  contextCostBasisEl = $("context-cost-basis");
+  contextCostBasisRow = $("context-cost-basis-row");
   contextTurnsEl = $("context-turns");
   contextMini = $("context-mini");
   contextMiniFill = $("context-mini-fill");
@@ -776,6 +784,16 @@ export function updateContextPanel() {
   contextCacheWriteEl.textContent = formatTokens(contextData.cacheWrite);
   contextModelEl.textContent = contextData.model;
   contextCostEl.textContent = "$" + contextData.cost.toFixed(4);
+  // Optional SDK fields: shown only once the CLI has actually reported them.
+  if (contextThinkingRow && contextThinkingEl) {
+    var hasThinking = typeof contextData.thinking === "number";
+    contextThinkingRow.classList.toggle("hidden", !hasThinking);
+    if (hasThinking) contextThinkingEl.textContent = formatTokens(contextData.thinking);
+  }
+  if (contextCostBasisRow && contextCostBasisEl) {
+    contextCostBasisRow.classList.toggle("hidden", !contextData.costBasis);
+    if (contextData.costBasis) contextCostBasisEl.textContent = contextData.costBasis;
+  }
   contextTurnsEl.textContent = String(contextData.turns);
 }
 
@@ -811,6 +829,29 @@ export function accumulateContext(cost, usage, modelUsage, lastStreamInputTokens
       contextData.model = displayModel;
       contextData.contextWindow = resolveContextWindow(displayModel, mu.contextWindow);
       if (mu.maxOutputTokens) contextData.maxOutputTokens = mu.maxOutputTokens;
+
+      // thinkingTokens and costBasis are per-model and optional: absent on
+      // older CLI builds and, for a resumed session, on the turns that ran
+      // before the field existed. Leave them null in that case so the rows
+      // stay hidden rather than claiming a confident zero.
+      var thinkingTotal = null;
+      var basis = null;
+      var basisMixed = false;
+      for (var mi = 0; mi < models.length; mi++) {
+        var entry = modelUsage[models[mi]];
+        if (!entry) continue;
+        if (typeof entry.thinkingTokens === "number") {
+          thinkingTotal = (thinkingTotal || 0) + entry.thinkingTokens;
+        }
+        if (entry.costBasis) {
+          if (basis === null) basis = entry.costBasis;
+          else if (basis !== entry.costBasis) basisMixed = true;
+        }
+      }
+      contextData.thinking = thinkingTotal;
+      // Several models in one query can be priced differently; say so rather
+      // than reporting whichever happened to come first.
+      contextData.costBasis = basisMixed ? "mixed" : basis;
     }
   }
   if (!store.get('replayingHistory')) updateContextPanel();
@@ -832,7 +873,7 @@ export function applyContextView(view) {
 }
 
 export function resetContextData() {
-  contextData = { contextWindow: 0, maxOutputTokens: 0, model: "-", cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0 };
+  contextData = { contextWindow: 0, maxOutputTokens: 0, model: "-", cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, turns: 0, thinking: null, costBasis: null };
   store.set({ richContextUsage: null });
   // hideCtxPopover + updateContextPanel handled by store subscriber
 }

--- a/lib/public/modules/background-tasks-ui.js
+++ b/lib/public/modules/background-tasks-ui.js
@@ -76,13 +76,33 @@ function activityDotsHtml() {
   return '<span class="background-tasks-activity" aria-hidden="true"><i></i><i></i><i></i></span>';
 }
 
+// Ambient tasks are the CLI's own housekeeping. The SDK asks hosts to keep
+// them out of activity indicators; Clay still lists them so the user can see
+// what runs on their behalf. Absent means false (Codex has no ambient concept,
+// and older CLI builds report only user work).
+export function isAmbientTask(task) {
+  return !!(task && task.ambient === true);
+}
+
+export function splitTasks(tasks) {
+  var user = [];
+  var ambient = [];
+  var list = Array.isArray(tasks) ? tasks : [];
+  for (var i = 0; i < list.length; i++) {
+    if (!list[i]) continue;
+    if (isAmbientTask(list[i])) ambient.push(list[i]);
+    else user.push(list[i]);
+  }
+  return { user: user, ambient: ambient };
+}
+
 function taskRowHtml(task, now) {
   var taskType = task.task_type || 'other';
   var icon = TASK_TYPE_ICONS[taskType] || TASK_TYPE_ICONS.other;
   var description = task.description || 'Background task';
   var startedAt = typeof task.started_at === 'number' ? task.started_at : 0;
   var elapsed = formatElapsed(startedAt, now);
-  return '<div class="background-task-row">' +
+  return '<div class="background-task-row' + (isAmbientTask(task) ? ' ambient' : '') + '">' +
     '<span class="background-task-icon" title="' + escapeHtml(taskType) + '">' + iconHtml(icon) + '</span>' +
     '<span class="background-task-description" title="' + escapeHtml(description) + '">' +
       escapeHtml(description) + '</span>' +
@@ -97,8 +117,11 @@ function taskRowHtml(task, now) {
 
 function renderBackgroundTasks() {
   var tasks = store.get('activeBackgroundTasks') || [];
+  var split = splitTasks(tasks);
   var existing = document.getElementById('background-tasks-bar');
-  if (tasks.length === 0) {
+  // Ambient-only means nothing the user asked for is running, so the composer
+  // stays quiet: no bar, no dots, no count.
+  if (split.user.length === 0) {
     if (existing) existing.remove();
     expanded = false;
     stopElapsedTimer();
@@ -111,8 +134,8 @@ function renderBackgroundTasks() {
   bar.id = 'background-tasks-bar';
   bar.className = 'background-tasks-bar' + (expanded ? ' expanded' : '');
 
-  var taskLabel = tasks.length === 1 ? 'background task' : 'background tasks';
-  var summary = tasks.length + ' ' + taskLabel;
+  var taskLabel = split.user.length === 1 ? 'background task' : 'background tasks';
+  var summary = split.user.length + ' ' + taskLabel;
   var html = '<button type="button" class="background-tasks-toggle" aria-expanded="' + expanded + '"' +
     ' aria-controls="background-tasks-list" aria-label="' + summary + ', ' +
     (expanded ? 'collapse' : 'expand') + ' details">' +
@@ -124,7 +147,13 @@ function renderBackgroundTasks() {
   if (expanded) {
     var now = Date.now();
     html += '<div class="background-tasks-list" id="background-tasks-list">';
-    for (var i = 0; i < tasks.length; i++) html += taskRowHtml(tasks[i], now);
+    for (var i = 0; i < split.user.length; i++) html += taskRowHtml(split.user[i], now);
+    // Housekeeping is shown, not hidden: the user can see what Clay runs on
+    // its own and stop a runaway one. Kept visually subordinate to real work.
+    if (split.ambient.length > 0) {
+      html += '<div class="background-tasks-section-label">Housekeeping</div>';
+      for (var a = 0; a < split.ambient.length; a++) html += taskRowHtml(split.ambient[a], now);
+    }
     html += '</div>';
   }
   bar.innerHTML = html;

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -193,7 +193,9 @@ function attachMessageProcessor(ctx) {
 
     // Cache slash_commands and model from CLI init message
     if (parsed.yokeType === "init") {
-      var previousBackgroundTaskCount = (session.activeBackgroundTasks || []).length;
+      // Ambient housekeeping never drove the sidebar badge, so a reset that
+      // only clears ambient watchers must not rebroadcast the session list.
+      var previousBackgroundTaskCount = backgroundTaskTiming.countUserTasks(session.activeBackgroundTasks);
       session.activeBackgroundTasks = [];
       sendToSession(session, { type: "active_background_tasks", tasks: [] });
       if (previousBackgroundTaskCount !== 0) sm.broadcastSessionList();
@@ -688,7 +690,9 @@ function attachMessageProcessor(ctx) {
 
     } else if (parsed.yokeType === "background_tasks_changed") {
       var previousBackgroundTasks = session.activeBackgroundTasks || [];
-      var previousBackgroundTaskCount = previousBackgroundTasks.length;
+      // Count user work only: an ambient watcher starting or stopping must not
+      // rebroadcast the session list and flicker every client's sidebar badge.
+      var previousBackgroundTaskCount = backgroundTaskTiming.countUserTasks(previousBackgroundTasks);
       // Vendors re-send the whole list on every change, so carry each task's
       // first-seen time forward; otherwise the composer's elapsed timer would
       // restart whenever any other task starts or finishes.
@@ -698,7 +702,7 @@ function attachMessageProcessor(ctx) {
       );
       session.activeBackgroundTasks = activeBackgroundTasks;
       sendToSession(session, { type: "active_background_tasks", tasks: activeBackgroundTasks });
-      if (previousBackgroundTaskCount !== activeBackgroundTasks.length) {
+      if (previousBackgroundTaskCount !== backgroundTaskTiming.countUserTasks(activeBackgroundTasks)) {
         sm.broadcastSessionList();
       }
 

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -5,6 +5,7 @@ var utils = require("./utils");
 var users = require("./users");
 var { CODEX_DEFAULTS } = require("./codex-defaults");
 var hygiene = require("./session-hygiene");
+var backgroundTaskTiming = require("./background-task-timing");
 
 function createSessionManager(opts) {
   var cwd = opts.cwd;
@@ -508,7 +509,9 @@ function createSessionManager(opts) {
       title: s.title || "New Session",
       active: isActive,
       isProcessing: s.isProcessing,
-      backgroundTaskCount: (s.activeBackgroundTasks || []).length,
+      // Sidebar badge: user work only. Ambient housekeeping is surfaced in the
+      // composer's expanded list, never as a count demanding attention.
+      backgroundTaskCount: backgroundTaskTiming.countUserTasks(s.activeBackgroundTasks),
       lastActivity: s.lastActivity || s.createdAt || 0,
       loop: loop,
       spawn: s.spawn || null,

--- a/lib/yoke/adapters/claude.js
+++ b/lib/yoke/adapters/claude.js
@@ -20,6 +20,49 @@ var claudeUserInput = require("../claude-user-input");
 // emitted. Keep in sync with the client's generic user-dialog renderer.
 var SUPPORTED_DIALOG_KINDS = ["refusal_fallback_prompt"];
 
+// Clay renders a per-task Stop control in the composer's background-tasks bar
+// (public/modules/background-tasks-ui.js), wired through project-sessions.js
+// `stop_task` -> adapter.stopTask -> rawQuery.stopTask (worker path: the
+// stop_task message in claude-worker.js). Declaring that affordance makes an
+// interrupt spare running background tasks so Stop only aborts the current
+// turn. The CLI fails CLOSED on absence: without this, every interrupt would
+// also kill background tasks, since a consumer with no per-task control could
+// not otherwise stop a runaway one.
+//
+// Declared identically on the in-process and OS-user worker paths. The CLI
+// takes first-attached-client-wins on multi-client sessions, so the two paths
+// must not disagree, or which one connected first would decide whether Stop
+// kills background work.
+var PER_TASK_STOP_AFFORDANCE = true;
+
+// --- System prompt recording (SDK `snapshot`) ---
+// Records the conversation's system prompt once and replays it verbatim on
+// every later request and resume, which keeps the prompt-cache prefix and
+// extended-thinking context stable across CLI upgrades and flag changes.
+//
+// OFF for Clay's persistent sessions, deliberately. getSessionSystemPrompt
+// (project.js) recomposes the append from live state every time the query is
+// rebuilt - sticky notes, pair/Driver role, and the Mate Capsule catalog - and
+// three call sites exist purely to force that re-render mid-conversation
+// (project-capsule-catalog.js refreshSessions, project.js pair regrouping,
+// sdk-bridge refreshEnvironmentRuntime). Because Clay resumes those
+// conversations, a recorded prompt would pin the first render and silently
+// swallow every later update until compaction.
+//
+// Callers whose prompt is fixed for the life of the conversation opt in with
+// queryOpts.systemPromptSnapshot. A bare string prompt cannot be recorded, so
+// it is promoted to the custom form the SDK requires.
+function applySystemPromptSnapshot(systemPrompt, enabled) {
+  if (!enabled || !systemPrompt) return systemPrompt;
+  if (typeof systemPrompt === "string" || Array.isArray(systemPrompt)) {
+    return { type: "custom", prompt: systemPrompt, snapshot: true };
+  }
+  if (typeof systemPrompt === "object") {
+    return Object.assign({}, systemPrompt, { snapshot: true });
+  }
+  return systemPrompt;
+}
+
 function getSharedSkillPlugins(homeDir, existingPlugins) {
   var plugins = Array.isArray(existingPlugins) ? existingPlugins.slice() : [];
   var bridgePath = skillDiscovery.ensureClaudeCodexPlugin(homeDir ? { homeDir: homeDir } : null);
@@ -45,10 +88,16 @@ function buildWorkerQueryOptions(queryOpts, claudeOpts, workerCwd) {
   if (claudeOpts.permissionMode) queryOptions.permissionMode = claudeOpts.permissionMode;
   if (claudeOpts.allowDangerouslySkipPermissions) queryOptions.allowDangerouslySkipPermissions = true;
   if (claudeOpts.settings) queryOptions.settings = claudeOpts.settings;
-  if (queryOpts.appendSystemPrompt) queryOptions.systemPrompt = { type: "preset", preset: "claude_code", append: queryOpts.appendSystemPrompt };
+  if (queryOpts.appendSystemPrompt) {
+    queryOptions.systemPrompt = applySystemPromptSnapshot(
+      { type: "preset", preset: "claude_code", append: queryOpts.appendSystemPrompt },
+      queryOpts.systemPromptSnapshot
+    );
+  }
   queryOptions.plugins = queryOpts.skipSkills ? (claudeOpts.plugins || []) : getSharedSkillPlugins(claudeOpts.originalHome, claudeOpts.plugins);
   if (queryOpts.toolServerDescriptors) queryOptions.mcpServerDescriptors = queryOpts.toolServerDescriptors;
   if (queryOpts.onUserDialog) queryOptions.supportedDialogKinds = SUPPORTED_DIALOG_KINDS;
+  queryOptions.perTaskStopAffordance = PER_TASK_STOP_AFFORDANCE;
   if (queryOpts.model) queryOptions.model = queryOpts.model;
   if (queryOpts.effort) queryOptions.effort = queryOpts.effort;
   if (queryOpts.resumeSessionId) queryOptions.resume = queryOpts.resumeSessionId;
@@ -404,6 +453,11 @@ function normalizeBackgroundTasks(tasks) {
       task_id: task && task.task_id,
       task_type: taskType,
       description: (task && task.description) || "",
+      // Housekeeping the CLI does not surface as user work (skip_transcript
+      // tasks, auto-started live-update watchers). Clay keeps these out of its
+      // activity indicators and lists them as a subdued secondary group.
+      // Normalized to a boolean so consumers never have to test for absence.
+      ambient: !!(task && task.ambient),
     };
     // The SDK does not report a start time today. Forward one if a future
     // version adds it; otherwise the session stamps first-seen time.
@@ -1454,12 +1508,17 @@ function createClaudeAdapter(opts) {
       if (_claudeBinaryPath) sdkOptions.pathToClaudeCodeExecutable = _claudeBinaryPath;
 
       // YOKE standard options -> SDK options
-      if (queryOpts.systemPrompt) sdkOptions.systemPrompt = queryOpts.systemPrompt;
+      if (queryOpts.systemPrompt) {
+        sdkOptions.systemPrompt = applySystemPromptSnapshot(queryOpts.systemPrompt, queryOpts.systemPromptSnapshot);
+      }
       // Additive variant: keep the full Claude Code system prompt and append.
       // A plain-string systemPrompt REPLACES the whole prompt, so pair
       // presets and other add-ons must come through here instead.
       if (!queryOpts.systemPrompt && queryOpts.appendSystemPrompt) {
-        sdkOptions.systemPrompt = { type: "preset", preset: "claude_code", append: queryOpts.appendSystemPrompt };
+        sdkOptions.systemPrompt = applySystemPromptSnapshot(
+          { type: "preset", preset: "claude_code", append: queryOpts.appendSystemPrompt },
+          queryOpts.systemPromptSnapshot
+        );
       }
       if (queryOpts.model) sdkOptions.model = queryOpts.model;
       if (queryOpts.effort) sdkOptions.effort = queryOpts.effort;
@@ -1475,6 +1534,7 @@ function createClaudeAdapter(opts) {
         sdkOptions.onUserDialog = queryOpts.onUserDialog;
         sdkOptions.supportedDialogKinds = SUPPORTED_DIALOG_KINDS;
       }
+      sdkOptions.perTaskStopAffordance = PER_TASK_STOP_AFFORDANCE;
       if (queryOpts.resumeSessionId) sdkOptions.resume = queryOpts.resumeSessionId;
       if (queryOpts.persistSession === false) sdkOptions.persistSession = false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "clay-server",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clay-server",
-      "version": "4.0.0-beta.1",
+      "version": "4.0.0-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.241",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.258",
         "@lydell/node-pty": "^1.2.0-beta.3",
         "@openai/codex": "^0.152.1",
         "@seald-io/nedb": "^4.1.2",
@@ -84,21 +84,22 @@
       "license": "MIT"
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.241.tgz",
-      "integrity": "sha512-pIHdCSTywFe30H0oWDCKZzC4ipBLtF5YMDRKjf6PHyARg57O4l/72v3b6QKnnefwtKKMe6uWJ1Y9lUJg/sKWyA==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.258.tgz",
+      "integrity": "sha512-RxJ5fSPCGCxX5qO/b4IPXhldvtLHeYBAzTUJ4eOzO+gTrepZQSDmwSlQD6nnoEquKGJzOMHCjhdEtBfDjbDWUg==",
+      "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.241",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.241",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.241",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.241",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.241",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.241",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.241",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.241"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.258",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.258",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.258",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.258",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.258",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.258",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.258",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.258"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -107,96 +108,104 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.241.tgz",
-      "integrity": "sha512-v26ta54lKFMFEZzbOE+6p3YhKERWnDiEA6OmkSAg+3fAQHOa1+aLTKw222cfgzxgiVixwFtHMk8c63zsDd8aXQ==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.258.tgz",
+      "integrity": "sha512-Hrhzc9WVGSid+DghdTcpVr/8fyXnTD6KeSlDpKx6Wru47J/Nq7RTYiZJt+cex+O2ehaHMEcuYEgoqJ3K/X9NlA==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.241.tgz",
-      "integrity": "sha512-5jweT0vft1ZCaGSoxZHF9vJlHbx8Yxx4+x5aHAIXTd4lx7ZbT4o5buEF8kpmTeHUB+Fw9jtFIm4QDsRiBXgf+Q==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.258.tgz",
+      "integrity": "sha512-AVqxGX4988J5cS+TMqIzH85+sbsLhJu5Ou9TIALcO/v2Z9ze8GK4vX2ydAYvU/SRnjTvEaiITX+Xcm5afP1IbQ==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.241.tgz",
-      "integrity": "sha512-SxszQGffXiLzMEnAv+pJXEmQbA8haijKyRjjH/jOt1CLeMIfpjKcO9WQDv8dEA8nREWS3zJ103zjgecAF7oOQQ==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.258.tgz",
+      "integrity": "sha512-Jj3K1Ip7WpyMouZCjd7kgV3KswUBF62WAnyG0iaYvKZJvXgYKbIAkjcQ2F2Rx5ZuRUNWAVncE9LeHmdIdx78VQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.241.tgz",
-      "integrity": "sha512-GslvPvSzehfCZyzOaJAt4lgodznm5zpl/LMXN8ygD12z5qnpM+I9/eFnmAaISJ0L8/vyohtlAP1jjaeR2jz1AQ==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.258.tgz",
+      "integrity": "sha512-I/BLt2vdvqK2B2px526U1lw7Rv+SI+Ld22+wLwu8gLRQk5SYhSW9dmMYEO+GCeF7vQzfzJvMQ4IzbbY+aSGACg==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.241.tgz",
-      "integrity": "sha512-gJRa922Qcm7loumHcXMDFEFg//tz1aOi7Nx0sQa9I9lC1JSN8yL6i7/idzOU5Hp193tEDFOgqIMFL/yRiXg+rw==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.258.tgz",
+      "integrity": "sha512-2MJeFVJM/3xwZASP3yn2OuQ9RHIoS30DC/B7oG1XPYcbToPLH4QIfCPLWbSQfqCdp+NEBupLMM9BWpDz4s8Q0g==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.241.tgz",
-      "integrity": "sha512-kZigJ5Ug2I2G/n7Cunmwy4TGr0lOGnWrz6TkzyWiDcUmJOodoTH6GZECNarWAtETfN03AAeLfrpiz8z3hOEDqA==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.258.tgz",
+      "integrity": "sha512-sM7GzRyrOpFhwMn2Ng8nLiWK6cc04uCEu3Zh9mrJS2r3iQu1TryHKoPTjc2Ip0N75sHmwhNodgoRs8NtG1Gkkw==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.241.tgz",
-      "integrity": "sha512-/3yA9jQuCvHDVlILzhtslH6kFYOvydXyMZiKwnzqM8ZfvFTNO41w8TpiFpBLseyM+4A4E8QMeTKu3L01Xyb5IQ==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.258.tgz",
+      "integrity": "sha512-n/Vf6oXAo9EZVSSM5+9d+8dFrUrX9cbgSHK/1njkvykWAN5xsfBbikJYqwhbW84GCYkpXYM+gGNZe23h0fHldw==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.241",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.241.tgz",
-      "integrity": "sha512-cHYdAgORl9kynujMeYXyV1uj/hbmsBjRw9dRVkIW4/4sF7S6L4u/qDSzn1/wiNP7g2yWSJ4KbsvHDH2WWDnCBQ==",
+      "version": "0.3.258",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.258.tgz",
+      "integrity": "sha512-UDbXE6n37ZMUogVVYEWX901NNmbyXUv1VvGYN/vfOiIWKUJXCAypam71dBlYFhlAhVX28qCd64w+pTZDYQfYQA==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "homepage": "https://github.com/chadbyte/clay#readme",
   "author": "Chad",
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.241",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.258",
     "@lydell/node-pty": "^1.2.0-beta.3",
     "@openai/codex": "^0.152.1",
     "@seald-io/nedb": "^4.1.2",

--- a/test/background-task-timing.test.js
+++ b/test/background-task-timing.test.js
@@ -147,3 +147,145 @@ test("the sidebar task-count badge keeps its own style rule", function () {
     "the activity indicator has a reduced-motion fallback"
   );
 });
+
+// --- ambient (housekeeping) tasks ------------------------------------------
+
+test("the Claude adapter forwards the ambient flag and defaults it to false", function () {
+  var normalize = require("../lib/yoke/adapters/claude").contractTestKit.normalizeEvent;
+  var events = normalize({
+    type: "system",
+    subtype: "background_tasks_changed",
+    tasks: [
+      { task_id: "t1", task_type: "local_bash", description: "npm test" },
+      { task_id: "t2", task_type: "local_agent", description: "watcher", ambient: true },
+      { task_id: "t3", task_type: "local_bash", description: "explicit", ambient: false },
+    ],
+  });
+  var result = Array.isArray(events) ? events[0] : events;
+  assert.strictEqual(result.tasks[0].ambient, false, "absent normalizes to false, not undefined");
+  assert.strictEqual(result.tasks[1].ambient, true);
+  assert.strictEqual(result.tasks[2].ambient, false);
+  // The existing normalization must survive alongside the new field.
+  assert.strictEqual(result.tasks[0].task_type, "shell");
+  assert.strictEqual(result.tasks[1].task_type, "agent");
+});
+
+test("the start-time merge preserves the ambient flag", function () {
+  var merged = timing.mergeStartTimes([], [
+    task("a", { ambient: true }),
+    task("b", { ambient: false }),
+  ], T0);
+  assert.strictEqual(merged[0].ambient, true);
+  assert.strictEqual(merged[1].ambient, false);
+
+  // And across a re-emission, alongside the carried-forward stamp.
+  var again = timing.mergeStartTimes(merged, [task("a", { ambient: true })], T0 + 5000);
+  assert.strictEqual(again[0].ambient, true);
+  assert.strictEqual(again[0].started_at, T0, "ambient tasks keep their elapsed clock too");
+});
+
+test("Codex tasks carry no ambient flag and count as user work", function () {
+  var tasks = backgroundTasks.mapTerminals({ terminals: [{ id: "term-1", command: "npm test" }] });
+  assert.strictEqual(tasks[0].ambient, undefined, "Codex has no ambient concept");
+  assert.strictEqual(timing.countUserTasks(tasks), 1, "absent must not be read as ambient");
+});
+
+test("counting and splitting ignore ambient housekeeping", function () {
+  var list = [
+    task("user-1"),
+    task("amb-1", { ambient: true }),
+    task("user-2", { ambient: false }),
+    task("amb-2", { ambient: true }),
+  ];
+  assert.strictEqual(timing.countUserTasks(list), 2);
+  assert.deepStrictEqual(timing.userTasks(list).map(function (t) { return t.task_id; }), ["user-1", "user-2"]);
+  assert.deepStrictEqual(timing.ambientTasks(list).map(function (t) { return t.task_id; }), ["amb-1", "amb-2"]);
+
+  // Ambient-only reads as "no user work running".
+  assert.strictEqual(timing.countUserTasks([task("amb", { ambient: true })]), 0);
+  assert.strictEqual(timing.countUserTasks([]), 0);
+  assert.strictEqual(timing.countUserTasks(null), 0);
+});
+
+test("the sidebar badge and change notifications count user work only", function () {
+  // sessions.js feeds every sidebar badge site from this one field, and
+  // sdk-message-processor decides whether to rebroadcast the session list from
+  // the same count. Both must ignore ambient watchers.
+  var sessions = fs.readFileSync(path.join(__dirname, "..", "lib", "sessions.js"), "utf8");
+  assert.ok(
+    /backgroundTaskCount: backgroundTaskTiming\.countUserTasks\(s\.activeBackgroundTasks\)/.test(sessions),
+    "the sidebar badge counts non-ambient tasks"
+  );
+  var processor = fs.readFileSync(path.join(__dirname, "..", "lib", "sdk-message-processor.js"), "utf8");
+  assert.strictEqual(
+    (processor.match(/backgroundTaskTiming\.countUserTasks\(/g) || []).length, 3,
+    "both the init reset and the changed handler's before/after counts use it"
+  );
+  assert.ok(
+    !/previousBackgroundTaskCount !== activeBackgroundTasks\.length/.test(processor),
+    "the raw length comparison is gone"
+  );
+});
+
+// --- client rendering ------------------------------------------------------
+
+function loadClientHelpers() {
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "public", "modules", "background-tasks-ui.js"),
+    "utf8"
+  );
+  var start = source.indexOf("export function isAmbientTask");
+  var end = source.indexOf("function taskRowHtml");
+  assert.ok(start !== -1 && end > start, "isAmbientTask and splitTasks must be present");
+  var body = source.slice(start, end).replace(/export function/g, "function");
+  return new Function(body + "\nreturn { isAmbientTask: isAmbientTask, splitTasks: splitTasks };")();
+}
+
+test("the composer splits user work from housekeeping", function () {
+  var helpers = loadClientHelpers();
+  var split = helpers.splitTasks([
+    { task_id: "u1", description: "build" },
+    { task_id: "a1", description: "watcher", ambient: true },
+    { task_id: "u2", description: "test", ambient: false },
+    null,
+  ]);
+  assert.deepStrictEqual(split.user.map(function (t) { return t.task_id; }), ["u1", "u2"]);
+  assert.deepStrictEqual(split.ambient.map(function (t) { return t.task_id; }), ["a1"]);
+  assert.deepStrictEqual(helpers.splitTasks(null), { user: [], ambient: [] });
+});
+
+test("the composer bar hides entirely when only housekeeping is running", function () {
+  // Ambient-only must read as quiet: no bar, no dots, no count. Pin the guard
+  // so nobody restores the old `tasks.length === 0` check.
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "public", "modules", "background-tasks-ui.js"),
+    "utf8"
+  );
+  assert.ok(
+    /if \(split\.user\.length === 0\) \{[\s\S]{0,200}?existing\.remove\(\)/.test(source),
+    "the bar is removed when no user task is running"
+  );
+  assert.ok(
+    !/if \(tasks\.length === 0\)/.test(source),
+    "the raw total-length guard is gone"
+  );
+  // Summary and aria label count user work only.
+  assert.ok(/var taskLabel = split\.user\.length === 1/.test(source));
+  assert.ok(/var summary = split\.user\.length \+ ' ' \+ taskLabel/.test(source));
+});
+
+test("housekeeping rows keep Stop and elapsed, under a labelled section", function () {
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "public", "modules", "background-tasks-ui.js"),
+    "utf8"
+  );
+  assert.ok(source.indexOf("background-tasks-section-label") !== -1, "the group has a section label");
+  assert.ok(/for \(var a = 0; a < split\.ambient\.length; a\+\+\) html \+= taskRowHtml\(split\.ambient\[a\], now\)/.test(source),
+    "ambient rows reuse taskRowHtml, so Stop and elapsed behave identically");
+  assert.ok(/isAmbientTask\(task\) \? ' ambient' : ''/.test(source), "ambient rows are marked for styling");
+
+  var css = fs.readFileSync(path.join(__dirname, "..", "lib", "public", "css", "input.css"), "utf8");
+  assert.ok(/\.background-task-row\.ambient \.background-task-description \{ color: var\(--text-muted\)/.test(css),
+    "housekeeping descriptions are muted");
+  assert.ok(css.indexOf(".background-tasks-section-label") !== -1, "the section label is styled");
+});

--- a/test/claude-sdk-options.test.js
+++ b/test/claude-sdk-options.test.js
@@ -1,0 +1,215 @@
+var test = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+
+var claudeAdapter = require("../lib/yoke/adapters/claude");
+var buildWorkerQueryOptions = claudeAdapter.contractTestKit.buildWorkerQueryOptions;
+var normalizeEvent = claudeAdapter.contractTestKit.normalizeEvent;
+
+// --- perTaskStopAffordance -------------------------------------------------
+// Clay renders a per-task Stop control, so it must declare the affordance.
+// The CLI fails CLOSED without it: an interrupt would also kill every running
+// background task.
+
+test("the OS-user worker path declares the per-task stop affordance", function () {
+  var options = buildWorkerQueryOptions({}, {}, "/tmp/work");
+  assert.strictEqual(options.perTaskStopAffordance, true);
+});
+
+test("the affordance is declared even for queries with no dialog support", function () {
+  // supportedDialogKinds is conditional; the affordance must not be, or an
+  // interrupt on those sessions would silently kill background tasks.
+  var options = buildWorkerQueryOptions({}, {}, "/tmp/work");
+  assert.strictEqual(options.supportedDialogKinds, undefined);
+  assert.strictEqual(options.perTaskStopAffordance, true);
+});
+
+test("both query paths declare the affordance identically", function () {
+  // First-attached-client wins on multi-client sessions, so the in-process and
+  // worker paths disagreeing would make Stop's behavior depend on which one
+  // connected first. Pin both against the source.
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "yoke", "adapters", "claude.js"),
+    "utf8"
+  );
+  var assignments = source.match(/perTaskStopAffordance = PER_TASK_STOP_AFFORDANCE/g) || [];
+  assert.strictEqual(assignments.length, 2, "in-process and worker paths both assign it");
+  assert.ok(
+    /var PER_TASK_STOP_AFFORDANCE = true;/.test(source),
+    "both read the same constant so they cannot drift apart"
+  );
+});
+
+test("the worker receives the affordance as a serializable value", function () {
+  // buildWorkerQueryOptions output crosses process IPC as msg.options.
+  var options = buildWorkerQueryOptions({}, {}, "/tmp/work");
+  var roundTripped = JSON.parse(JSON.stringify(options));
+  assert.strictEqual(roundTripped.perTaskStopAffordance, true);
+});
+
+// --- systemPrompt snapshot -------------------------------------------------
+
+test("system prompt recording stays off unless the caller opts in", function () {
+  var options = buildWorkerQueryOptions({ appendSystemPrompt: "Extra rules." }, {}, "/tmp/work");
+  assert.deepStrictEqual(options.systemPrompt, {
+    type: "preset",
+    preset: "claude_code",
+    append: "Extra rules.",
+  });
+  assert.strictEqual(options.systemPrompt.snapshot, undefined);
+});
+
+test("opting in records a preset-plus-append prompt", function () {
+  var options = buildWorkerQueryOptions(
+    { appendSystemPrompt: "Extra rules.", systemPromptSnapshot: true },
+    {},
+    "/tmp/work"
+  );
+  assert.deepStrictEqual(options.systemPrompt, {
+    type: "preset",
+    preset: "claude_code",
+    append: "Extra rules.",
+    snapshot: true,
+  });
+});
+
+test("Clay's live session prompt is never recorded", function () {
+  // getSessionSystemPrompt (project.js) recomposes from sticky notes, pair
+  // role, and the Capsule catalog, and three call sites force a mid-session
+  // re-render. Recording it would pin the first render until compaction.
+  var bridge = fs.readFileSync(path.join(__dirname, "..", "lib", "sdk-bridge.js"), "utf8");
+  var start = bridge.indexOf("var queryOpts = {");
+  assert.ok(start !== -1, "the main session query options must still be built here");
+  var block = bridge.slice(start, start + 2000);
+  assert.ok(block.indexOf("appendSystemPrompt:") !== -1, "the session prompt is an append");
+  assert.ok(
+    block.indexOf("systemPromptSnapshot") === -1,
+    "the live session path must not opt into system-prompt recording"
+  );
+});
+
+test("a bare string prompt is promoted to the custom form the SDK can record", function () {
+  // The SDK cannot record a bare string; it needs { type: 'custom', ... }.
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "yoke", "adapters", "claude.js"),
+    "utf8"
+  );
+  var start = source.indexOf("function applySystemPromptSnapshot");
+  var end = source.indexOf("function getSharedSkillPlugins");
+  assert.ok(start !== -1 && end > start, "applySystemPromptSnapshot must exist");
+  var apply = new Function(
+    source.slice(start, end) + "\nreturn applySystemPromptSnapshot;"
+  )();
+
+  assert.deepStrictEqual(
+    apply("You are a title generator.", true),
+    { type: "custom", prompt: "You are a title generator.", snapshot: true }
+  );
+  assert.deepStrictEqual(
+    apply(["line one", "line two"], true),
+    { type: "custom", prompt: ["line one", "line two"], snapshot: true }
+  );
+  assert.deepStrictEqual(
+    apply({ type: "preset", preset: "claude_code", append: "x" }, true),
+    { type: "preset", preset: "claude_code", append: "x", snapshot: true }
+  );
+  // Opting out leaves the value untouched, including the bare string form.
+  assert.strictEqual(apply("plain", false), "plain");
+  assert.strictEqual(apply("plain", undefined), "plain");
+  assert.strictEqual(apply(null, true), null);
+});
+
+test("applying the snapshot flag does not mutate the caller's prompt object", function () {
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "yoke", "adapters", "claude.js"),
+    "utf8"
+  );
+  var apply = new Function(
+    source.slice(
+      source.indexOf("function applySystemPromptSnapshot"),
+      source.indexOf("function getSharedSkillPlugins")
+    ) + "\nreturn applySystemPromptSnapshot;"
+  )();
+  var original = { type: "preset", preset: "claude_code", append: "x" };
+  apply(original, true);
+  assert.strictEqual(original.snapshot, undefined);
+});
+
+// --- usage pass-through ----------------------------------------------------
+
+test("the adapter forwards modelUsage whole so new SDK fields survive", function () {
+  var events = normalizeEvent({
+    type: "result",
+    subtype: "success",
+    total_cost_usd: 0.5,
+    duration_ms: 10,
+    usage: { input_tokens: 5, output_tokens: 7 },
+    modelUsage: { "claude-opus-5": { outputTokens: 420, thinkingTokens: 101, costBasis: "list" } },
+  });
+  var result = Array.isArray(events) ? events[0] : events;
+  assert.strictEqual(result.modelUsage["claude-opus-5"].thinkingTokens, 101);
+  assert.strictEqual(result.modelUsage["claude-opus-5"].costBasis, "list");
+});
+
+test("the usage panel sums thinking tokens across every model in the turn", function () {
+  // A single turn's modelUsage can hold several models (verified live: a haiku
+  // internal call alongside the opus main loop). Reading only the first entry
+  // would report 0 thinking tokens while the main model spent 101.
+  var source = fs.readFileSync(
+    path.join(__dirname, "..", "lib", "public", "modules", "app-panels.js"),
+    "utf8"
+  );
+  var start = source.indexOf("export function accumulateContext");
+  var end = source.indexOf("// contextView:");
+  assert.ok(start !== -1 && end > start, "accumulateContext must be present");
+  var body = source.slice(start, end).replace("export function", "function");
+  // Stub the module-level collaborators the extracted function touches.
+  var accumulate = new Function(
+    "store", "resolveContextWindow", "updateContextPanel", "contextData",
+    body + "\nreturn accumulateContext;"
+  );
+
+  var contextData = {
+    contextWindow: 0, maxOutputTokens: 0, model: "-", cost: 0, input: 0,
+    output: 0, cacheRead: 0, cacheWrite: 0, turns: 0, thinking: null, costBasis: null,
+  };
+  var fn = accumulate(
+    { get: function () { return null; } },
+    function (m, w) { return w || 0; },
+    function () {},
+    contextData
+  );
+
+  fn(0.1, { output_tokens: 433 }, {
+    "claude-haiku-4-5": { outputTokens: 13, thinkingTokens: 0, costBasis: "list" },
+    "claude-opus-5": { outputTokens: 420, thinkingTokens: 101, costBasis: "list" },
+  }, null);
+  assert.strictEqual(contextData.thinking, 101, "thinking is summed across models");
+  assert.strictEqual(contextData.costBasis, "list");
+
+  // Models priced differently must not report whichever came first.
+  fn(0.2, { output_tokens: 10 }, {
+    "a": { outputTokens: 1, thinkingTokens: 2, costBasis: "list" },
+    "b": { outputTokens: 1, thinkingTokens: 3, costBasis: "managed" },
+  }, null);
+  assert.strictEqual(contextData.thinking, 5);
+  assert.strictEqual(contextData.costBasis, "mixed");
+
+  // Older CLI builds omit both fields entirely: stay null so the rows hide
+  // instead of claiming a confident zero.
+  fn(0.3, { output_tokens: 10 }, { "old": { outputTokens: 9 } }, null);
+  assert.strictEqual(contextData.thinking, null);
+  assert.strictEqual(contextData.costBasis, null);
+});
+
+test("the usage panel markup has hidden rows for both optional fields", function () {
+  var html = fs.readFileSync(path.join(__dirname, "..", "lib", "public", "index.html"), "utf8");
+  assert.ok(/id="context-thinking-row"[^>]*class="[^"]*hidden/.test(html)
+    || /class="usage-row hidden" id="context-thinking-row"/.test(html),
+    "the thinking row starts hidden");
+  assert.ok(/class="usage-row hidden" id="context-cost-basis-row"/.test(html),
+    "the cost-basis row starts hidden");
+  assert.ok(html.indexOf('id="context-thinking"') !== -1);
+  assert.ok(html.indexOf('id="context-cost-basis"') !== -1);
+});

--- a/test/yoke-adapter-contract.test.js
+++ b/test/yoke-adapter-contract.test.js
@@ -93,14 +93,16 @@ test("YOKE background-task producers emit the normalized level-state contract", 
       subtype: "background_tasks_changed",
       tasks: [
         { task_id: "bash-1", task_type: "local_bash", description: "Wait for build" },
-        { task_id: "agent-1", task_type: "local_agent", description: "Review changes" },
+        { task_id: "agent-1", task_type: "local_agent", description: "Review changes", ambient: true },
         { task_id: "unknown-1", task_type: "native_monitor", description: "Check status" },
       ],
     },
+    // Claude reports the SDK's ambient flag; the adapter normalizes an absent
+    // value to false so hosts never have to test for undefined.
     expectedTasks: [
-      { task_id: "bash-1", task_type: "shell", description: "Wait for build" },
-      { task_id: "agent-1", task_type: "agent", description: "Review changes" },
-      { task_id: "unknown-1", task_type: "other", description: "Check status" },
+      { task_id: "bash-1", task_type: "shell", description: "Wait for build", ambient: false },
+      { task_id: "agent-1", task_type: "agent", description: "Review changes", ambient: true },
+      { task_id: "unknown-1", task_type: "other", description: "Check status", ambient: false },
     ],
   }, {
     name: "Codex",
@@ -108,6 +110,9 @@ test("YOKE background-task producers emit the normalized level-state contract", 
     rawEvent: {
       terminals: [{ id: "terminal-1", commandLine: "npm test" }],
     },
+    // Codex background terminals have no ambient concept, so the field stays
+    // absent rather than being invented as false. countUserTasks treats absent
+    // as user work, so Codex tasks keep driving the activity indicators.
     expectedTasks: [
       { task_id: "terminal-1", task_type: "shell", description: "npm test" },
     ],


### PR DESCRIPTION
## Summary

Updates `@anthropic-ai/claude-agent-sdk` 0.3.241 → 0.3.258 (11 releases) and adopts the new capabilities that matter to Clay.

### perTaskStopAffordance (behavior-critical companion)
Clay renders a per-task Stop control wired to the `stop_task` control request. On 0.3.258 the CLI fails closed without this declaration: an interrupt would kill all background tasks. Declared unconditionally via one shared constant on both the in-process and OS-user worker paths (first-attached-client-wins means the paths must not disagree). Result: Stop aborts the current turn only; tasks are stopped individually from the tasks bar.

### systemPrompt snapshot — plumbing only, deliberately off
The SDK recommends `snapshot: true`, but Clay's persistent sessions re-render their prompt mid-conversation on purpose (sticky notes, pair/Driver role, capsule catalog — three call sites exist solely to force the refresh). A recorded prompt would silently freeze those until compaction. Added `applySystemPromptSnapshot()` with correct shaping for both prompt forms behind a `systemPromptSnapshot` opt-in that no caller sets; a guard test fails if the live session path ever opts in.

### Usage panel fields
`thinkingTokens` and `costBasis` (both per-model in `modelUsage`, already forwarded whole) now render in the usage panel: thinking tokens summed across all models in a turn (a live turn was observed reporting two models — reading only the first would show 0 while the main model spent 101), and cost basis with `"mixed"` when models disagree. Rows stay hidden until the CLI actually reports the fields, so resumed/older sessions show nothing rather than a fabricated zero.

### Ambient background tasks — filtered from indicators, surfaced as Housekeeping
The CLI now marks its own housekeeping (skip_transcript tasks, live-update watchers) with `ambient`. Per SDK guidance these no longer count toward the composer summary/dots, sidebar badges, or session-list rebroadcasts, and the bar stays hidden when only ambient tasks run. They are not hidden entirely: expanded, they appear under a muted "Housekeeping" section with elapsed time and their own Stop button (with perTaskStopAffordance declared, that button is the only kill path for a runaway watcher). Codex terminals have no ambient concept; absence counts as user work, unchanged.

### Compatibility
zod 4.4.3 satisfies the new `^4.0.0` peer; `zod/v3` type subpath resolves; Clay's `sdk.tool()`/`createSdkMcpServer` paths verified live. A real query on 0.3.258 with the new options completed successfully with `thinkingTokens` and `costBasis` present as typed.

### Noted but not adopted (follow-up candidates)
`interrupt cancel_queued` (Stop-means-stop-everything), PreModelSwitch/PostModelSwitch hooks, per-MCP-server `timeout`, `default_to_no` on permission requests, authoritative `queued_turn_count`, `getContextUsage({detail:'summary'})`.

## Test plan
- Full suite: **885 tests, 885 pass, 0 fail** (re-verified independently; +20 across `test/claude-sdk-options.test.js` and extended timing/contract tests).
- Live end-to-end query on 0.3.258 succeeded with both new options set.
- Visual QA of the Housekeeping section against the real stylesheet (screenshot verified; summary counts user tasks only, ambient rows muted with Stop/elapsed intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)