### PR TITLE
fix(sessions): preserve Claude startup input and default to private

### DIFF
--- a/lib/project-session-handoff.js
+++ b/lib/project-session-handoff.js
@@ -78,7 +78,7 @@ function attachSessionHandoff(ctx) {
     ) || null;
     var target = sm.createSessionRaw({
       ownerId: source.ownerId || null,
-      sessionVisibility: source.sessionVisibility || "shared",
+      sessionVisibility: "private",
       vendor: targetVendor,
       model: targetModel || null,
       effort: targetEffort,

--- a/lib/project-session-spawn.js
+++ b/lib/project-session-spawn.js
@@ -198,7 +198,7 @@ function attachSessionSpawn(ctx) {
     var create = typeof sm.createSessionRaw === "function" ? sm.createSessionRaw : sm.createSession;
     var session = create.call(sm, {
       ownerId: parent.ownerId || null,
-      sessionVisibility: parent.sessionVisibility || "shared",
+      sessionVisibility: "private",
       vendor: vendor,
     });
     session.spawn = { parentId: parent.localId, index: index, batchId: batchId };

--- a/lib/project-sessions.js
+++ b/lib/project-sessions.js
@@ -5,6 +5,7 @@ var { execFileSync } = require("child_process");
 var { CODEX_DEFAULTS, getCodexConfig } = require("./codex-defaults");
 var updateSnooze = require("./update-snooze");
 var yoke = require("./yoke");
+var sessionVisibility = require("./session-visibility");
 
 function vendorSupportsTui(vendor) {
   var info = yoke.getVendorInfo(vendor);
@@ -496,7 +497,7 @@ function attachSessions(ctx) {
       sm.sweepBlankSessions();
       var sessionOpts = {};
       if (ws._clayUser && usersModule.isMultiUser()) sessionOpts.ownerId = ws._clayUser.id;
-      if (msg.sessionVisibility) sessionOpts.sessionVisibility = msg.sessionVisibility;
+      sessionOpts.sessionVisibility = sessionVisibility.normalize(msg.sessionVisibility);
       if (msg.vendor) sessionOpts.vendor = msg.vendor;
       // Mode resolution: vendors without a TUI session mode are always GUI.
       // TUI-capable sessions honor the explicit msg.mode if provided, otherwise
@@ -581,7 +582,8 @@ function attachSessions(ctx) {
         if (reusable) {
           if (sessionOpts.vendor && reusable.vendor !== sessionOpts.vendor) reusable.vendor = sessionOpts.vendor;
           if (!reusable.effort) reusable.effort = sessionOpts.effort;
-          if (msg.sessionVisibility) reusable.sessionVisibility = msg.sessionVisibility;
+          sm.setSessionVisibility(reusable.localId, sessionOpts.sessionVisibility);
+          sessionVisibility.revokeViewers(ctx, reusable);
           sm.switchSession(reusable.localId, ws);
           newSess = reusable;
         } else {
@@ -609,9 +611,7 @@ function attachSessions(ctx) {
     }
 
     if (msg.type === "set_session_visibility") {
-      if (typeof msg.sessionId === "number" && (msg.visibility === "shared" || msg.visibility === "private")) {
-        sm.setSessionVisibility(msg.sessionId, msg.visibility);
-      }
+      sessionVisibility.handleChange(ctx, ws, msg);
       return true;
     }
 

--- a/lib/public/modules/sidebar-sessions.js
+++ b/lib/public/modules/sidebar-sessions.js
@@ -697,7 +697,7 @@ function showSessionCtxMenu(anchorBtn, sessionId, title, cliSid, sessionData) {
 
   // Session visibility toggle (only the session owner can change)
   if (store.get('isMultiUserMode') && sessionData && sessionData.ownerId && sessionData.ownerId === store.get('myUserId')) {
-    var currentVis = (sessionData && sessionData.sessionVisibility) || "shared";
+    var currentVis = (sessionData && sessionData.sessionVisibility) || "private";
     var isPrivate = currentVis === "private";
     var visItem = document.createElement("button");
     visItem.className = "session-ctx-item";
@@ -1290,7 +1290,7 @@ function renderSessionItem(s, options) {
   if (s.loop && s.loop.source === "debate") {
     textHtml += '<span class="session-debate-icon" title="Debate">' + iconHtml("mic") + '</span>';
   }
-  if (store.get('isMultiUserMode') && s.sessionVisibility === "private") {
+  if (store.get('isMultiUserMode') && s.sessionVisibility !== "shared") {
     textHtml += '<span class="session-private-icon" title="Private session">' + iconHtml("lock") + '</span>';
   }
   textHtml += highlightMatch(s.title || "New Session", searchQuery);

--- a/lib/session-visibility.js
+++ b/lib/session-visibility.js
@@ -1,0 +1,39 @@
+function normalize(value) {
+  return value === "shared" ? "shared" : "private";
+}
+
+function restore(meta) {
+  // Older releases persisted the shared default without recording intent.
+  return meta.sessionVisibilityExplicit === true ? normalize(meta.sessionVisibility) : "private";
+}
+
+function handleChange(ctx, ws, msg) {
+  if (typeof msg.sessionId !== "number" || (msg.visibility !== "shared" && msg.visibility !== "private")) return;
+  var session = ctx.sm.sessions.get(msg.sessionId);
+  if (!session) return;
+  if (ctx.usersModule.isMultiUser()) {
+    var user = ws._clayUser;
+    var project = ctx.getProjectAccess ? ctx.getProjectAccess() : { visibility: "public" };
+    if (!user || !session.ownerId || session.ownerId !== user.id ||
+        !ctx.usersModule.canAccessSession(user.id, session, project)) return;
+  } else if (session.ownerId) {
+    return;
+  }
+  ctx.sm.setSessionVisibility(msg.sessionId, msg.visibility);
+  revokeViewers(ctx, session);
+}
+
+function revokeViewers(ctx, session) {
+  if (ctx.usersModule.isMultiUser() && session.sessionVisibility === "private") {
+    ctx.clients.forEach(function(client) {
+      if (client._clayActiveSession !== session.localId) return;
+      if (client._clayUser && client._clayUser.id === session.ownerId) return;
+      // Clear the server-side selection before reconnecting so no further
+      // session events or input can cross the revoked access boundary.
+      client._clayActiveSession = null;
+      if (client.readyState === 1) client.close(1008, "Session access changed");
+    });
+  }
+}
+
+module.exports = { normalize: normalize, restore: restore, handleChange: handleChange, revokeViewers: revokeViewers };

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -7,6 +7,7 @@ var { CODEX_DEFAULTS } = require("./codex-defaults");
 var hygiene = require("./session-hygiene");
 var backgroundTaskTiming = require("./background-task-timing");
 var sessionProvenance = require("./session-provenance");
+var sessionVisibility = require("./session-visibility");
 
 function createSessionManager(opts) {
   var cwd = opts.cwd;
@@ -166,7 +167,8 @@ function createSessionManager(opts) {
       if (session.dangerouslySkipPermissions) metaObj.dangerouslySkipPermissions = true;
       if (session.permissionMode) metaObj.permissionMode = session.permissionMode;
       if (session.permissionModeBeforeFullAccess) metaObj.permissionModeBeforeFullAccess = session.permissionModeBeforeFullAccess;
-      if (session.sessionVisibility) metaObj.sessionVisibility = session.sessionVisibility;
+      metaObj.sessionVisibility = sessionVisibility.normalize(session.sessionVisibility);
+      if (session.sessionVisibilityExplicit) metaObj.sessionVisibilityExplicit = true;
       if (session.bookmarked) metaObj.bookmarked = true;
       if (typeof session.favoriteOrder === "number") metaObj.favoriteOrder = session.favoriteOrder;
       if (session.lastRewindUuid) metaObj.lastRewindUuid = session.lastRewindUuid;
@@ -321,7 +323,8 @@ function createSessionManager(opts) {
       session.terminalId = null;
       session.runtimeMode = null;
       session.runtimeTerminalId = null;
-      session.sessionVisibility = m.sessionVisibility || "shared";
+      session.sessionVisibility = sessionVisibility.restore(m);
+      session.sessionVisibilityExplicit = m.sessionVisibilityExplicit === true;
       session.bookmarked = !!m.bookmarked;
       session.favoriteOrder = typeof m.favoriteOrder === "number" ? m.favoriteOrder : null;
       sessions.set(localId, session);
@@ -447,7 +450,7 @@ function createSessionManager(opts) {
         terminalId: null,
         runtimeMode: null,
         runtimeTerminalId: null,
-        sessionVisibility: "shared",
+        sessionVisibility: "private",
         bookmarked: false,
         favoriteOrder: null,
       };
@@ -536,7 +539,7 @@ function createSessionManager(opts) {
       loop: loop,
       spawn: s.spawn || null,
       ownerId: s.ownerId || null,
-      sessionVisibility: s.sessionVisibility || "shared",
+      sessionVisibility: sessionVisibility.normalize(s.sessionVisibility),
       bookmarked: !!s.bookmarked,
       favoriteOrder: typeof s.favoriteOrder === "number" ? s.favoriteOrder : null,
       unread: unreadMap[s.localId] || 0,
@@ -620,7 +623,8 @@ function createSessionManager(opts) {
       history: [],
       messageUUIDs: [],
       ownerId: (sessionOpts && sessionOpts.ownerId) || null,
-      sessionVisibility: (sessionOpts && sessionOpts.sessionVisibility) || "shared",
+      sessionVisibility: sessionVisibility.normalize(sessionOpts && sessionOpts.sessionVisibility),
+      sessionVisibilityExplicit: !!(sessionOpts && sessionOpts.sessionVisibility === "shared"),
       bookmarked: false,
       favoriteOrder: null,
       vendor: (sessionOpts && sessionOpts.vendor) || null,
@@ -661,7 +665,8 @@ function createSessionManager(opts) {
       history: [],
       messageUUIDs: [],
       ownerId: (sessionOpts && sessionOpts.ownerId) || null,
-      sessionVisibility: (sessionOpts && sessionOpts.sessionVisibility) || "shared",
+      sessionVisibility: sessionVisibility.normalize(sessionOpts && sessionOpts.sessionVisibility),
+      sessionVisibilityExplicit: !!(sessionOpts && sessionOpts.sessionVisibility === "shared"),
       bookmarked: false,
       favoriteOrder: null,
       vendor: (sessionOpts && sessionOpts.vendor) || null,
@@ -916,7 +921,8 @@ function createSessionManager(opts) {
     // Send to active clients without recording to history/disk (ephemeral data)
     if (sendEach) {
       var data = JSON.stringify(obj);
-      sendEach(function (ws) {
+      sendEach(function (ws, filterFn) {
+        if (filterFn && !filterFn(session)) return;
         if (session.homeDebatePlanning === true) return;
         if (ws._clayActiveSession === session.localId && ws.readyState === 1) {
           ws.send(data);
@@ -947,7 +953,8 @@ function createSessionManager(opts) {
       // Multi-user: send to clients whose active session matches this one
       var data = JSON.stringify(outgoingObj);
       var ioData = null;
-      sendEach(function (ws) {
+      sendEach(function (ws, filterFn) {
+        if (filterFn && !filterFn(session)) return;
         if (session.homeDebatePlanning === true) return;
         if (ws._clayActiveSession === session.localId) {
           if (ws.readyState === 1) ws.send(data);
@@ -1290,7 +1297,9 @@ function createSessionManager(opts) {
     setSessionVisibility: function (localId, visibility) {
       var session = sessions.get(localId);
       if (!session) return { error: "Session not found" };
+      if (visibility !== "shared" && visibility !== "private") return { error: "Invalid session visibility" };
       session.sessionVisibility = visibility;
+      session.sessionVisibilityExplicit = true;
       saveSessionFile(session);
       broadcastSessionList();
       return { ok: true };

--- a/lib/users-permissions.js
+++ b/lib/users-permissions.js
@@ -96,8 +96,8 @@ function attachPermissions(deps) {
     }
     // Owner can always see their own sessions
     if (session.ownerId === userId) return true;
-    // Shared sessions are visible to all project members (default)
-    if (!session.sessionVisibility || session.sessionVisibility === "shared") return true;
+    // Sharing is opt-in; missing or invalid visibility stays private.
+    if (session.sessionVisibility === "shared") return true;
     // Private sessions are only visible to the owner
     return false;
   }

--- a/lib/yoke/adapters/claude-worker.js
+++ b/lib/yoke/adapters/claude-worker.js
@@ -424,22 +424,32 @@ async function handleQueryStart(msg) {
   function perf(label) { console.log("[PERF] sdk-worker: " + label + " +" + (Date.now() - t0) + "ms (local +" + (Date.now() - localT0) + "ms)"); }
   perf("handleQueryStart entered");
 
+  // Socket messages keep arriving while the SDK import awaits. Accept input
+  // and cancellation synchronously, before yielding to the next IPC message.
+  messageQueue = createMessageQueue();
+  abortController = new AbortController();
+  if (msg.prompt) messageQueue.push(msg.prompt);
+
   var sdk;
   try {
     perf("loading SDK");
     sdk = await getSDK();
     perf("SDK loaded");
   } catch (e) {
+    messageQueue.end();
+    messageQueue = null;
+    abortController = null;
+    sdkModule = null;
     sendToDaemon({ type: "query_error", error: "Failed to load SDK: " + (e.message || e), exitCode: null, stderr: null });
     return;
   }
 
-  messageQueue = createMessageQueue();
-  abortController = new AbortController();
-
-  // Push the initial user message
-  if (msg.prompt) {
-    messageQueue.push(msg.prompt);
+  if (abortController.signal.aborted) {
+    messageQueue.end();
+    messageQueue = null;
+    abortController = null;
+    sendToDaemon({ type: "query_done" });
+    return;
   }
 
   // Build query options (callbacks are local, everything else from daemon)

--- a/test/claude-worker-startup.test.js
+++ b/test/claude-worker-startup.test.js
@@ -1,0 +1,140 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var path = require("node:path");
+var vm = require("node:vm");
+var EventEmitter = require("node:events");
+
+function loadWorker(relativePath) {
+  var socket = new EventEmitter();
+  var sent = [];
+  socket.write = function(line) {
+    var message = JSON.parse(line);
+    sent.push(message);
+    socket.emit("daemon_message", message);
+  };
+  var filename = path.join(__dirname, "..", relativePath);
+  var context = vm.createContext({
+    require: function(name) {
+      if (name === "net") return { connect: function() { return socket; } };
+      if (name === "fs") return { writeSync: function() {}, existsSync: function() { return false; } };
+      if (name === "child_process") return { execSync: function() { throw new Error("No CLI in test"); } };
+      return require(name);
+    },
+    __dirname: path.dirname(filename),
+    process: { env: {}, argv: ["node", filename, "/test.sock"], pid: 1, on: function() {} },
+    console: { log: function() {}, error: function() {} },
+    AbortController: AbortController,
+    setInterval: function() {},
+    clearInterval: function() {},
+    setTimeout: setTimeout,
+  });
+  vm.runInContext(fs.readFileSync(filename, "utf8"), context, { filename: filename });
+  var resolveSDK;
+  var rejectSDK;
+  context.sdkModule = new Promise(function(resolve, reject) {
+    resolveSDK = resolve;
+    rejectSDK = reject;
+  });
+  var received = [];
+  var signal;
+  var sdk = {
+    query: function(args) {
+      signal = args.options.abortController.signal;
+      return (async function*() {
+        for await (var message of args.prompt) {
+          received.push(message);
+          yield { type: "assistant", message: message };
+        }
+      })();
+    },
+  };
+  return {
+    context: context,
+    sent: sent,
+    received: received,
+    ready: function() { resolveSDK(sdk); },
+    fail: function() { rejectSDK(new Error("SDK unavailable")); },
+    signal: function() { return signal; },
+    send: function(message) { socket.emit("data", Buffer.from(JSON.stringify(message) + "\n")); },
+    sendBatch: function(messages) {
+      socket.emit("data", Buffer.from(messages.map(function(message) {
+        return JSON.stringify(message) + "\n";
+      }).join("")));
+    },
+    done: function() {
+      return new Promise(function(resolve, reject) {
+        socket.on("daemon_message", function(message) {
+          if (message.type === "query_done") resolve();
+          if (message.type === "query_error") reject(new Error(message.error));
+        });
+      });
+    },
+  };
+}
+
+["lib/yoke/adapters/claude-worker.js"].forEach(function(workerPath) {
+  test(workerPath + ": handles query start and first input in one socket chunk", { timeout: 1000 }, async function() {
+    var worker = loadWorker(workerPath);
+    var done = worker.done();
+    worker.sendBatch([
+      { type: "query_start", options: {} },
+      { type: "push_message", content: "first message" },
+      { type: "end_messages" },
+    ]);
+    worker.ready();
+    await done;
+    assert.deepEqual(worker.received, ["first message"]);
+  });
+
+  test(workerPath + ": preserves the first prompt while SDK loading is pending", async function() {
+    var worker = loadWorker(workerPath);
+    var run = worker.context.handleQueryStart({ options: {}, singleTurn: true });
+    worker.send({ type: "push_message", content: { type: "user", message: { role: "user", content: "first" } } });
+    worker.ready();
+    await run;
+    assert.equal(worker.received.length, 1, "first message must reach SDK without a second send");
+    assert.equal(worker.received[0].message.content, "first");
+    assert.equal(worker.sent.at(-1).type, "query_done");
+  });
+
+  test(workerPath + ": preserves ordered messages and end during startup", async function() {
+    var worker = loadWorker(workerPath);
+    var run = worker.context.handleQueryStart({ options: {}, prompt: "initial" });
+    worker.send({ type: "push_message", content: "first" });
+    worker.send({ type: "push_message", content: "second" });
+    worker.send({ type: "end_messages" });
+    worker.ready();
+    await run;
+    assert.deepEqual(worker.received, ["initial", "first", "second"]);
+    // A reused worker must allocate its next queue before even a cached SDK await.
+    run = worker.context.handleQueryStart({ options: {}, singleTurn: true });
+    worker.send({ type: "push_message", content: "next turn" });
+    await run;
+    assert.deepEqual(worker.received, ["initial", "first", "second", "next turn"]);
+  });
+
+  test(workerPath + ": retains Stop received during SDK loading", async function() {
+    var worker = loadWorker(workerPath);
+    var run = worker.context.handleQueryStart({ options: {}, singleTurn: true });
+    worker.send({ type: "abort" });
+    worker.ready();
+    await run;
+    assert.equal(worker.signal(), undefined, "cancelled startup must not invoke the SDK");
+    assert.equal(worker.sent.at(-1).type, "query_done");
+    assert.equal(worker.context.messageQueue, null);
+    assert.equal(worker.context.abortController, null);
+  });
+
+  test(workerPath + ": releases startup state if SDK loading fails", async function() {
+    var worker = loadWorker(workerPath);
+    var run = worker.context.handleQueryStart({ options: {} });
+    worker.send({ type: "push_message", content: "first" });
+    worker.fail();
+    await run;
+    assert.equal(worker.sent.at(-1).type, "query_error");
+    assert.match(worker.sent.at(-1).error, /SDK unavailable/);
+    assert.equal(worker.context.messageQueue, null);
+    assert.equal(worker.context.abortController, null);
+  });
+});

--- a/test/session-visibility.test.js
+++ b/test/session-visibility.test.js
@@ -1,0 +1,112 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var createSessionManager = require("../lib/sessions").createSessionManager;
+var visibility = require("../lib/session-visibility");
+var permissions = require("../lib/users-permissions").attachPermissions({
+  findUserById: function(id) { return { id: id, role: id === "admin" ? "admin" : "member" }; },
+});
+var project = { visibility: "public" };
+
+function fixture(t, extra) {
+  var root = fs.mkdtempSync(path.join(os.tmpdir(), "clay-visibility-"));
+  t.after(function() { fs.rmSync(root, { recursive: true, force: true }); });
+  var options = Object.assign({ cwd: root, sessionsBase: path.join(root, "sessions"), cliSessionsDir: path.join(root, "cli"), send: function() {} }, extra);
+  return { manager: function() { return createSessionManager(options); } };
+}
+
+test("new GUI and raw sessions are private, including admin-created sessions", function(t) {
+  var sm = fixture(t).manager();
+  ["createSession", "createSessionRaw"].forEach(function(method) {
+    ["alice", "admin"].forEach(function(ownerId) {
+      var session = sm[method]({ ownerId: ownerId });
+      assert.equal(session.sessionVisibility, "private");
+      assert.equal(permissions.canAccessSession(ownerId, session, project), true);
+      assert.equal(permissions.canAccessSession("bob", session, project), false);
+    });
+  });
+  assert.equal(sm.mapSessionForClient({ localId: 99 }).sessionVisibility, "private");
+});
+
+test("legacy persisted shared defaults become private without losing ownership or history", function(t) {
+  var f = fixture(t);
+  var sm = f.manager();
+  [undefined, "shared", "private"].forEach(function(value, index) {
+    var id = "legacy-" + index;
+    fs.writeFileSync(path.join(sm.sessionsDir, id + ".jsonl"), [
+      JSON.stringify({ type: "meta", localId: index + 1, cliSessionId: id, ownerId: "alice", sessionVisibility: value, title: "Legacy" }),
+      JSON.stringify({ type: "user_message", text: "Preserved history" }),
+    ].join("\n") + "\n");
+  });
+  var restored = f.manager();
+  assert.equal(restored.sessions.size, 3);
+  restored.sessions.forEach(function(session) {
+    assert.equal(session.sessionVisibility, "private");
+    assert.equal(session.ownerId, "alice");
+    assert.equal(session.history[0].text, "Preserved history");
+    assert.equal(permissions.canAccessSession("bob", session, project), false);
+    assert.equal(permissions.canAccessSession("alice", session, project), true);
+  });
+});
+
+test("explicit sharing and returning to private survive restarts", function(t) {
+  var f = fixture(t);
+  var sm = f.manager();
+  var session = sm.createSessionRaw({ ownerId: "alice" });
+  session.cliSessionId = "explicit-share";
+  sm.setSessionVisibility(session.localId, "shared");
+  var restored = f.manager();
+  var shared = Array.from(restored.sessions.values())[0];
+  assert.equal(shared.sessionVisibility, "shared");
+  assert.equal(permissions.canAccessSession("bob", shared, project), true);
+  restored.setSessionVisibility(shared.localId, "private");
+  assert.equal(Array.from(f.manager().sessions.values())[0].sessionVisibility, "private");
+});
+
+test("missing visibility denies members and ownerless history remains admin-only", function() {
+  assert.equal(permissions.canAccessSession("bob", { ownerId: "alice" }, project), false);
+  assert.equal(permissions.canAccessSession("admin", { ownerId: "alice" }, project), false);
+  assert.equal(permissions.canAccessSession("admin", {}, project), true);
+  assert.equal(permissions.canAccessSession("bob", {}, project), false);
+  assert.equal(permissions.canAccessSession("bob", { sessionVisibility: "shared" }, project), false);
+});
+
+test("only the owner can share; making private revokes a connected viewer", function() {
+  var session = { localId: 1, ownerId: "alice", sessionVisibility: "private" };
+  var changes = [];
+  var closed = [];
+  var viewer = { _clayUser: { id: "bob" }, _clayActiveSession: 1, readyState: 1, close: function() { closed.push("bob"); } };
+  var ctx = {
+    sm: {
+      sessions: new Map([[1, session]]),
+      setSessionVisibility: function(id, value) { changes.push(value); session.sessionVisibility = value; },
+    },
+    usersModule: Object.assign({ isMultiUser: function() { return true; } }, permissions),
+    clients: new Set([viewer]),
+  };
+  ["bob", "admin"].forEach(function(id) {
+    visibility.handleChange(ctx, { _clayUser: { id: id } }, { sessionId: 1, visibility: "shared" });
+  });
+  assert.deepEqual(changes, []);
+  visibility.handleChange(ctx, { _clayUser: { id: "alice" } }, { sessionId: 1, visibility: "shared" });
+  assert.deepEqual(changes, ["shared"]);
+  visibility.handleChange(ctx, { _clayUser: { id: "alice" } }, { sessionId: 1, visibility: "private" });
+  assert.deepEqual(closed, ["bob"]);
+  assert.equal(viewer._clayActiveSession, null);
+});
+
+test("private sessions do not broadcast content or activity to other project members", function(t) {
+  var received = [];
+  var ws = { _clayActiveSession: 1, readyState: 1, send: function(data) { received.push(JSON.parse(data)); } };
+  var sm = fixture(t, { sendEach: function(fn) {
+    fn(ws, function(session) { return permissions.canAccessSession("bob", session, project); });
+  } }).manager();
+  var session = sm.createSessionRaw({ ownerId: "alice" });
+  received.length = 0;
+  session.isProcessing = true;
+  sm.sendToSession(session, { type: "text_delta", text: "secret" });
+  sm.sendAndRecord(session, { type: "assistant", text: "secret" });
+  assert.deepEqual(received, []);
+});


### PR DESCRIPTION
## Changes

Fix two multi-user session failures:

- Claude workers allocate their input queue before awaiting SDK loading, so the first message is retained during startup. Startup cancellation and SDK-load failures clean up correctly.
- New sessions default to Private. Legacy sessions restore as Private, ownerless history remains admin-only, and only the owner can explicitly share a session. Spawned and handoff sessions start private. Returning to Private revokes other active viewers, and session broadcasts enforce access checks.

## Migration

Older records saved `shared` for both the automatic default and deliberate sharing. Without reliable evidence of intent, those records become Private when loaded by the updated daemon. Owners must share them again; subsequent explicit sharing persists across restarts. Ownership and conversation history are preserved.

## Validation

Regression coverage includes delayed SDK startup and batched IPC, worker reuse and cancellation, privacy defaults, legacy migration, sharing persistence, forged visibility changes, and connected-viewer revocation.

Full suite on the PR branch based on current `main`: **1,541 passed, 0 failed** (Node 22.22.1; CommandLineTools Git). `git diff --check` passes. No live Linux deployment test performed.
