### PR TITLE
fix(auth): recheck Codex credentials after login

### DIFF
--- a/lib/project-vendor-login.js
+++ b/lib/project-vendor-login.js
@@ -20,6 +20,7 @@
 // auth_required forever.
 
 var vendorRegistry = require("./yoke/vendor-registry");
+var yoke = require("./yoke");
 
 // Login CLIs print a success line and then hand the shell back, so the PTY
 // itself does not exit. Watch the output stream instead. Deliberately narrow:
@@ -209,6 +210,10 @@ function attachVendorLogin(ctx) {
     flow.finishing = true;
     flow.completed = !!succeeded;
 
+    // The next session must not reuse the pre-login "not authenticated"
+    // result. Re-check before restarting the runtime, which will then read
+    // the newly written credential file.
+    if (succeeded) yoke.invalidateAuthCache();
     var refresh = succeeded ? refreshVendorAuth(vendor) : Promise.resolve(false);
     refresh.then(function (restarted) {
       discardFlow(vendor);

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -61,6 +61,20 @@ function attachMessageProcessor(ctx) {
     if (session._lastAuthEmit && (now - session._lastAuthEmit) < 5000) return;
     session._lastAuthEmit = now;
 
+    // Codex can leave a transient 401 in its app-server event stream after a
+    // successful device login. Confirm the CLI's current credential state
+    // before interrupting another session with a login modal.
+    var vendor = session.vendor || "claude";
+    yoke.invalidateAuthCache();
+    var authState = yoke.checkAuth();
+    if (authState[vendor]) {
+      sendAndRecord(session, {
+        type: "error",
+        text: "Authentication is available, but " + vendor + " reported an auth-like error. Try again.",
+      });
+      return;
+    }
+
     var authUser = session.ownerId ? usersModule.findUserById(session.ownerId) : null;
     var authLinuxUser = authUser && authUser.linuxUser ? authUser.linuxUser : null;
     var canAutoLogin = !usersModule.isMultiUser()
@@ -76,7 +90,7 @@ function attachMessageProcessor(ctx) {
     sendToSession(session, {
       type: "auth_required",
       text: authTitle,
-      vendor: session.vendor || "claude",
+      vendor: vendor,
       loginCommand: loginCommand,
       linuxUser: authLinuxUser,
       canAutoLogin: canAutoLogin,
@@ -88,7 +102,7 @@ function attachMessageProcessor(ctx) {
         slug: slug,
         sessionId: session.localId,
         ownerId: session.ownerId || null,
-        vendor: session.vendor || "claude",
+        vendor: vendor,
         loginCommand: loginCommand,
         linuxUser: authLinuxUser,
         canAutoLogin: canAutoLogin,

--- a/test/auth-required-history-replay.test.js
+++ b/test/auth-required-history-replay.test.js
@@ -3,11 +3,14 @@ var assert = require("node:assert");
 var fs = require("fs");
 var path = require("path");
 
-test("authentication recovery stays out of transcript history and ignores replay", function () {
+test("authentication recovery does not replay or retain pre-login auth state", function () {
   var processor = fs.readFileSync(path.join(__dirname, "../lib/sdk-message-processor.js"), "utf8");
   var messages = fs.readFileSync(path.join(__dirname, "../lib/public/modules/app-messages.js"), "utf8");
+  var login = fs.readFileSync(path.join(__dirname, "../lib/project-vendor-login.js"), "utf8");
 
   assert.match(processor, /Authentication recovery is transient UI state[\s\S]*sendToSession\(session, \{[\s\S]*type: "auth_required"/);
   assert.doesNotMatch(processor, /sendAndRecord\(session, \{[\s\S]{0,300}type: "auth_required"/);
+  assert.match(processor, /yoke\.invalidateAuthCache\(\);[\s\S]*var authState = yoke\.checkAuth\(\);[\s\S]*if \(authState\[vendor\]\)/);
   assert.match(messages, /if \(!store\.get\('replayingHistory'\)\) autoStartLoginIfNeeded\(msg\);/);
+  assert.match(login, /if \(succeeded\) yoke\.invalidateAuthCache\(\);/);
 });


### PR DESCRIPTION
## Summary
- clear cached vendor authentication after a successful login
- verify current credentials before reopening an auth modal
- cover replay and stale-auth recovery paths

## Testing
- node --test --test-force-exit test/auth-required-history-replay.test.js test/vendor-login-flow.test.js