### PR TITLE
fix(worker): restore split worker creation

### DIFF
--- a/lib/project-session-pair.js
+++ b/lib/project-session-pair.js
@@ -322,8 +322,7 @@ function attachSessionPair(ctx) {
         title: resolved.partner.title || "New Session",
         turns: count > 0 ? recentTurns(resolved.partner, count) : [],
       };
-      // The same bounded capacity report partner_status returns, so a Driver
-      // already reading turns needs no second call; null for anyone else.
+      // partner_status's bounded report, so reading turns needs no second call.
       payload.capacity = lifecycle.optionalStatus(caller);
       return toolResult(payload);
     } catch (e) {
@@ -411,7 +410,8 @@ function attachSessionPair(ctx) {
       .concat(workerProposal.getToolDefs(boundSession));
   }
 
-  var factory = attachPairFactory({ sm: sm, splitStore: store, ctx: ctx });
+  // Passed through as-is; re-wrapping drops fields. See session-pair-factory.js.
+  var factory = attachPairFactory(ctx);
   var createPairRecord = factory.createPairRecord;
   var createWorkerForDriver = factory.createWorkerForDriver;
   var createPair = factory.createPair;

--- a/lib/public/modules/tools.js
+++ b/lib/public/modules/tools.js
@@ -203,6 +203,23 @@ export function toolActivityText(name, input) {
   return "Running " + name + "...";
 }
 
+// The sublabel for a call that has finished. `toolActivityText` is written in
+// the present progressive for a call in flight, so re-asserting it after a
+// result has arrived leaves a finished card claiming to still be running —
+// which is how a failed custom tool ended up reading "Running
+// send_to_partner..." beside its own error output.
+//
+// Only ever used where a result exists, so a genuinely in-flight call is never
+// relabelled. A failure states so plainly; a success keeps whatever specific
+// description the activity text produced ("Reading foo.js"), because that still
+// describes the call accurately, and only the generic present-progressive
+// fallback is replaced.
+export function toolTerminalText(name, input, isError) {
+  if (isError) return name + " failed";
+  var activity = toolActivityText(name, input);
+  return activity === "Running " + name + "..." ? name : activity;
+}
+
 function shortPath(p) {
   if (!p) return "";
   var parts = p.split("/");
@@ -2136,9 +2153,12 @@ export function updateToolResult(id, content, isError, images) {
   var tool = tools[id];
   if (!tool) return;
 
+  // Re-render the sublabel from the now-complete input (streaming can have
+  // built it from a partial one), but in its terminal form: a result has
+  // arrived, so this call is no longer running.
   var subtitleText = tool.el.querySelector(".tool-subtitle-text");
   if (subtitleText && tool.input) {
-    subtitleText.textContent = toolActivityText(tool.name, tool.input);
+    subtitleText.textContent = toolTerminalText(tool.name, tool.input, isError);
   }
 
   var resultBlock = document.createElement("div");

--- a/lib/session-pair-factory.js
+++ b/lib/session-pair-factory.js
@@ -9,6 +9,17 @@
 // Ownership always comes from the connection or the Driver session, never from
 // the incoming message.
 //
+// CONTEXT CONTRACT: this module reads `sm`, `splitStore`, `isMate`,
+// `usersModule` and `sendTo` off its own argument, all at the top level.
+// attachSessionPair's context already carries all five, so it is passed
+// through unchanged. Re-wrapping it (it was once `{ sm, splitStore, ctx }`)
+// leaves `isMate`, `usersModule` and `sendTo` undefined, which silently
+// disables the Mate guard, breaks the pair_session_create reply, and throws
+// "Cannot read properties of undefined (reading 'isMultiUser')" the moment a
+// pair is created for an owned session — single-user installs escape it only
+// because a Driver with no ownerId short-circuits that expression. Add any new
+// dependency as a top-level field of that same context.
+//
 // Two ordering rules matter and are load-bearing:
 //
 //   1. Nothing is created until everything is validated. Driver eligibility and

--- a/test/session-pair-factory-wiring.test.js
+++ b/test/session-pair-factory-wiring.test.js
@@ -1,0 +1,318 @@
+// Regression: the pair factory is constructed with attachSessionPair's own
+// context.
+//
+// attachPairFactory reads sm, splitStore, isMate, usersModule and sendTo off
+// its argument. project-session-pair.js used to wrap that as
+// { sm, splitStore, ctx }, which left isMate, usersModule and sendTo
+// undefined. The single-user path happened to survive, because a Driver with no
+// ownerId short-circuits `ws._clayUser && ctx.usersModule.isMultiUser()` before
+// the undefined dereference. In multi-user, where the Driver has an ownerId,
+// the same expression threw "Cannot read properties of undefined (reading
+// 'isMultiUser')" and send_to_partner failed on its very first call.
+//
+// These tests drive the real attachSessionPair + send_to_partner tool, in both
+// modes, so the wiring cannot silently regress again.
+
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var path = require("node:path");
+
+var root = path.join(__dirname, "..");
+var pairModule = require("../lib/project-session-pair");
+
+var CLAUDE_CATALOG = [{ value: "fable", resolvedModel: "claude-fable-5", displayName: "Claude Fable" }];
+var CODEX_CATALOG = ["gpt-5.6-terra", "gpt-5.6-sol"];
+
+function parse(result) { return JSON.parse(result.content[0].text); }
+
+function toolNamed(tools, name) {
+  for (var i = 0; i < tools.length; i++) {
+    if (tools[i].name === name) return tools[i];
+  }
+  return null;
+}
+
+// A world built the way project.js builds one: one flat context object carrying
+// every dependency, exactly as attachSessionPair receives it.
+function makeWorld(options) {
+  var opts = options || {};
+  var nextId = 10;
+  var driver = {
+    localId: 1,
+    ownerId: opts.ownerId === undefined ? null : opts.ownerId,
+    title: "Planner", vendor: "claude", model: "claude-fable-5",
+    history: [], isProcessing: false,
+  };
+  var sessions = new Map([[1, driver]]);
+  var groups = [];
+  var created = [];
+  var sentTo = [];
+  var intervals = [];
+  var realSetInterval = global.setInterval;
+  global.setInterval = function (fn, ms) {
+    var id = realSetInterval(fn, ms);
+    intervals.push(id);
+    return id;
+  };
+
+  var sm = {
+    sessions: sessions,
+    installedVendors: ["claude", "codex"],
+    modelsByVendor: { claude: CLAUDE_CATALOG, codex: CODEX_CATALOG },
+    defaultModelByVendor: {},
+    capabilitiesByVendor: {},
+    lastVendor: "codex",
+    sendAndRecord: function (session, message) { session.history.push(message); },
+    sendToSession: function () {},
+    broadcastSessionList: function () {},
+    createSessionRaw: function (spec) {
+      var s = {
+        localId: nextId++, ownerId: spec.ownerId === undefined ? null : spec.ownerId,
+        vendor: spec.vendor, model: spec.model || null, effort: spec.effort || null,
+        history: [], isProcessing: false, lastActivity: Date.now(),
+      };
+      sessions.set(s.localId, s);
+      created.push(s);
+      return s;
+    },
+    deleteSessionQuiet: function (id) { sessions.delete(id); },
+  };
+
+  var sdk = {
+    pushMessage: function () { return false; },
+    startQuery: function (session) {
+      session.history.push({ type: "delta", text: "worker result" });
+      session.isProcessing = false;
+      return Promise.resolve();
+    },
+  };
+
+  var attached = pairModule.attachSessionPair({
+    sm: sm,
+    isMate: !!opts.isMate,
+    splitStore: {
+      groupForMember: function (id) {
+        for (var i = 0; i < groups.length; i++) {
+          if (groups[i].members.indexOf(id) !== -1) return groups[i];
+        }
+        return null;
+      },
+      create: function (ws, msg) {
+        if (opts.groupCreateFails) return { ok: false, error: "A session can belong to only one split group" };
+        var g = {
+          id: "sg_" + (groups.length + 1),
+          members: msg.members.slice(),
+          pair: msg.pair,
+          ownerId: ws && ws._clayUser ? ws._clayUser.id : null,
+        };
+        groups.push(g);
+        return { ok: true, group: g };
+      },
+      dissolve: function (ws, msg) {
+        for (var i = 0; i < groups.length; i++) {
+          if (groups[i].id === msg.id) return { ok: true, group: groups.splice(i, 1)[0] };
+        }
+        return { ok: false, error: "Split group not found" };
+      },
+    },
+    getSdk: function () { return sdk; },
+    send: function () {},
+    sendTo: function (ws, message) { sentTo.push({ ws: ws, message: message }); },
+    usersModule: { isMultiUser: function () { return !!opts.multiUser; } },
+    getLinuxUserForSession: function () { return null; },
+    onProcessingChanged: function () {},
+  });
+
+  var world = {
+    attached: attached, driver: driver, sm: sm, sessions: sessions,
+    groups: groups, created: created, sentTo: sentTo,
+    tool: function (name, session) {
+      return toolNamed(attached.getToolDefs(session || driver), name);
+    },
+    worker: function () {
+      var g = groups[0];
+      return g && g.pair ? sessions.get(g.pair.workerId) : null;
+    },
+    dispose: function () {
+      for (var i = 0; i < intervals.length; i++) clearInterval(intervals[i]);
+      global.setInterval = realSetInterval;
+    },
+  };
+  return world;
+}
+
+// Delegate and settle the turn, the way the real bridge does on completion.
+async function delegate(world, message) {
+  var send = world.tool("send_to_partner");
+  assert.ok(send, "the Driver has send_to_partner");
+  var raw = await send.handler({ message: message || "Build it", wait: false });
+  var worker = world.worker();
+  if (worker) world.attached.handleTurnDone(worker);
+  return raw;
+}
+
+// --- The regression, in both modes ---------------------------------------
+
+test("send_to_partner creates the pair in single-user mode", async function (t) {
+  var world = makeWorld({ multiUser: false, ownerId: null });
+  t.after(world.dispose);
+
+  var raw = await delegate(world, "Implement the parser");
+  assert.equal(raw.isError, undefined, "no error: " + raw.content[0].text);
+  var result = parse(raw);
+  assert.equal(result.workerCreated, true);
+
+  assert.equal(world.groups.length, 1, "exactly one pair");
+  var worker = world.worker();
+  assert.ok(worker, "the Worker session exists");
+  assert.deepEqual(world.groups[0].pair, { driverId: 1, workerId: worker.localId });
+  assert.equal(world.groups[0].members.length, 2);
+  assert.equal(worker.ownerId, null, "single-user sessions carry no owner");
+});
+
+test("send_to_partner creates the pair in multi-user mode for an owned Driver", async function (t) {
+  // The exact case the wrapped context broke: an owned Driver makes
+  // `ws._clayUser` truthy, so `ctx.usersModule.isMultiUser()` is evaluated.
+  var world = makeWorld({ multiUser: true, ownerId: "alice" });
+  t.after(world.dispose);
+
+  var raw = await delegate(world, "Implement the parser");
+  assert.equal(raw.isError, undefined,
+    "no undefined isMultiUser error: " + raw.content[0].text);
+  assert.equal(/isMultiUser|Cannot read properties of undefined/.test(raw.content[0].text), false,
+    "the failure mode this test exists for");
+
+  var result = parse(raw);
+  assert.equal(result.workerCreated, true);
+  assert.equal(world.groups.length, 1);
+
+  var worker = world.worker();
+  assert.ok(worker);
+  assert.deepEqual(world.groups[0].pair, { driverId: 1, workerId: worker.localId });
+  // Ownership is derived from the connection the factory builds for the Driver,
+  // so the Worker and the group belong to the Driver's owner.
+  assert.equal(worker.ownerId, "alice", "the Worker inherits the Driver's owner");
+  assert.equal(world.groups[0].ownerId, "alice", "and so does the group record");
+});
+
+test("the wiring passes the whole context, so every dependency resolves", function () {
+  var pairSource = fs.readFileSync(path.join(root, "lib/project-session-pair.js"), "utf8");
+  var factorySource = fs.readFileSync(path.join(root, "lib/session-pair-factory.js"), "utf8");
+
+  assert.match(pairSource, /var factory = attachPairFactory\(ctx\);/,
+    "the factory receives attachSessionPair's own context");
+  assert.equal(/attachPairFactory\(\{/.test(pairSource), false,
+    "never a re-wrapped object that would drop fields");
+
+  // Everything the factory reads must be a top-level field of that context.
+  var reads = {};
+  var re = /ctx\.([A-Za-z_$][\w$]*)/g;
+  var match;
+  while ((match = re.exec(factorySource)) !== null) reads[match[1]] = true;
+  var names = Object.keys(reads).sort();
+  assert.deepEqual(names, ["isMate", "sendTo", "splitStore", "sm", "usersModule"].sort(),
+    "the factory's exact dependency list");
+  for (var i = 0; i < names.length; i++) {
+    assert.match(pairSource, new RegExp("ctx\\." + names[i] + "\\b|var \\w+ = ctx\\." + names[i]),
+      names[i] + " is a real field of the pair context");
+  }
+});
+
+// --- Guarantees the fix must not weaken ----------------------------------
+
+test("the Mate guard actually fires again", async function (t) {
+  // With the wrapped context ctx.isMate was undefined, so this guard was dead.
+  var world = makeWorld({ isMate: true, multiUser: false });
+  t.after(world.dispose);
+
+  var send = world.tool("send_to_partner");
+  if (!send) {
+    // A Mate project may not mount the pair tools at all, which is a stronger
+    // refusal than the guard; either way no pair may be created.
+    assert.equal(world.groups.length, 0);
+    return;
+  }
+  var raw = await send.handler({ message: "x", wait: false });
+  assert.equal(raw.isError, true);
+  assert.match(raw.content[0].text, /only available in projects/);
+  assert.equal(world.groups.length, 0, "no pair was created in a Mate project");
+  assert.deepEqual(world.created, [], "and no session either");
+});
+
+test("owner, eligibility and preflight guarantees still hold after the fix", async function (t) {
+  // Eligibility: a below-tier Driver gets no tools and creates nothing.
+  var below = makeWorld({ multiUser: true, ownerId: "alice" });
+  t.after(below.dispose);
+  below.driver.model = "claude-sonnet-5";
+  assert.equal(below.tool("send_to_partner"), null, "no pair tools below the Driver tier");
+  assert.equal(below.groups.length, 0);
+
+  // Preflight: an unavailable vendor is refused and nothing is created.
+  var badVendor = makeWorld({ multiUser: true, ownerId: "alice" });
+  t.after(badVendor.dispose);
+  var res = await badVendor.tool("send_to_partner").handler({ message: "x", workerVendor: "nope" });
+  assert.equal(res.isError, true);
+  assert.match(res.content[0].text, /vendor is not installed/);
+  assert.deepEqual(badVendor.created, [], "no orphan session");
+  assert.equal(badVendor.groups.length, 0, "no group");
+
+  // Preflight: an unavailable model, same outcome.
+  var badModel = makeWorld({ multiUser: true, ownerId: "alice" });
+  t.after(badModel.dispose);
+  var res2 = await badModel.tool("send_to_partner").handler({ message: "x", workerModel: "gpt-9-imaginary" });
+  assert.equal(res2.isError, true);
+  assert.match(res2.content[0].text, /model is not available/);
+  assert.deepEqual(badModel.created, []);
+  assert.equal(badModel.groups.length, 0);
+});
+
+test("a late group-write failure leaves no orphan, in either mode", async function (t) {
+  var modes = [
+    { multiUser: false, ownerId: null },
+    { multiUser: true, ownerId: "alice" },
+  ];
+  for (var i = 0; i < modes.length; i++) {
+    var world = makeWorld(Object.assign({ groupCreateFails: true }, modes[i]));
+    t.after(world.dispose);
+
+    var raw = await world.tool("send_to_partner").handler({ message: "x", wait: false });
+    assert.equal(raw.isError, true, "the delegation reports the failure");
+    assert.match(raw.content[0].text, /only one split group/);
+    assert.equal(world.groups.length, 0, "no group");
+    // The Worker this call created was removed; the Driver is untouched.
+    assert.equal(world.sessions.size, 1, "only the pre-existing Driver remains");
+    assert.equal(world.sessions.get(1), world.driver);
+  }
+});
+
+test("the pair_session_create WebSocket flow can report its result again", function (t) {
+  // createPair calls ctx.sendTo, which the wrapped context left undefined, so
+  // the "Add Split Worker" flow threw instead of answering the client.
+  var world = makeWorld({ multiUser: true, ownerId: "alice" });
+  t.after(world.dispose);
+  var ws = { _clayUser: { id: "alice" }, _clayActiveSession: 1 };
+
+  var handled = world.attached.handleMessage(ws, {
+    type: "pair_session_create",
+    driver: { sessionId: 1 },
+    worker: { vendor: "codex" },
+  });
+  assert.equal(handled, true);
+  assert.equal(world.sentTo.length, 1, "the client was answered");
+  assert.equal(world.sentTo[0].message.type, "pair_session_created");
+  assert.equal(world.sentTo[0].message.ok, true, world.sentTo[0].message.error || "");
+  assert.equal(world.groups.length, 1);
+
+  // And a refusal is reported rather than thrown.
+  var world2 = makeWorld({ multiUser: true, ownerId: "alice" });
+  t.after(world2.dispose);
+  world2.attached.handleMessage(ws, {
+    type: "pair_session_create",
+    driver: { sessionId: 1 },
+    worker: { vendor: "not-installed" },
+  });
+  assert.equal(world2.sentTo.length, 1);
+  assert.equal(world2.sentTo[0].message.ok, false);
+  assert.match(world2.sentTo[0].message.error, /vendor is not installed/);
+});

--- a/test/tool-terminal-label.test.js
+++ b/test/tool-terminal-label.test.js
@@ -1,0 +1,135 @@
+// A tool call that has produced a result must not keep the present-progressive
+// sublabel it had while running.
+//
+// updateToolResult re-renders the sublabel from the now-complete input, which
+// is right (streaming can have built it from a partial one), but it used
+// toolActivityText — written for a call in flight. A failed custom tool
+// therefore rendered "Running send_to_partner..." next to its own error output.
+// Still-running calls must keep the running label, so the terminal form is only
+// ever used where a result exists.
+
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var path = require("node:path");
+
+var root = path.join(__dirname, "..");
+var source = fs.readFileSync(path.join(root, "lib/public/modules/tools.js"), "utf8");
+
+// toolActivityText, toolTerminalText and shortPath are self-contained, so they
+// are evaluated directly rather than asserted against their own source text.
+function loadLabels() {
+  var start = source.indexOf("export function toolActivityText(name, input)");
+  var end = source.indexOf("\nfunction shortPath(p)");
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  var body = source.slice(start, end).replace(/^export function/gm, "function");
+  var shortPathStart = source.indexOf("function shortPath(p)");
+  var shortPathEnd = source.indexOf("\n}", shortPathStart) + 2;
+  body += "\n" + source.slice(shortPathStart, shortPathEnd);
+  var factory = new Function(body +
+    "\nreturn { toolActivityText: toolActivityText, toolTerminalText: toolTerminalText };");
+  return factory();
+}
+
+var labels = loadLabels();
+
+// --- The reported defect --------------------------------------------------
+
+test("a failed custom tool call renders a terminal failure, not a running label", function () {
+  var running = labels.toolActivityText("send_to_partner", { message: "do the thing" });
+  assert.equal(running, "Running send_to_partner...", "the in-flight label, for reference");
+
+  var terminal = labels.toolTerminalText("send_to_partner", { message: "do the thing" }, true);
+  assert.equal(terminal, "send_to_partner failed");
+  assert.equal(/Running|\.\.\./.test(terminal), false,
+    "no present-progressive text and no ellipsis survives on a finished card");
+});
+
+test("every custom or MCP tool name fails legibly", function () {
+  var names = ["send_to_partner", "replace_partner", "partner_status",
+    "mcp__clay-sessions__send_to_partner", "respond_to_worker_permission", "some_unknown_tool"];
+  for (var i = 0; i < names.length; i++) {
+    var terminal = labels.toolTerminalText(names[i], {}, true);
+    assert.equal(terminal, names[i] + " failed", names[i]);
+    assert.equal(/Running/.test(terminal), false);
+  }
+});
+
+test("a successful call drops the generic running text but keeps a real description", function () {
+  // The generic fallback is the only misleading one once a result exists.
+  assert.equal(labels.toolTerminalText("send_to_partner", { message: "x" }, false), "send_to_partner");
+  assert.equal(labels.toolTerminalText("some_unknown_tool", {}, false), "some_unknown_tool");
+
+  // A specific description still describes the call accurately, so it stays.
+  assert.equal(labels.toolTerminalText("Read", { file_path: "/a/b/c/foo.js" }, false),
+    labels.toolActivityText("Read", { file_path: "/a/b/c/foo.js" }));
+  assert.match(labels.toolTerminalText("Read", { file_path: "/a/b/c/foo.js" }, false), /^Reading /);
+  assert.match(labels.toolTerminalText("Edit", { file_path: "/a/b.js" }, false), /^Editing /);
+  assert.match(labels.toolTerminalText("Bash", { description: "run the tests" }, false), /run the tests/);
+});
+
+test("an error wins over any specific description", function () {
+  assert.equal(labels.toolTerminalText("Read", { file_path: "/a/b.js" }, true), "Read failed");
+  assert.equal(labels.toolTerminalText("Bash", { description: "run the tests" }, true), "Bash failed");
+  assert.equal(labels.toolTerminalText("Edit", { file_path: "/a/b.js" }, true), "Edit failed");
+});
+
+test("falsy and missing error flags are treated as success", function () {
+  assert.equal(labels.toolTerminalText("send_to_partner", {}, false), "send_to_partner");
+  assert.equal(labels.toolTerminalText("send_to_partner", {}, undefined), "send_to_partner");
+  assert.equal(labels.toolTerminalText("send_to_partner", {}), "send_to_partner");
+});
+
+// --- Still-running calls are never relabelled ----------------------------
+
+test("the terminal label is used only where a result has arrived", function () {
+  // Start of a call: the running label, unchanged.
+  var starting = source.slice(source.indexOf("ctx.setActivity(toolActivityText(name, input));"));
+  starting = starting.slice(0, starting.indexOf("\n}") + 2);
+  assert.match(starting, /toolActivityText\(name, input\)/,
+    "an in-flight call keeps the present-progressive label");
+  assert.equal(/toolTerminalText/.test(starting), false);
+
+  // Result arrival: the terminal label, carrying the error flag.
+  var result = source.slice(source.indexOf("export function updateToolResult(id, content, isError, images)"));
+  result = result.slice(0, result.indexOf("var resultBlock"));
+  assert.match(result, /subtitleText\.textContent = toolTerminalText\(tool\.name, tool\.input, isError\);/);
+  assert.equal(/toolActivityText/.test(result), false,
+    "the running label is no longer re-asserted after completion");
+
+  // Exactly one terminal call site, so nothing else can mask a live call.
+  assert.equal((source.match(/toolTerminalText\(/g) || []).length, 2,
+    "one definition-internal use plus the single call site");
+});
+
+test("the completed card still gets its error state and icon", function () {
+  // The sublabel is the text half; markToolDone owns the class and icon, and
+  // both are driven by the same isError the server sent.
+  var done = source.slice(source.indexOf("export function markToolDone(id, isError)"));
+  done = done.slice(0, done.indexOf("export function markAllToolsDone"));
+  assert.match(done, /tool\.el\.classList\.add\("done"\);/);
+  assert.match(done, /if \(isError\) tool\.el\.classList\.add\("error"\);/);
+  assert.match(done, /alert-triangle/, "a failure gets the error icon");
+  assert.match(source, /markToolDone\(id, isError\);/, "and updateToolResult finishes the card");
+});
+
+test("the error flag is plumbed intact from the server, so no normalization was needed", function () {
+  // The renderer already receives the provider's own flag; the defect was
+  // purely the client re-writing the sublabel after completion.
+  var processor = fs.readFileSync(path.join(root, "lib/sdk-message-processor.js"), "utf8");
+  assert.match(processor, /is_error: block\.is_error \|\| false,/,
+    "the server forwards the provider's error flag");
+  var messages = fs.readFileSync(path.join(root, "lib/public/modules/app-messages.js"), "utf8");
+  assert.match(messages, /updateToolResult\(msg\.id, msg\.content \|\| "", msg\.is_error \|\| false, msg\.images\);/,
+    "and the router passes it straight to the renderer");
+});
+
+test("client conventions hold", function () {
+  var fn = source.slice(source.indexOf("export function toolTerminalText"));
+  fn = fn.slice(0, fn.indexOf("\n}") + 2);
+  assert.equal(/=>/.test(fn), false, "no arrow functions");
+  assert.equal(/^\s*(const|let)\s/m.test(fn), false, "var only");
+  assert.equal(/localStorage|alert\(|confirm\(/.test(fn), false);
+  assert.match(source, /export function toolTerminalText/, "ESM export");
+});


### PR DESCRIPTION
Pass the complete session-pair context into the Worker factory, restore multi-user creation and pair replies, and show terminal labels for completed tool failures. Verified by 16 focused tests and the full 1405-test suite.