### PR TITLE
fix(auth): refresh Codex login across projects

### DIFF
--- a/lib/project-vendor-login.js
+++ b/lib/project-vendor-login.js
@@ -63,7 +63,8 @@ function looksLikeLoginSuccess(text) {
  *   sm, tm, adapters,
  *   send, sendTo,
  *   usersModule,
- *   getOsUserInfoForWs, getOsUserInfoForLinuxUser, getLinuxUserForSession
+ *   getOsUserInfoForWs, getOsUserInfoForLinuxUser, getLinuxUserForSession,
+ *   refreshVendorAuthEverywhere
  */
 function attachVendorLogin(ctx) {
   var slug = ctx.slug;
@@ -81,6 +82,7 @@ function attachVendorLogin(ctx) {
   var getOsUserInfoForWs = ctx.getOsUserInfoForWs;
   var getOsUserInfoForLinuxUser = ctx.getOsUserInfoForLinuxUser;
   var getLinuxUserForSession = ctx.getLinuxUserForSession;
+  var refreshVendorAuthEverywhere = ctx.refreshVendorAuthEverywhere;
 
   // vendor -> flow record. At most one live login terminal per vendor.
   var _flows = Object.create(null);
@@ -182,13 +184,17 @@ function attachVendorLogin(ctx) {
   // the credentials the login just wrote. Shared adapter instances (Claude) are
   // reused by every project, so tearing one down here would kill unrelated
   // sessions; those runtimes pick up new credentials on their own.
-  function refreshVendorAuth(vendor) {
+  function refreshVendorAuth(vendor, linuxUser) {
     var adapter = adapters[vendor];
     if (!adapter || typeof adapter.shutdown !== "function") return Promise.resolve(false);
     if (adapter.shared) {
       console.log("[vendor-login] " + vendor + " adapter is shared; skipping restart for " + slug);
       return Promise.resolve(false);
     }
+    if (typeof adapter.refreshAuthIdentity === "function") {
+      return Promise.resolve(adapter.refreshAuthIdentity(linuxUser || null));
+    }
+    if (linuxUser) return Promise.resolve(false);
     // adapter.shutdown() already fans out to every per-OS-user runtime it
     // created (shutdownUserRuntimes), so one call covers isolated setups too.
     return Promise.resolve()
@@ -214,7 +220,12 @@ function attachVendorLogin(ctx) {
     // result. Re-check before restarting the runtime, which will then read
     // the newly written credential file.
     if (succeeded) yoke.invalidateAuthCache();
-    var refresh = succeeded ? refreshVendorAuth(vendor) : Promise.resolve(false);
+    var refresh = Promise.resolve(false);
+    if (succeeded) {
+      refresh = typeof refreshVendorAuthEverywhere === "function"
+        ? refreshVendorAuthEverywhere(vendor, flow.linuxUser || null)
+        : refreshVendorAuth(vendor, flow.linuxUser || null);
+    }
     refresh.then(function (restarted) {
       discardFlow(vendor);
       closeFlowTerminal(flow);
@@ -396,6 +407,7 @@ function attachVendorLogin(ctx) {
     listFlows: listFlows,
     forgetTerminal: forgetTerminal,
     isLoginTerminal: isLoginTerminal,
+    refreshVendorAuth: refreshVendorAuth,
   };
 }
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -1610,6 +1610,7 @@ function createProjectContext(opts) {
     getOsUserInfoForWs: getOsUserInfoForWs,
     getOsUserInfoForLinuxUser: getOsUserInfoForLinuxUser,
     getLinuxUserForSession: getLinuxUserForSession,
+    refreshVendorAuthEverywhere: opts.refreshVendorAuthEverywhere,
   });
 
   // --- Filesystem handler (delegated to project-filesystem.js) ---
@@ -2141,6 +2142,7 @@ function createProjectContext(opts) {
     listKnowledgeFiles: _knowledge.listKnowledgeFiles,
     refreshCapsuleCatalog: _capsuleCatalog.refreshSessions,
     getNotificationsModule: function () { return _notifications; },
+    refreshVendorAuth: _vendorLogin.refreshVendorAuth,
     getSchedules: _loop.getSchedules,
     importSchedule: _loop.importSchedule,
     removeSchedule: _loop.removeSchedule,

--- a/lib/server.js
+++ b/lib/server.js
@@ -1155,6 +1155,24 @@ function createServer(opts) {
   }
 
   // --- Project management ---
+  function refreshVendorAuthEverywhere(vendor, linuxUser) {
+    var refreshes = [];
+    projects.forEach(function (projectCtx) {
+      if (!projectCtx || typeof projectCtx.refreshVendorAuth !== "function") return;
+      try {
+        refreshes.push(Promise.resolve(projectCtx.refreshVendorAuth(vendor, linuxUser)).catch(function (err) {
+          console.error("[server] Cross-project " + vendor + " auth refresh failed:", err && err.message ? err.message : err);
+          return false;
+        }));
+      } catch (err) {
+        console.error("[server] Cross-project " + vendor + " auth refresh threw:", err && err.message ? err.message : err);
+      }
+    });
+    return Promise.all(refreshes).then(function (results) {
+      return results.some(function (refreshed) { return !!refreshed; });
+    });
+  }
+
   function addProject(cwd, slug, title, icon, projectOwnerId, worktreeMeta, extraOpts) {
     if (projects.has(slug)) return false;
     var extra = extraOpts || {};
@@ -1327,6 +1345,7 @@ function createServer(opts) {
       onDmMessage: handleDmMessage,
       broadcastAll: broadcastAll,
       notificationsModule: _globalNotifications,
+      refreshVendorAuthEverywhere: refreshVendorAuthEverywhere,
       getProject: function (s) { return projects.get(s) || null; },
       isUserOnline: isUserOnline,
     });

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -1943,6 +1943,23 @@ function createCodexAdapter(opts) {
       ]).then(function() { return true; });
     },
 
+    // A device login writes credentials for one OS identity. Refresh only
+    // that identity in OS-isolated deployments; single-user projects restart
+    // their sole app-server.
+    refreshAuthIdentity: function(linuxUser) {
+      if (!_runtimeLinuxUser && linuxUser) {
+        var userRuntime = _userRuntimes[linuxUser];
+        if (!userRuntime) return Promise.resolve(false);
+        return userRuntime.shutdown().then(function() {
+          delete _userRuntimes[linuxUser];
+          return true;
+        });
+      }
+      if (_runtimeLinuxUser && linuxUser !== _runtimeLinuxUser) return Promise.resolve(false);
+      if (_requiresLinuxUser) return Promise.resolve(false);
+      return adapter.shutdown();
+    },
+
     shutdownIfIdle: function(idleMs) {
       if (!_runtimeLinuxUser && Object.keys(_userRuntimes).length > 0) {
         return shutdownUserRuntimes("shutdownIfIdle", idleMs).then(function(results) {

--- a/test/codex-os-user-isolation.test.js
+++ b/test/codex-os-user-isolation.test.js
@@ -68,3 +68,28 @@ test("Codex fails closed when OS-user isolation lacks a mapped Linux user", asyn
     /requires a mapped Linux user/
   );
 });
+
+test("Codex auth refresh restarts only the matching Linux user runtime", async function() {
+  var servers = [];
+  var adapter = createCodexAdapter({
+    cwd: process.cwd(),
+    osUsers: true,
+    resolveOsUserInfo: fakeUserInfo,
+    createAppServer: function(options) {
+      var server = createFakeServer(options);
+      servers.push(server);
+      return server;
+    },
+  });
+
+  await adapter.init({ linuxUser: "alice" });
+  await adapter.init({ linuxUser: "bob" });
+  await adapter.refreshAuthIdentity("alice");
+
+  assert.strictEqual(servers[0].started, false, "Alice's stale app-server is stopped");
+  assert.strictEqual(servers[1].started, true, "Bob's authenticated app-server stays running");
+
+  await adapter.init({ linuxUser: "alice" });
+  await adapter.init({ linuxUser: "bob" });
+  assert.strictEqual(servers.length, 3, "only Alice gets a fresh app-server");
+});

--- a/test/vendor-login-flow.test.js
+++ b/test/vendor-login-flow.test.js
@@ -68,6 +68,7 @@ function createHarness(opts) {
     getOsUserInfoForWs: options.getOsUserInfoForWs || function () { return null; },
     getOsUserInfoForLinuxUser: options.getOsUserInfoForLinuxUser || function () { return null; },
     getLinuxUserForSession: options.getLinuxUserForSession || function () { return null; },
+    refreshVendorAuthEverywhere: options.refreshVendorAuthEverywhere || null,
   });
 
   return {
@@ -163,6 +164,25 @@ test("successful login restarts the vendor adapter, announces auth_refreshed and
   assert.deepStrictEqual(h.tm.closed, [terminalId], "the login terminal does not linger in the sidebar");
   assert.deepStrictEqual(h.login.listFlows(), [], "the flow record is cleared");
   assert.deepStrictEqual(h.lastOf("vendor_login_state").flows, []);
+});
+
+test("successful login refreshes the authenticated identity across all projects", async function () {
+  var refreshes = [];
+  var h = createHarness({
+    refreshVendorAuthEverywhere: function (vendor, linuxUser) {
+      refreshes.push({ vendor: vendor, linuxUser: linuxUser });
+      return Promise.resolve(true);
+    },
+  });
+  h.login.handleVendorLoginMessage({}, { type: "vendor_login_start", vendor: "codex", auto: true });
+  h.tm.emitData(h.tm.created[0].id, "Successfully logged in.\r\n");
+
+  await new Promise(function (resolve) { setTimeout(resolve, 2200); });
+  await flush();
+
+  assert.deepStrictEqual(refreshes, [{ vendor: "codex", linuxUser: null }]);
+  assert.deepStrictEqual(h.shutdowns, [], "the server-wide coordinator owns adapter refresh");
+  assert.strictEqual(h.lastOf("auth_refreshed").adapterRestarted, true);
 });
 
 test("logging out does not read as a successful login", async function () {


### PR DESCRIPTION
## Summary
- propagate successful Codex login refreshes to every project
- restart only the authenticated Linux user's Codex runtimes under OS-user isolation
- preserve lazy initialization for inactive projects

## Testing
- npm test
- node --test --test-force-exit test/vendor-login-flow.test.js test/codex-os-user-isolation.test.js test/auth-required-history-replay.test.js