### PR TITLE
fix(ui): show visibility badges only for shared sessions

### DIFF
--- a/lib/public/css/admin.css
+++ b/lib/public/css/admin.css
@@ -651,7 +651,7 @@
 }
 
 /* --- Session visibility indicator --- */
-.session-private-icon {
+.session-shared-icon {
   display: inline-flex;
   align-items: center;
   margin-right: 4px;
@@ -659,7 +659,7 @@
   vertical-align: middle;
 }
 
-.session-private-icon svg {
+.session-shared-icon svg {
   width: 12px;
   height: 12px;
 }

--- a/lib/public/modules/sidebar-sessions.js
+++ b/lib/public/modules/sidebar-sessions.js
@@ -1290,8 +1290,8 @@ function renderSessionItem(s, options) {
   if (s.loop && s.loop.source === "debate") {
     textHtml += '<span class="session-debate-icon" title="Debate">' + iconHtml("mic") + '</span>';
   }
-  if (store.get('isMultiUserMode') && s.sessionVisibility !== "shared") {
-    textHtml += '<span class="session-private-icon" title="Private session">' + iconHtml("lock") + '</span>';
+  if (store.get('isMultiUserMode') && s.sessionVisibility === "shared") {
+    textHtml += '<span class="session-shared-icon" title="Shared session" aria-label="Shared session">' + iconHtml("users") + '</span>';
   }
   textHtml += highlightMatch(s.title || "New Session", searchQuery);
   textSpan.innerHTML = textHtml;


### PR DESCRIPTION
Private is the default session state, so private rows now have no visibility icon. Only explicitly Shared sessions display a users badge with a “Shared session” tooltip and accessibility label.

Validation: both existing sidebar UI tests pass on the PR branch, and `git diff --check` passes. This changes presentation only; session access policy is unchanged.
