### PR TITLE
fix(home): restore project bootstrap and default root workspace

### DIFF
--- a/lib/public/modules/home-surface-boot.js
+++ b/lib/public/modules/home-surface-boot.js
@@ -1,4 +1,4 @@
-// One-shot boot routing after durable Home preferences become available.
+// One-shot routing for a server-selected project or the no-project Home fallback.
 import { store } from './store.js';
 import { rememberHomePrimarySurface } from './home-surface.js';
 
@@ -10,9 +10,13 @@ function explicitProjectPath(pathname) {
 }
 
 export function resolveHomeBootDestination(options) {
-  if (!options || options.surfaceLoaded !== true) return "wait";
+  if (!options) return "wait";
   if (options.paneMode || explicitProjectPath(options.pathname)) return "project";
-  if (options.surface === "project" && options.currentSlug) return "project";
+  // The server-selected project embedded in the root shell is authoritative.
+  // Home is entered only through an explicit in-app action; reloading `/`
+  // returns to the project workspace even if Home was the last open surface.
+  if (options.currentSlug) return "project";
+  if (options.surfaceLoaded !== true) return "wait";
   if (options.dockLoaded !== true) return "wait";
   return "home";
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -124,6 +124,14 @@ function stripPrefix(urlPath, slug) {
   return rest || "/";
 }
 
+function injectRootProjectSlug(html, slug) {
+  var bodyPattern = /<body\b([^>]*)>/i;
+  if (!bodyPattern.test(html)) throw new Error("App shell body is missing");
+  return html.replace(bodyPattern, function (_match, attributes) {
+    return '<body' + attributes + ' data-home-project-slug="' + slug + '">';
+  });
+}
+
 /**
  * Create a multi-project server.
  * opts: { tlsOptions, caPath, pinHash, port, debug, dangerouslySkipPermissions }
@@ -741,7 +749,8 @@ function createServer(opts) {
     // --- Skills routes (delegated to server-skills) ---
     if (skills.handleRequest(req, res, fullUrl)) return;
 
-    // Root path — render home while keeping the last accessible project connected.
+    // Root path — render the default project workspace while keeping Home
+    // available as an explicit client-side surface.
     if (fullUrl === "/" && req.method === "GET") {
       if (!isRequestAuthed(req)) {
         res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
@@ -751,11 +760,16 @@ function createServer(opts) {
       if (projects.size > 0) {
         var targetSlug = null;
         var reqUser = users.isMultiUser() ? getMultiUserFromReq(req) : null;
+        function isOrdinaryProject(slug) {
+          var candidate = slug ? projects.get(slug) : null;
+          var status = candidate && candidate.getStatus ? candidate.getStatus() : null;
+          return !!candidate && (!status || status.isMate !== true);
+        }
         var homePreference = typeof users.getHomeSurfacePreference === "function"
           ? users.getHomeSurfacePreference(reqUser ? reqUser.id : "default")
           : null;
         var preferredContextSlug = homePreference && homePreference.projectSlug;
-        if (preferredContextSlug && projects.has(preferredContextSlug)) {
+        if (isOrdinaryProject(preferredContextSlug)) {
           if (reqUser && onGetProjectAccess) {
             var preferredAccess = onGetProjectAccess(preferredContextSlug);
             if (preferredAccess && !preferredAccess.error && users.canAccessProject(reqUser.id, preferredAccess)) {
@@ -767,7 +781,7 @@ function createServer(opts) {
         }
         // Check for last-visited project cookie
         var lastProject = parseCookies(req)["clay_last_project"];
-        if (!targetSlug && lastProject && projects.has(lastProject)) {
+        if (!targetSlug && isOrdinaryProject(lastProject)) {
           if (reqUser && onGetProjectAccess) {
             var lpAccess = onGetProjectAccess(lastProject);
             if (lpAccess && !lpAccess.error && users.canAccessProject(reqUser.id, lpAccess)) {
@@ -781,6 +795,7 @@ function createServer(opts) {
         if (!targetSlug) {
           projects.forEach(function (ctx, s) {
             if (targetSlug) return;
+            if (!isOrdinaryProject(s)) return;
             if (reqUser && onGetProjectAccess) {
               var access = onGetProjectAccess(s);
               if (access && !access.error && users.canAccessProject(reqUser.id, access)) {
@@ -794,7 +809,7 @@ function createServer(opts) {
         if (targetSlug) {
           try {
             var homeHtml = fs.readFileSync(path.join(publicDir, "index.html"), "utf8");
-            homeHtml = homeHtml.replace("<body>", '<body data-home-project-slug="' + targetSlug + '">');
+            homeHtml = injectRootProjectSlug(homeHtml, targetSlug);
             res.writeHead(200, { "Content-Type": "text/html; charset=utf-8", "Cache-Control": "no-cache" });
             res.end(homeHtml);
           } catch (e) {

--- a/test/fixtures/root-project-server.js
+++ b/test/fixtures/root-project-server.js
@@ -1,0 +1,85 @@
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+
+var fixtureHome = fs.mkdtempSync(path.join(os.tmpdir(), "clay-root-project-"));
+process.env.CLAY_HOME = fixtureHome;
+
+var tokens = {
+  visitor: "visitor:integration-token",
+  preferred: "preferred:integration-token",
+  denied: "denied:integration-token",
+  admin: "admin:integration-token",
+};
+
+fs.writeFileSync(path.join(fixtureHome, "users.json"), JSON.stringify({
+  multiUser: true,
+  users: [
+    { id: "visitor", username: "visitor", displayName: "Visitor", role: "user", pinHash: "set" },
+    { id: "preferred", username: "preferred", displayName: "Preferred", role: "user", pinHash: "set", homeSurfacePreference: { surface: "home", projectSlug: "preferred-private" } },
+    { id: "denied", username: "denied", displayName: "Denied", role: "user", pinHash: "set", homeSurfacePreference: { surface: "home", projectSlug: "admin-private" } },
+    { id: "admin", username: "admin", displayName: "Admin", role: "admin", pinHash: "set", homeSurfacePreference: { surface: "home", projectSlug: "mate-clay" } },
+  ],
+  invites: [],
+}));
+
+fs.writeFileSync(path.join(fixtureHome, "auth-tokens.json"), JSON.stringify((function () {
+  var records = {};
+  Object.keys(tokens).forEach(function (userId) { records[tokens[userId]] = userId; });
+  return records;
+})()));
+
+var accessBySlug = {
+  "public-default": { slug: "public-default", visibility: "public", ownerId: "owner", allowedUsers: [] },
+  "preferred-private": { slug: "preferred-private", visibility: "private", ownerId: "owner", allowedUsers: ["preferred"] },
+  "admin-private": { slug: "admin-private", visibility: "private", ownerId: "owner", allowedUsers: [] },
+  "mate-clay": { slug: "mate-clay", visibility: "private", ownerId: "admin", allowedUsers: [] },
+};
+
+var createServer = require("../../lib/server").createServer;
+var relay = createServer({
+  port: 0,
+  onGetProjectAccess: function (slug) {
+    return accessBySlug[slug] || { error: "Project not found" };
+  },
+});
+
+function addProject(slug, title, ownerId, extra) {
+  var directory = path.join(fixtureHome, slug);
+  fs.mkdirSync(directory, { recursive: true });
+  relay.addProject(directory, slug, title, null, ownerId || "owner", null, extra || null);
+}
+
+addProject("public-default", "Public Default");
+addProject("preferred-private", "Preferred Private");
+addProject("admin-private", "Admin Private");
+addProject("mate-clay", "Clay", "admin", { isMate: true, mateId: "clay" });
+
+var closing = false;
+function finish() {
+  try { fs.rmSync(fixtureHome, { recursive: true, force: true }); } catch (e) {}
+  process.exit(0);
+}
+
+function closeFixture() {
+  if (closing) return;
+  closing = true;
+  Promise.resolve(relay.destroyAll()).then(function () { relay.server.close(finish); }).catch(finish);
+  setTimeout(finish, 2000).unref();
+}
+
+process.on("message", function (message) {
+  if (message === "clear-ordinary") {
+    relay.destroyProject("public-default");
+    relay.destroyProject("preferred-private");
+    relay.destroyProject("admin-private");
+    if (process.send) process.send({ clearedOrdinary: true });
+  }
+  if (message === "close") closeFixture();
+});
+process.on("SIGINT", closeFixture);
+process.on("SIGTERM", closeFixture);
+
+relay.server.listen(0, "127.0.0.1", function () {
+  if (process.send) process.send({ port: relay.server.address().port, tokens: tokens });
+});

--- a/test/home-spatial-chat.test.js
+++ b/test/home-spatial-chat.test.js
@@ -100,13 +100,13 @@ test("home shell only toggles reversible project chrome", function () {
   assert.doesNotMatch(appSource, /isHomeHubVisible\(\) && store\.get\('currentSlug'\)/);
 });
 
-test("Cmd+K remains a global conversation search from a direct home load", function () {
+test("Cmd+K remains a global conversation search when Home is explicitly opened", function () {
   assert.match(paletteSource, /document\.addEventListener\("keydown"[\s\S]*\(e\.metaKey \|\| e\.ctrlKey\) && e\.key === "k"/);
   assert.match(paletteSource, /fetch\("\/api\/palette\/search"/);
   assert.doesNotMatch(paletteSource, /ctx\.projectList|cmd-palette-group-label">Projects|entry\.type === "project"/);
   assert.match(paletteSource, /navigateToSession[\s\S]*ctx\.switchProject\(item\.projectSlug\)/);
   assert.match(projectsSource, /if \(homeVisible && alreadyInProject\) \{[\s\S]*hideHomeHub\(\)/);
-  assert.match(serverSource, /Root path — render home while keeping the last accessible project connected/);
+  assert.match(serverSource, /Root path — render the default project workspace/);
   assert.match(serverSource, /Fall back to first accessible project/);
   assert.match(serverSource, /data-home-project-slug/);
 });

--- a/test/home-surface-boot.test.js
+++ b/test/home-surface-boot.test.js
@@ -6,18 +6,19 @@ var pathToFileURL = require("node:url").pathToFileURL;
 
 var root = path.join(__dirname, "..");
 
-test("Home boot precedence keeps explicit projects authoritative and legacy root safe", async function () {
+test("root and explicit project boots default to the project workspace", async function () {
   var boot = await import(pathToFileURL(path.join(root, "lib/public/modules/home-surface-boot.js")).href);
-  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: false }), "wait");
+  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: false, currentSlug: null }), "wait");
   assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: true, surface: "home", currentSlug: "alpha", pathname: "/p/alpha/" }), "project");
   assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: true, surface: "home", currentSlug: "alpha", pathname: "/", paneMode: true }), "project");
+  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: false, dockLoaded: false, surface: "home", currentSlug: "alpha", pathname: "/" }), "project");
   assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: true, surface: "project", currentSlug: "alpha", pathname: "/" }), "project");
-  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: false, surface: "home", currentSlug: "alpha", pathname: "/" }), "wait");
-  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: true, surface: "home", currentSlug: "alpha", pathname: "/" }), "home");
-  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: true, surface: null, currentSlug: "alpha", pathname: "/" }), "home");
+  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: true, surface: "home", currentSlug: "alpha", pathname: "/" }), "project");
+  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: false, surface: "home", currentSlug: null, pathname: "/" }), "wait");
+  assert.equal(boot.resolveHomeBootDestination({ surfaceLoaded: true, dockLoaded: true, surface: "home", currentSlug: null, pathname: "/" }), "home");
 });
 
-test("hard-refresh Home boot waits for durable state then restores once without clobbering it", async function () {
+test("hard-refresh after explicit Home returns to the server-selected project", async function () {
   var originals = { document: global.document, location: global.location, history: global.history };
   var bodyClasses = new Set();
   var overlayClasses = new Set(["hidden"]);
@@ -57,8 +58,11 @@ test("hard-refresh Home boot waits for durable state then restores once without 
       dockLibraryOpen: false,
     });
     boot.initHomeSurfaceBoot();
-    assert.equal(bodyClasses.has("home-surface-boot-pending"), true);
+    assert.equal(bodyClasses.has("home-surface-boot-pending"), false);
     assert.equal(overlayMessage.textContent, "Restoring your workspace…");
+    assert.equal(storeModule.store.get('homeSurfaceBootResolved'), true);
+    assert.equal(storeModule.store.get('homeSurfaceRestoreRequested'), undefined);
+    assert.deepEqual(routes, ["/p/alpha/"]);
     surface.handleHomeSurfaceState({ preference: {
       surface: "home",
       projectSlug: "alpha",
@@ -70,7 +74,7 @@ test("hard-refresh Home boot waits for durable state then restores once without 
     assert.equal(storeModule.store.get('homeSurfaceRestoreRequested'), undefined);
     storeModule.store.set({ homeDockPreferenceLoaded: true });
     assert.equal(storeModule.store.get('homeSurfaceBootResolved'), true);
-    assert.equal(storeModule.store.get('homeSurfaceRestoreRequested'), true);
+    assert.equal(storeModule.store.get('homeSurfaceRestoreRequested'), undefined);
     assert.equal(storeModule.store.get('homePreferredMateId'), "mate-a");
     assert.deepEqual(storeModule.store.get('homeActiveSessionByMate'), { "mate-a": "session-a" });
     assert.equal(storeModule.store.get('homeSidebarCollapsed'), true);
@@ -79,15 +83,15 @@ test("hard-refresh Home boot waits for durable state then restores once without 
     assert.equal(storeModule.store.get('dockFocus'), true);
     assert.equal(storeModule.store.get('dockActiveToolId'), "translator");
     assert.equal(bodyClasses.has("home-surface-boot-pending"), false);
-    assert.deepEqual(routes, []);
+    assert.deepEqual(routes, ["/p/alpha/"]);
     surface.handleHomeSurfaceState({ preference: {
       surface: "home", projectSlug: "alpha", activeMateId: "mate-a",
       activeSessionByMate: { "mate-a": "session-a" }, sidebarCollapsed: true,
       chatScope: "current",
     } });
     assert.equal(storeModule.store.get('homeSurfaceBootResolved'), true);
-    assert.equal(storeModule.store.get('homeSurfaceRestoreRequested'), true);
-    assert.deepEqual(routes, []);
+    assert.equal(storeModule.store.get('homeSurfaceRestoreRequested'), undefined);
+    assert.deepEqual(routes, ["/p/alpha/"]);
   } finally {
     global.document = originals.document;
     global.location = originals.location;
@@ -112,5 +116,6 @@ test("Home entry, Return, and initial restoration use the existing preference pa
   assert.match(surface, /homeActiveSessionByMate: normalizeSessions\(preference\.activeSessionByMate\)/);
   assert.match(surface, /homeChatScope: normalizeChatScope\(preference\.chatScope\)/);
   assert.match(dock, /homeDockPreferenceLoaded: true[\s\S]*dockActiveToolId: saved\.activeToolId \|\| null[\s\S]*dockFocus: saved\.dockOpen === true && saved\.dockFocus === true/);
-  assert.match(server, /getHomeSurfacePreference[\s\S]*preferredContextSlug[\s\S]*projects\.has\(preferredContextSlug\)[\s\S]*if \(!targetSlug && lastProject/);
+  assert.match(server, /getHomeSurfacePreference[\s\S]*preferredContextSlug[\s\S]*isOrdinaryProject\(preferredContextSlug\)[\s\S]*if \(!targetSlug && isOrdinaryProject\(lastProject\)\)/);
+  assert.match(server, /injectRootProjectSlug\(homeHtml, targetSlug\)/);
 });

--- a/test/root-project-server.test.js
+++ b/test/root-project-server.test.js
@@ -1,0 +1,81 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var path = require("node:path");
+var fork = require("node:child_process").fork;
+
+function startFixture() {
+  return new Promise(function (resolve, reject) {
+    var child = fork(path.join(__dirname, "fixtures/root-project-server.js"), [], { stdio: ["ignore", "ignore", "pipe", "ipc"] });
+    var errors = "";
+    child.stderr.on("data", function (chunk) { errors += chunk.toString(); });
+    child.once("error", reject);
+    child.on("message", function onReady(message) {
+      if (!message || !message.port) return;
+      child.removeListener("message", onReady);
+      resolve({ child: child, port: message.port, tokens: message.tokens, errors: function () { return errors; } });
+    });
+  });
+}
+
+function requestRoot(fixture, userId, lastProject) {
+  var cookie = "relay_auth_user=" + fixture.tokens[userId];
+  if (lastProject) cookie += "; clay_last_project=" + lastProject;
+  return fetch("http://127.0.0.1:" + fixture.port + "/", {
+    headers: { Cookie: cookie },
+    redirect: "manual",
+  });
+}
+
+function waitForChild(child, key) {
+  return new Promise(function (resolve, reject) {
+    var timer = setTimeout(function () { reject(new Error("Timed out waiting for fixture")); }, 5000);
+    child.on("message", function onMessage(message) {
+      if (!message || !message[key]) return;
+      clearTimeout(timer);
+      child.removeListener("message", onMessage);
+      resolve(message);
+    });
+  });
+}
+
+function expectedRootBody(slug) {
+  return new RegExp('<body class="capsules-disabled" data-home-project-slug="' + slug + '">');
+}
+
+test("root project routing uses the real authenticated app shell", async function (t) {
+  var fixture = await startFixture();
+  t.after(function () { if (fixture.child.connected) fixture.child.send("close"); });
+
+  await t.test("authenticated root chooses an ordinary project", async function () {
+    var response = await requestRoot(fixture, "visitor");
+    var html = await response.text();
+    assert.equal(response.status, 200);
+    assert.match(html, expectedRootBody("public-default"));
+  });
+
+  await t.test("saved Home state keeps its accessible preferred project context", async function () {
+    var response = await requestRoot(fixture, "preferred");
+    assert.match(await response.text(), expectedRootBody("preferred-private"));
+  });
+
+  await t.test("denied saved preference falls back to an accessible project", async function () {
+    var response = await requestRoot(fixture, "denied");
+    assert.match(await response.text(), expectedRootBody("public-default"));
+  });
+
+  await t.test("admin skips a preferred Mate and can use a private project", async function () {
+    var response = await requestRoot(fixture, "admin", "admin-private");
+    assert.match(await response.text(), expectedRootBody("admin-private"));
+  });
+
+  await t.test("only a Mate remaining falls back to the unbound app shell", async function () {
+    var cleared = waitForChild(fixture.child, "clearedOrdinary");
+    fixture.child.send("clear-ordinary");
+    await cleared;
+    var response = await requestRoot(fixture, "admin");
+    var html = await response.text();
+    assert.equal(response.status, 200);
+    assert.match(html, /<body class="capsules-disabled">/);
+    assert.doesNotMatch(html, /data-home-project-slug=/);
+  });
+}, { timeout: 20000 });


### PR DESCRIPTION
Opening `/` could leave users on Home with an ineffective Close button: the server injected the selected project by replacing `<body>`, but the app shell now has a body class. The replacement silently failed, leaving the client on `/ws` without a project destination.

Preserve body attributes when injecting the selected project, select only authorized ordinary projects, and make root loads open the project workspace even when Home was previously saved as the visible surface. Explicit Home opening and Close remain available; users without an ordinary project retain the Home fallback.

Validation:
- Live HTTP regressions use the actual app shell and cover saved preferences, access filtering, admin Mate exclusion, and no ordinary project.
- Real local Chromium checks passed for root load, explicit Home, Close, reload, and admin fallback.
- The reported remote instance timed out from the test environment; it was not deployed or restarted.
- All 1,552 tests passed on this branch based on current main.
