### PR TITLE
fix(worker): restore durable identity and accurate usage

### DIFF
--- a/lib/project-pair-lifecycle.js
+++ b/lib/project-pair-lifecycle.js
@@ -86,22 +86,47 @@ function attachPairLifecycle(ctx) {
   var store = ctx.splitStore;
   var turnControl = ctx.turnControl;
 
-  // Per-Driver ledger of the Worker generations it has run, newest last.
-  // Lives on the live Driver session object: it informs the Driver's next
-  // choice within this session and is deliberately not persisted, because a
-  // bounded observation of a session that no longer exists would only be
-  // misleading after a restart.
   function ledgerFor(driver) {
     if (!Array.isArray(driver._workerGenerations)) driver._workerGenerations = [];
+    var group = store.groupForMember(driver.localId);
+    var worker = group && group.pair && sm.sessions.get(group.pair.workerId);
+    var generation = worker && (worker._pairGeneration || worker.sessionProvenance && worker.sessionProvenance.generation);
+    if (worker && Number.isInteger(generation) && generation > 0 && !findGeneration(driver, worker)) {
+      driver._workerGenerations.push({
+        generation: generation,
+        workerSessionId: worker.localId,
+        workerOriginId: worker.sessionOriginId || null,
+        vendor: worker.vendor || null,
+        model: worker.model || null,
+        effort: worker.effort || null,
+        startedAt: worker.sessionProvenance && worker.sessionProvenance.createdAt || Date.now(),
+        endedAt: null,
+        observed: null,
+        evaluation: null,
+      });
+      while (driver._workerGenerations.length > MAX_GENERATIONS) driver._workerGenerations.shift();
+    }
     return driver._workerGenerations;
   }
-
   function recordGenerationStart(driver, worker) {
     var ledger = ledgerFor(driver);
-    var generation = ledger.length + 1;
+    var existing = findGeneration(driver, worker);
+    if (existing && !existing.endedAt) {
+      worker._pairGeneration = existing.generation;
+      return existing.generation;
+    }
+    var generation = 1;
+    for (var i = 0; i < ledger.length; i++) {
+      if (Number.isInteger(ledger[i].generation) && ledger[i].generation >= generation) generation = ledger[i].generation + 1;
+    }
+    if (worker.sessionProvenance && Number.isInteger(worker.sessionProvenance.generation) &&
+        worker.sessionProvenance.generation >= generation) {
+      generation = worker.sessionProvenance.generation;
+    }
     ledger.push({
       generation: generation,
       workerSessionId: worker.localId,
+      workerOriginId: worker.sessionOriginId || null,
       vendor: worker.vendor || null,
       model: worker.model || null,
       effort: worker.effort || null,
@@ -112,21 +137,38 @@ function attachPairLifecycle(ctx) {
     });
     while (ledger.length > MAX_GENERATIONS) ledger.shift();
     worker._pairGeneration = generation;
+    if (worker.sessionProvenance) worker.sessionProvenance.generation = generation;
+    if (typeof sm.saveSessionFile === "function") {
+      sm.saveSessionFile(driver);
+      sm.saveSessionFile(worker);
+    }
     return generation;
   }
-
-  function findGeneration(driver, workerSessionId) {
-    var ledger = ledgerFor(driver);
+  function findGeneration(driver, worker) {
+    var ledger = Array.isArray(driver._workerGenerations) ? driver._workerGenerations : [];
+    var originId = worker && worker.sessionOriginId || null;
     for (var i = ledger.length - 1; i >= 0; i--) {
-      if (ledger[i].workerSessionId === workerSessionId) return ledger[i];
+      if (originId && ledger[i].workerOriginId === originId) {
+        ledger[i].workerSessionId = worker.localId;
+        return ledger[i];
+      }
     }
-    return null;
+    if (!worker || !originId) return null;
+    var generation = worker._pairGeneration || worker.sessionProvenance && worker.sessionProvenance.generation;
+    if (!Number.isInteger(generation) || generation < 1) return null;
+    var candidates = [];
+    for (var j = 0; j < ledger.length; j++) {
+      if (!ledger[j].workerOriginId && ledger[j].generation === generation) candidates.push(ledger[j]);
+    }
+    if (candidates.length !== 1) return null;
+    candidates[0].workerOriginId = originId;
+    candidates[0].workerSessionId = worker.localId;
+    if (typeof sm.saveSessionFile === "function") sm.saveSessionFile(driver);
+    return candidates[0];
   }
-
-  // Objective signals the server already has. Recorded when a generation ends
-  // so the Driver's next decision can use them without a transcript.
   function closeGeneration(driver, worker) {
-    var record = findGeneration(driver, worker.localId);
+    ledgerFor(driver);
+    var record = findGeneration(driver, worker);
     if (!record || record.endedAt) return record;
     var continuity = continuityStatus(worker);
     var context = contextStatus(worker);
@@ -138,10 +180,9 @@ function attachPairLifecycle(ctx) {
       usedTokens: context.current.usedTokens,
       usedRatio: context.current.usedRatio,
     };
+    if (typeof sm.saveSessionFile === "function") sm.saveSessionFile(driver);
     return record;
   }
-
-  // The exact pair, with the Driver's structural capability re-checked on every call.
   function resolveDriverPair(caller) {
     if (!caller) throw new Error("pair lifecycle tools require a session-bound tool server");
     // Exact live object identity, before anything is read off the caller. A
@@ -169,8 +210,6 @@ function attachPairLifecycle(ctx) {
     return null;
   }
 
-  // Bounded status for the reuse-vs-replace decision. Exact pair only; no
-  // other user's data and no transcript.
   function partnerStatus(caller) {
     var resolved = resolveDriverPair(caller);
     var worker = resolved.worker;
@@ -229,15 +268,11 @@ function attachPairLifecycle(ctx) {
     };
   }
 
-  // Transactional replacement. Rejects an active Worker unless interrupt is
-  // explicitly true, cancels anything the old Worker was waiting on, dissolves
-  // the exact pair without deleting history, and creates a fresh Worker.
-  // Idempotent in the sense that it either completes or leaves the existing
-  // pair untouched; it never half-dissolves.
   function replacePartner(args, caller) {
     var resolved = resolveDriverPair(caller);
     var group = resolved.group;
     var oldWorker = resolved.worker;
+    ledgerFor(caller);
     turnControl.assertWorkerAction(caller);
     var replacementEntry = replacementState.begin(caller, args.transactionId, oldWorker, replacementFingerprint(args, oldWorker));
     var replay = replacementState.replayValue(replacementEntry);
@@ -344,7 +379,10 @@ function attachPairLifecycle(ctx) {
         ". " + restoreNote + interruptNote);
     }
     var closed = closeGeneration(caller, oldWorker);
-    if (closed && args.evaluation) applyEvaluation(closed, args.evaluation);
+    if (closed && args.evaluation) {
+      applyEvaluation(closed, args.evaluation);
+      if (typeof sm.saveSessionFile === "function") sm.saveSessionFile(caller);
+    }
     var generation = recordGenerationStart(caller, created.worker);
 
     var result = {
@@ -372,17 +410,15 @@ function attachPairLifecycle(ctx) {
       });
   }
 
-  // Shape check only; writes nothing. Lets a caller that is about to destroy
-  // something reject a malformed assessment first.
+  // No global or cross-user ranking is formed from Worker evaluations.
   function validateEvaluation(raw) {
-    var input = raw && typeof raw === "object" ? raw : {};
+    var input = typeof raw === "string" ? { outcome: raw } : (raw && typeof raw === "object" ? raw : {});
     var outcome = typeof input.outcome === "string" ? input.outcome.trim().toLowerCase() : "";
     if (EVALUATION_OUTCOMES.indexOf(outcome) === -1) {
       throw new Error('evaluation outcome must be one of: ' + EVALUATION_OUTCOMES.join(", "));
     }
     return { outcome: outcome, note: clampText(input.note, MAX_NOTE_CHARS) };
   }
-
   function applyEvaluation(record, raw) {
     var clean = validateEvaluation(raw);
     record.evaluation = {
@@ -393,23 +429,20 @@ function attachPairLifecycle(ctx) {
     return record.evaluation;
   }
 
-  // Attach a bounded assessment to one exact Worker generation. The Driver
-  // supplies the judgement; the server supplies the objective observations and
-  // refuses anything outside the enum. No global or cross-user ranking is
-  // formed from this.
   function recordEvaluation(args, caller) {
     var resolved = resolveDriverPair(caller);
+    var ledger = ledgerFor(caller);
     var target = Number.isInteger(args.generation)
       ? (function () {
-        var ledger = ledgerFor(caller);
         for (var i = 0; i < ledger.length; i++) {
           if (ledger[i].generation === args.generation) return ledger[i];
         }
         return null;
       })()
-      : findGeneration(caller, resolved.worker.localId);
+      : findGeneration(caller, resolved.worker);
     if (!target) throw new Error("no such Split Worker generation for this Driver");
     var evaluation = applyEvaluation(target, args);
+    if (typeof sm.saveSessionFile === "function") sm.saveSessionFile(caller);
     return {
       status: "recorded",
       generation: target.generation,
@@ -420,11 +453,6 @@ function attachPairLifecycle(ctx) {
     };
   }
 
-  // Tool handlers for the three lifecycle tools, with this module's own error
-  // shaping. Kept here so the pair coordinator only wires names to handlers.
-  // partnerStatus, or null when this session cannot legitimately ask for it.
-  // Lets read_partner fold the capacity report in without duplicating the
-  // guard chain or swallowing errors inline at the call site.
   function optionalStatus(boundSession) {
     try { return partnerStatus(boundSession); } catch (e) { return null; }
   }

--- a/lib/project-pair-usage.js
+++ b/lib/project-pair-usage.js
@@ -52,14 +52,17 @@ function contextStatus(session) {
     if (input !== null) { cumulativeInput += input; observedInput = true; }
     if (output !== null) { cumulativeOutput += output; observedOutput = true; }
     results++;
-    lastTask = { inputTokens: input, outputTokens: output, currentInputTokens: firstNumber(item.lastStreamInputTokens) };
+    lastTask = { inputTokens: input, outputTokens: output, currentInputTokens: null };
     var observedWindow = matchingWindow(item.modelUsage, session.model);
     if (observedWindow !== null) window = observedWindow;
   }
-  if (used === null && lastTask && lastTask.currentInputTokens !== null) {
-    used = lastTask.currentInputTokens;
-    source = "last_stream_input";
+  if (used !== null && window !== null && used > window) {
+    used = null;
+    source = "unavailable";
   }
+  // Older result records contain lastStreamInputTokens, but that field was
+  // populated from adapter snapshots that could be cumulative or inflated by
+  // cache accounting. It is not safe evidence of current context occupancy.
   var ratio = used !== null && window !== null && window > 0 ? Math.min(1, Math.round((used / window) * 1000) / 1000) : null;
   return {
     current: { source: source, usedTokens: used, windowTokens: window, usedRatio: ratio,

--- a/lib/project-worker-proposal.js
+++ b/lib/project-worker-proposal.js
@@ -6,6 +6,18 @@ var driverOrchestration = require("./session-driver-orchestration");
 var proposalControl = require("./worker-proposal-control");
 var runtimeCatalog = require("./worker-runtime-catalog");
 var MAX_SUMMARY_CHARS = 600, MAX_PLAN_CHARS = 6000, MAX_TASK_CHARS = 30000, MAX_RATIONALE_CHARS = 1000;
+var EVALUATION_OUTCOMES = ["succeeded", "partial", "failed", "abandoned"];
+function normalizeEvaluation(raw) {
+  if (raw == null) return null;
+  var input = typeof raw === "string" ? { outcome: raw } : raw;
+  if (!input || typeof input !== "object") return { error: "evaluation must be an outcome string or object" };
+  var outcome = typeof input.outcome === "string" ? input.outcome.trim().toLowerCase() : "";
+  if (EVALUATION_OUTCOMES.indexOf(outcome) === -1) {
+    return { error: "evaluation outcome must be one of: " + EVALUATION_OUTCOMES.join(", ") };
+  }
+  var note = typeof input.note === "string" ? input.note.replace(/\s+/g, " ").trim().slice(0, 400) : "";
+  return { value: { outcome: outcome, note: note } };
+}
 function modelValue(entry) {
   if (typeof entry === "string") return entry;
   return entry && (entry.value || entry.id) || "";
@@ -227,6 +239,8 @@ function attachWorkerProposal(ctx) {
     if (!task) return toolResult({ error: "message is required so an accepted replacement delegates exactly once." });
     if (!rationale) return toolResult({ error: "recommendationRationale is required for the replacement audit trail." });
     if (task.length > MAX_TASK_CHARS) return toolResult({ error: "The Split Worker task is too long." });
+    var normalizedEvaluation = normalizeEvaluation(args.evaluation);
+    if (normalizedEvaluation && normalizedEvaluation.error) return toolResult({ error: normalizedEvaluation.error });
     await ensureModelCatalogs();
     var liveGroup = store.groupForMember(session.localId);
     if (!isLiveSession(session) || !driverEligibility.isEligibleDriverSession(session, sm) ||
@@ -261,7 +275,7 @@ function attachWorkerProposal(ctx) {
       sourceGroupId: sourceGroupId,
       sourceWorkerId: sourceWorkerId,
       interrupt: args.interrupt === true,
-      evaluation: args.evaluation || null,
+      evaluation: normalizedEvaluation ? normalizedEvaluation.value : null,
       transactionId: "replace_" + crypto.randomUUID(),
     };
     if (superseded) updateProposal(session, superseded, { status: "superseded", supersededBy: proposal.proposalId });

--- a/lib/session-pair-mcp-server.js
+++ b/lib/session-pair-mcp-server.js
@@ -1,6 +1,12 @@
 // Partner-control tools for sessions that belong to a split group.
 
 var buildShape = require("./session-spawn-mcp-server").buildShape;
+var z;
+try { z = require("zod"); } catch (e) { z = null; }
+var evaluationSchema = z ? z.union([
+  z.string(),
+  z.object({ outcome: z.string(), note: z.string().optional() }),
+]) : null;
 
 // `options.lifecycle` adds the autonomous management tools. They are omitted
 // for a plain side-by-side split, which has no Driver role to exercise them.
@@ -68,7 +74,7 @@ function getToolDefs(handlers, options) {
         workerEffort: { type: "string", description: "Optional reasoning effort for the new Worker." },
         recommendationRationale: { type: "string", description: "Concise Driver-authored explanation of why the recommended replacement vendor, model, and effort fit the next task." },
         evaluation: {
-          type: "object",
+          schema: evaluationSchema,
           description: "Optional bounded assessment of the Worker being replaced, recorded against that exact generation.",
         },
         operationId: { type: "string", description: "Optional stable id for this replacement. Reusing it within the same human turn returns the original operation instead of replacing twice." },

--- a/lib/session-provenance.js
+++ b/lib/session-provenance.js
@@ -69,6 +69,7 @@ function restore(meta, session) {
     createdVia: stored.createdVia === "split-worker" ? "split-worker" : null,
     createdAt: typeof stored.createdAt === "number" && isFinite(stored.createdAt) ? stored.createdAt : null,
   };
+  session._pairGeneration = session.sessionProvenance.generation;
   return storedOriginId !== session.sessionOriginId || JSON.stringify(stored) !== JSON.stringify(session.sessionProvenance);
 }
 

--- a/lib/session-spawn-mcp-server.js
+++ b/lib/session-spawn-mcp-server.js
@@ -12,7 +12,8 @@ function buildShape(props, required) {
     var key = keys[i];
     var prop = props[key];
     var field;
-    if (prop.type === "number") field = z.number();
+    if (prop.schema) field = prop.schema;
+    else if (prop.type === "number") field = z.number();
     else if (prop.type === "boolean") field = z.boolean();
     else if (prop.enum) field = z.enum(prop.enum);
     else field = z.string();

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -186,6 +186,7 @@ function createSessionManager(opts) {
       var provenanceMeta = sessionProvenance.metadata(session);
       metaObj.sessionOriginId = provenanceMeta.sessionOriginId;
       if (provenanceMeta.sessionProvenance) metaObj.sessionProvenance = provenanceMeta.sessionProvenance;
+      if (Array.isArray(session._workerGenerations)) metaObj.workerGenerations = session._workerGenerations;
       var meta = JSON.stringify(metaObj);
       var lines = [meta];
       for (var i = 0; i < session.history.length; i++) {
@@ -308,6 +309,7 @@ function createSessionManager(opts) {
       if (m.ownerId) session.ownerId = m.ownerId;
       session.sessionOriginId = m.sessionOriginId || null;
       session._provenanceMigrationNeeded = sessionProvenance.restore(m, session);
+      if (Array.isArray(m.workerGenerations)) session._workerGenerations = m.workerGenerations;
       // Born-TUI session: PTY is gone after restart, but the cliSessionId
       // is still resumable via `claude --resume <id>`. We mark the mode
       // here so it shows up in the sidebar with the right icon; the

--- a/lib/yoke/adapters/codex.js
+++ b/lib/yoke/adapters/codex.js
@@ -193,7 +193,8 @@ function flattenEvent(notification, state) {
     if (turnStatus === "interrupted" || state.aborted) {
       events.push({ yokeType: "interrupted" });
     }
-    var inputTokens = state.lastInputTokens || (usage ? (usage.input_tokens || 0) + (usage.cached_input_tokens || 0) : 0);
+    var inputTokens = state.lastInputTokens !== null && state.lastInputTokens !== undefined
+      ? state.lastInputTokens : (usage ? (usage.input_tokens || 0) : 0);
     var outputTokens = (usage ? (usage.output_tokens || 0) : 0) || state.lastOutputTokens || 0;
     var cachedTokens = (usage ? (usage.cached_input_tokens || 0) : 0) || state.lastCachedTokens || 0;
     var hasTokenData = inputTokens > 0 || outputTokens > 0;
@@ -217,7 +218,7 @@ function flattenEvent(notification, state) {
       } : null,
       modelUsage: resultModelUsage,
       sessionId: state.threadId || null,
-      lastStreamInputTokens: state.lastInputTokens || null,
+      lastStreamInputTokens: null,
     });
     state.lastInputTokens = null;
     state.lastCachedTokens = null;
@@ -675,15 +676,28 @@ function flattenEvent(notification, state) {
   // context gauge must use the LAST turn, not the running total: each turn's
   // input already contains the whole conversation, so summing turns
   // overstates occupancy (a 5k + 8k thread reads as 13k of an 8k context).
-  // `total` is only a fallback for servers that omit lastTurn.
+  // A missing lastTurn is not evidence of current context occupancy. The
+  // protocol's total is cumulative across the thread and must never be used
+  // as the context gauge.
   if (method === "thread/tokenUsage/updated") {
     var tu = params.tokenUsage;
     if (tu) {
-      var turnUsage = tu.lastTurn || tu.total;
+      var turnUsage = tu.lastTurn;
       if (turnUsage) {
-        state.lastInputTokens = (turnUsage.inputTokens || 0) + (turnUsage.cachedInputTokens || 0);
+        var candidateInput = typeof turnUsage.inputTokens === "number" ? turnUsage.inputTokens : null;
+        var currentWindow = typeof tu.modelContextWindow === "number" ? tu.modelContextWindow : null;
+        state.lastInputTokens = candidateInput !== null && (currentWindow === null || candidateInput <= currentWindow) ? candidateInput : null;
         state.lastCachedTokens = turnUsage.cachedInputTokens || 0;
         state.lastOutputTokens = turnUsage.outputTokens || 0;
+        state.currentContextUsage = state.lastInputTokens !== null &&
+          (currentWindow === null || state.lastInputTokens <= currentWindow)
+          ? { input_tokens: state.lastInputTokens, contextWindow: currentWindow }
+          : { input_tokens: null, contextWindow: currentWindow };
+      } else {
+        state.lastInputTokens = null;
+        state.lastCachedTokens = null;
+        state.lastOutputTokens = null;
+        state.currentContextUsage = null;
       }
       if (tu.modelContextWindow) state.modelContextWindow = tu.modelContextWindow;
     }
@@ -734,6 +748,7 @@ function createEventState(model) {
     lastInputTokens: null,
     lastCachedTokens: null,
     lastOutputTokens: null,
+    currentContextUsage: null,
     modelContextWindow: null,
     done: false,
     aborted: false,
@@ -1107,6 +1122,9 @@ function createCodexQueryHandle(appServer, queryOpts) {
 
       var threadResult;
       if (queryOpts.resumeSessionId) {
+        // ThreadResumeParams in the installed app-server schema has no
+        // dynamicTools field. New tools therefore require a new Driver/Worker
+        // thread; resumed threads can only refresh handlers for persisted tools.
         threadResult = await appServer.send("thread/resume", {
           threadId: queryOpts.resumeSessionId,
           model: threadParams.model,
@@ -1269,11 +1287,7 @@ function createCodexQueryHandle(appServer, queryOpts) {
     },
 
     getContextUsage: function() {
-      if (state.lastInputTokens == null && state.modelContextWindow == null) return Promise.resolve(null);
-      return Promise.resolve({
-        input_tokens: state.lastInputTokens == null ? null : state.lastInputTokens,
-        contextWindow: state.modelContextWindow || null,
-      });
+      return Promise.resolve(state.currentContextUsage);
     },
 
     abort: function() {

--- a/test/codex-dynamic-tools.test.js
+++ b/test/codex-dynamic-tools.test.js
@@ -84,3 +84,52 @@ test("Codex registers and executes session-bound dynamic tools", async function 
     result: { contentItems: [{ type: "inputText", text: "Worker complete" }], success: true },
   }]);
 });
+
+test("Codex does not send unsupported dynamicTools on thread/resume", async function () {
+  var calls = [];
+  var server = {
+    started: true,
+    addHandler: function () { return { threadId: null, fn: function () {} }; },
+    removeHandler: function () {},
+    send: function (method, params) {
+      calls.push({ method: method, params: params });
+      if (method === "thread/resume") return Promise.resolve({ thread: { id: "resumed" } });
+      if (method === "turn/start") return Promise.resolve({});
+      return Promise.resolve({});
+    },
+  };
+  var handle = codexModule.contractTestKit.createQueryHandle(server, {
+    cwd: process.cwd(), model: "gpt-test", resumeSessionId: "resumed",
+    dynamicTools: [{ name: "new_tool", inputSchema: { type: "object" } }],
+    abortController: new AbortController(),
+  });
+  handle.pushMessage("Continue");
+  await new Promise(function (resolve) { setImmediate(resolve); });
+  handle.close();
+  var resume = calls.filter(function (call) { return call.method === "thread/resume"; })[0];
+  assert.ok(resume);
+  assert.equal(Object.prototype.hasOwnProperty.call(resume.params, "dynamicTools"), false,
+    "the installed protocol does not define dynamicTools for thread/resume");
+});
+
+test("Codex context accounting separates verified last-turn input from cumulative and cache totals", async function () {
+  var kit = codexModule.contractTestKit;
+  var state = kit.createEventState("gpt-test");
+  kit.normalizeEvent({ method: "thread/tokenUsage/updated", params: {
+    tokenUsage: { lastTurn: { inputTokens: 100, cachedInputTokens: 900, outputTokens: 5 }, total: { inputTokens: 99999 }, modelContextWindow: 1000 },
+  } }, state);
+  assert.equal(state.lastInputTokens, 100);
+  assert.deepEqual(state.currentContextUsage, { input_tokens: 100, contextWindow: 1000 });
+
+  kit.normalizeEvent({ method: "thread/tokenUsage/updated", params: {
+    tokenUsage: { total: { inputTokens: 99999 }, modelContextWindow: 1000 },
+  } }, state);
+  assert.equal(state.lastInputTokens, null, "a total-only update clears stale turn usage");
+  assert.equal(state.currentContextUsage, null);
+
+  kit.normalizeEvent({ method: "thread/tokenUsage/updated", params: {
+    tokenUsage: { lastTurn: { inputTokens: 5000 }, modelContextWindow: 1000 },
+  } }, state);
+  assert.equal(state.lastInputTokens, null, "an impossible snapshot is not trusted");
+  assert.deepEqual(state.currentContextUsage, { input_tokens: null, contextWindow: 1000 });
+});

--- a/test/pair-lifecycle.test.js
+++ b/test/pair-lifecycle.test.js
@@ -330,7 +330,7 @@ test("status separates current context from cumulative and last-task usage", asy
   assert.deepEqual(status.context.compactions, { observedCount: 0, active: false, lastObservedAt: null, scope: "loaded_session_history", complete: false });
 });
 
-test("status uses an exact last-stream reading and reports observed compactions", async function (t) {
+test("status distrusts legacy stream readings and reports observed compactions", async function (t) {
   var world = makeWorld();
   t.after(world.dispose);
   await makePair(world);
@@ -339,9 +339,28 @@ test("status uses an exact last-stream reading and reports observed compactions"
   worker.history.push({ type: "compacting", active: false, _ts: 200 });
   worker.history.push({ type: "result", usage: { input_tokens: 300, output_tokens: 20 }, lastStreamInputTokens: 175 });
   var status = parse(await world.tool("partner_status").handler({}));
-  assert.equal(status.context.current.source, "last_stream_input");
-  assert.equal(status.context.current.usedTokens, 175);
+  assert.equal(status.context.current.source, "unavailable");
+  assert.equal(status.context.current.usedTokens, null);
   assert.deepEqual(status.context.compactions, { observedCount: 1, active: false, lastObservedAt: 200, scope: "loaded_session_history", complete: false });
+});
+
+test("status rejects a current snapshot that exceeds its context window", function () {
+  var context = require("../lib/project-pair-lifecycle").contextStatus({
+    vendor: "codex", lastContextUsage: { input_tokens: 1200, contextWindow: 1000 }, history: [],
+  });
+  assert.equal(context.current.usedTokens, null);
+  assert.equal(context.current.source, "unavailable");
+  assert.equal(context.current.usedRatio, null);
+});
+
+test("status validates a snapshot after history supplies the context window", function () {
+  var context = require("../lib/project-pair-lifecycle").contextStatus({
+    vendor: "codex", model: "model-a", lastContextUsage: { input_tokens: 1200, contextWindow: null },
+    history: [{ type: "result", usage: null, modelUsage: { "model-a": { contextWindow: 1000 } } }],
+  });
+  assert.equal(context.current.usedTokens, null);
+  assert.equal(context.current.windowTokens, 1000);
+  assert.equal(context.current.usedRatio, null);
 });
 
 test("status uses the latest matching model window and leaves missing usage unknown", function () {
@@ -695,6 +714,52 @@ test("a recorded evaluation is bounded and comes back through status", async fun
   assert.equal(status.generations[0].vendor, "codex");
 });
 
+test("restored provenance reconstructs an active generation and preserves monotonic history", async function (t) {
+  var world = makeWorld();
+  t.after(world.dispose);
+  await makePair(world);
+  var worker = world.worker();
+  worker._pairGeneration = 12;
+  worker.sessionProvenance = { kind: "worker", generation: 12, createdAt: 10 };
+  world.driver._workerGenerations = [];
+  for (var i = 1; i <= 8; i++) {
+    world.driver._workerGenerations.push({ generation: i, workerSessionId: 100 + i, endedAt: 1, evaluation: null });
+  }
+  var status = parse(await world.tool("partner_status").handler({}));
+  assert.equal(status.worker.generation, 12);
+  assert.equal(status.generations.length, 5);
+  assert.equal(status.generations[status.generations.length - 1].generation, 12);
+  var evaluation = parse(await world.tool("record_partner_evaluation").handler({ outcome: "succeeded" }));
+  assert.equal(evaluation.generation, 12);
+  assert.equal(world.driver._workerGenerations[world.driver._workerGenerations.length - 1].evaluation.outcome, "succeeded");
+});
+
+test("first evaluation reconciles an empty restored ledger from Worker provenance", async function (t) {
+  var world = makeWorld();
+  t.after(world.dispose);
+  await makePair(world);
+  var worker = world.worker();
+  world.driver._workerGenerations = [];
+  var result = parse(await world.tool("record_partner_evaluation").handler({ outcome: "partial" }));
+  assert.equal(result.generation, worker.sessionProvenance.generation);
+  assert.equal(world.driver._workerGenerations.length, 1);
+  assert.equal(world.driver._workerGenerations[0].evaluation.outcome, "partial");
+  assert.equal(world.driver._workerGenerations[0].workerOriginId, worker.sessionOriginId);
+});
+
+test("first replacement closes an empty-ledger Worker's exact generation", async function (t) {
+  var world = makeWorld();
+  t.after(world.dispose);
+  await makePair(world);
+  var oldWorker = world.worker();
+  var oldOrigin = oldWorker.sessionOriginId;
+  world.driver._workerGenerations = [];
+  var result = parse(await replaceThroughProposal(world, {}));
+  assert.equal(result.previousGeneration, oldWorker.sessionProvenance.generation);
+  assert.equal(world.driver._workerGenerations[0].workerOriginId, oldOrigin);
+  assert.notEqual(world.driver._workerGenerations[0].endedAt, null);
+});
+
 test("an evaluation outcome outside the enum is refused", async function (t) {
   var world = makeWorld();
   t.after(world.dispose);
@@ -717,6 +782,7 @@ test("replacement records the observed signals for the generation it closed", as
   t.after(world.dispose);
   await makePair(world);
   var oldWorker = world.worker();
+  var oldOrigin = oldWorker.sessionOriginId;
   oldWorker.history.push({ type: "user_message", text: "t" });
   oldWorker.history.push({ type: "error", text: "boom" });
   oldWorker.lastContextUsage = { input_tokens: 5000, contextWindow: 10000 };
@@ -729,9 +795,58 @@ test("replacement records the observed signals for the generation it closed", as
   assert.equal(closed.evaluation.outcome, "failed");
   assert.equal(closed.observed.errorEntries, 1, "server-measured, not model-claimed");
   assert.equal(closed.observed.usedRatio, 0.5);
+  assert.equal(world.driver._workerGenerations[0].workerOriginId, oldOrigin,
+    "replacement closes the exact old Worker origin");
   assert.equal(status.generations.length, 2, "and the new generation is tracked");
   assert.equal(status.generations[1].generation, 2);
   assert.equal(status.generations[1].evaluation, null);
+});
+
+test("replacement switches model and effort while preserving prior Worker history", async function (t) {
+  var world = makeWorld();
+  t.after(world.dispose);
+  await makePair(world);
+  var oldWorker = world.worker();
+  oldWorker.history.push({ type: "user_message", text: "keep this history" });
+  var result = parse(await replaceThroughProposal(world, {
+    workerModel: "gpt-5.6-sol", workerEffort: "high",
+  }));
+  assert.equal(result.model, "gpt-5.6-sol");
+  assert.equal(result.effort, "high");
+  assert.equal(oldWorker.history.some(function (entry) { return entry.text === "keep this history"; }), true);
+  assert.notEqual(world.worker().localId, oldWorker.localId);
+});
+
+test("replacement accepts legacy string evaluation and rejects invalid input before posting", async function (t) {
+  var world = makeWorld();
+  t.after(world.dispose);
+  await makePair(world);
+  var worker = world.worker();
+  var before = world.driver.history.length;
+  var invalid = await world.tool("replace_partner").handler({
+    message: "invalid evaluation", recommendationRationale: "test", evaluation: "excellent",
+  });
+  assert.equal(invalid.isError, undefined);
+  var invalidProposal = parse(invalid);
+  assert.match(invalidProposal.error, /succeeded, partial, failed, abandoned/);
+  assert.equal(world.driver.history.length, before);
+  assert.equal(worker._lastTurnInterrupted, undefined);
+
+  var replaced = parse(await replaceThroughProposal(world, { evaluation: "partial" }));
+  assert.equal(replaced.status, "replaced");
+  var status = parse(await world.tool("partner_status").handler({}));
+  assert.equal(status.generations[0].evaluation.outcome, "partial");
+});
+
+test("replacement evaluation is exposed as string-or-object JSON schema", function () {
+  var z = require("zod");
+  var defs = require("../lib/session-pair-mcp-server").getToolDefs({}, { lifecycle: true });
+  var replace = toolNamed(defs, "replace_partner");
+  var schema = z.toJSONSchema(z.object(replace.inputSchema));
+  var evaluation = schema.properties.evaluation;
+  assert.ok(evaluation.anyOf);
+  assert.equal(evaluation.anyOf.some(function (entry) { return entry.type === "string"; }), true);
+  assert.equal(evaluation.anyOf.some(function (entry) { return entry.type === "object" && entry.properties.outcome; }), true);
 });
 
 // --- Security -------------------------------------------------------------

--- a/test/session-provenance.test.js
+++ b/test/session-provenance.test.js
@@ -7,6 +7,7 @@ var pathToFileURL = require("node:url").pathToFileURL;
 var createSessionManager = require("../lib/sessions").createSessionManager;
 var provenance = require("../lib/session-provenance");
 var attachPairFactory = require("../lib/session-pair-factory").attachPairFactory;
+var attachPairLifecycle = require("../lib/project-pair-lifecycle").attachPairLifecycle;
 
 function managerAt(root, sendEach) {
   return createSessionManager({
@@ -57,6 +58,75 @@ test("Worker provenance survives restart and local id reassignment", function (t
   assert.equal(restoredWorker.parentAvailable, true);
   assert.equal(restoredWorker.workerGeneration, 1);
   assert.equal(Object.prototype.hasOwnProperty.call(restoredWorker, "sessionOriginId"), false, "opaque durable anchors stay server-side");
+});
+
+test("persisted generation ledger and restored Worker generation survive reload", function (t) {
+  var root = fs.mkdtempSync(path.join(os.tmpdir(), "clay-generation-ledger-"));
+  t.after(function () { fs.rmSync(root, { recursive: true, force: true }); });
+  var first = managerAt(root);
+  var driver = first.createSessionRaw({ cliSessionId: "ledger-driver", vendor: "claude" });
+  var worker = first.createSessionRaw({ cliSessionId: "ledger-worker", vendor: "codex" });
+  provenance.markWorker(driver, worker, first.sessions);
+  worker.sessionProvenance.generation = 12;
+  worker._pairGeneration = 12;
+  driver._workerGenerations = [{ generation: 8, workerSessionId: 99, endedAt: 1, evaluation: null }];
+  first.saveSessionFile(driver);
+  first.saveSessionFile(worker);
+  var second = managerAt(root);
+  var restoredDriver = Array.from(second.sessions.values()).filter(function (s) { return s.cliSessionId === "ledger-driver"; })[0];
+  var restoredWorker = Array.from(second.sessions.values()).filter(function (s) { return s.cliSessionId === "ledger-worker"; })[0];
+  assert.equal(restoredWorker._pairGeneration, 12);
+  assert.equal(restoredWorker.sessionProvenance.generation, 12);
+  assert.deepEqual(restoredDriver._workerGenerations, [{ generation: 8, workerSessionId: 99, endedAt: 1, evaluation: null }]);
+});
+
+test("manager reload reconciles Worker origins before the first evaluation and close", async function (t) {
+  var root = fs.mkdtempSync(path.join(os.tmpdir(), "clay-generation-reload-"));
+  t.after(function () { fs.rmSync(root, { recursive: true, force: true }); });
+  var first = managerAt(root);
+  var driver = first.createSessionRaw({ cliSessionId: "origin-driver", vendor: "claude" });
+  var worker = first.createSessionRaw({ cliSessionId: "origin-worker", vendor: "codex" });
+  provenance.markWorker(driver, worker, first.sessions);
+  worker.sessionProvenance.generation = 1;
+  worker._pairGeneration = 1;
+  driver._workerGenerations = [{ generation: 1, workerSessionId: worker.localId, endedAt: null, evaluation: null }];
+  first.saveSessionFile(driver);
+  first.saveSessionFile(worker);
+
+  var inserted = first.createSessionRaw({ cliSessionId: "origin-inserted", vendor: "claude" });
+  inserted.createdAt = driver.createdAt - 1000;
+  inserted.history.push({ type: "user_message", text: "anchor" });
+  first.saveSessionFile(inserted);
+  var insertedTwo = first.createSessionRaw({ cliSessionId: "origin-inserted-two", vendor: "claude" });
+  insertedTwo.createdAt = driver.createdAt - 900;
+  insertedTwo.history.push({ type: "user_message", text: "anchor-two" });
+  first.saveSessionFile(insertedTwo);
+  var second = managerAt(root);
+  var restored = Array.from(second.sessions.values());
+  var restoredDriver = restored.filter(function (s) { return s.cliSessionId === "origin-driver"; })[0];
+  var restoredWorker = restored.filter(function (s) { return s.cliSessionId === "origin-worker"; })[0];
+  assert.notEqual(restoredWorker.localId, worker.localId, "reload reassigned local IDs");
+  var group = { id: "reloaded-group", pair: { driverId: restoredDriver.localId, workerId: restoredWorker.localId } };
+  var lifecycle = attachPairLifecycle({
+    sm: second,
+    splitStore: { groupForMember: function (id) { return id === restoredDriver.localId || id === restoredWorker.localId ? group : null; } },
+    turnControl: { blockedReason: function () { return null; }, status: function () { return {}; } },
+  });
+  var evaluatedResult = await lifecycle.toolHandlers(restoredDriver).evaluate({ outcome: "partial" });
+  var evaluated = JSON.parse(evaluatedResult.content[0].text);
+  assert.equal(evaluated.generation, 1);
+  assert.equal(restoredDriver._workerGenerations[0].workerOriginId, restoredWorker.sessionOriginId);
+  assert.equal(restoredDriver._workerGenerations[0].evaluation.outcome, "partial");
+  lifecycle.closeGeneration(restoredDriver, restoredWorker);
+  second.saveSessionFile(restoredDriver);
+
+  var third = managerAt(root);
+  var thirdDriver = Array.from(third.sessions.values()).filter(function (s) { return s.cliSessionId === "origin-driver"; })[0];
+  var thirdWorker = Array.from(third.sessions.values()).filter(function (s) { return s.cliSessionId === "origin-worker"; })[0];
+  assert.equal(thirdDriver._workerGenerations[0].workerOriginId, thirdWorker.sessionOriginId);
+  assert.equal(thirdDriver._workerGenerations[0].workerSessionId, thirdWorker.localId);
+  assert.equal(thirdDriver._workerGenerations[0].evaluation.outcome, "partial");
+  assert.notEqual(thirdDriver._workerGenerations[0].endedAt, null, "the exact old origin was closed");
 });
 
 test("factory-created Worker remains nested after a restart", function (t) {


### PR DESCRIPTION
Worker status could report cumulative Codex usage as current context, lose generation evaluations after restart, and reject an approved replacement card because its evaluation schema differed from validation.

This change separates verified current usage from cumulative totals, rejects impossible/legacy readings, persists evaluation records by durable Worker origin, and reconciles restored or empty ledgers before evaluation and replacement. Replacement evaluations accept legacy outcome strings and structured objects, with invalid values rejected before card creation. Existing approved model/effort replacement remains supported.

New Codex tool registrations still require a fresh thread: the inspected app-server resume protocol does not support dynamicTools. The code documents this limitation and tests avoid sending unsupported fields.

Validation: full integrated suite, client import checks, and regression coverage for changed local IDs after reload, first-operation evaluation/replacement, evaluation schemas, and context accounting. No deployment or daemon restart included.
