### PR TITLE
fix(auth): trust Codex runtime authentication failures

### DIFF
--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -61,19 +61,7 @@ function attachMessageProcessor(ctx) {
     if (session._lastAuthEmit && (now - session._lastAuthEmit) < 5000) return;
     session._lastAuthEmit = now;
 
-    // Codex can leave a transient 401 in its app-server event stream after a
-    // successful device login. Confirm the CLI's current credential state
-    // before interrupting another session with a login modal.
     var vendor = session.vendor || "claude";
-    yoke.invalidateAuthCache();
-    var authState = yoke.checkAuth();
-    if (authState[vendor]) {
-      sendAndRecord(session, {
-        type: "error",
-        text: "Authentication is available, but " + vendor + " reported an auth-like error. Try again.",
-      });
-      return;
-    }
 
     var authUser = session.ownerId ? usersModule.findUserById(session.ownerId) : null;
     var authLinuxUser = authUser && authUser.linuxUser ? authUser.linuxUser : null;

--- a/test/auth-required-history-replay.test.js
+++ b/test/auth-required-history-replay.test.js
@@ -10,7 +10,7 @@ test("authentication recovery does not replay or retain pre-login auth state", f
 
   assert.match(processor, /Authentication recovery is transient UI state[\s\S]*sendToSession\(session, \{[\s\S]*type: "auth_required"/);
   assert.doesNotMatch(processor, /sendAndRecord\(session, \{[\s\S]{0,300}type: "auth_required"/);
-  assert.match(processor, /yoke\.invalidateAuthCache\(\);[\s\S]*var authState = yoke\.checkAuth\(\);[\s\S]*if \(authState\[vendor\]\)/);
+  assert.doesNotMatch(processor, /Authentication is available, but[\s\S]*auth-like error/);
   assert.match(messages, /if \(!store\.get\('replayingHistory'\)\) autoStartLoginIfNeeded\(msg\);/);
   assert.match(login, /if \(succeeded\) yoke\.invalidateAuthCache\(\);/);
 });


### PR DESCRIPTION
## Summary
- treat Codex app-server authentication failures as authoritative
- stop relying on local credential-file status to suppress the login modal
- preserve transcript replay protection and cross-project credential refresh

## Testing
- node --test --test-force-exit test/auth-required-history-replay.test.js test/vendor-login-flow.test.js