### PR TITLE
fix(claude): prevent duplicate question forms

### DIFF
--- a/lib/ask-user-request-identity.js
+++ b/lib/ask-user-request-identity.js
@@ -1,0 +1,23 @@
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== "object") return value;
+  var keys = Object.keys(value).sort();
+  var result = {};
+  for (var i = 0; i < keys.length; i++) result[keys[i]] = canonicalize(value[keys[i]]);
+  return result;
+}
+
+function sameAskUserRequest(event, id, input) {
+  return !!(event && event.type === "tool_executing" && event.name === "AskUserQuestion"
+    && event.id === id && JSON.stringify(canonicalize(event.input || {})) === JSON.stringify(canonicalize(input || {})));
+}
+
+function hasRecordedAskUserRequest(history, id, input) {
+  if (!Array.isArray(history) || !id) return false;
+  for (var i = history.length - 1; i >= 0; i--) {
+    if (sameAskUserRequest(history[i], id, input)) return true;
+  }
+  return false;
+}
+
+module.exports = { canonicalize: canonicalize, sameAskUserRequest: sameAskUserRequest, hasRecordedAskUserRequest: hasRecordedAskUserRequest };

--- a/lib/project-ask-user.js
+++ b/lib/project-ask-user.js
@@ -1,4 +1,5 @@
 var userInput = require("./yoke/user-input");
+var askUserIdentity = require("./ask-user-request-identity");
 
 function attachAskUser(ctx) {
   function isFirstDebateQuestion(session) {
@@ -41,7 +42,9 @@ function attachAskUser(ctx) {
         if (boundSession.pendingAskUser && boundSession.pendingAskUser[request.id] === pending) delete boundSession.pendingAskUser[request.id];
       });
     }
-    ctx.record(boundSession, { type: "tool_executing", id: request.id, name: "AskUserQuestion", input: input });
+    if (!askUserIdentity.hasRecordedAskUserRequest(boundSession.history, request.id, input)) {
+      ctx.record(boundSession, { type: "tool_executing", id: request.id, name: "AskUserQuestion", input: input });
+    }
   }
 
   function createHandler(boundSession) {

--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -287,6 +287,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     slashCommands: [],
     processing: false,
     activeSessionId: null,
+    askUserRequests: {},
     activeBackgroundTasks: [],
     sessionVendorBound: false,
     cliSessionId: null,

--- a/lib/public/modules/ask-user-state.js
+++ b/lib/public/modules/ask-user-state.js
@@ -1,0 +1,66 @@
+import { store } from './store.js';
+
+function scopeKey() {
+  var sessionId = store.get('paneSessionId') || store.get('activeSessionId') || "unknown";
+  var project = store.get('currentSlug') || "unknown-project";
+  var pane = store.get('paneMode') ? "pane" : "main";
+  return project + "\u0000" + pane + "\u0000" + String(sessionId);
+}
+
+function requestKey(toolId) {
+  return scopeKey() + "\u0000" + String(toolId);
+}
+
+function requests() {
+  return store.get('askUserRequests') || {};
+}
+
+export function getAskUserRequestKey(toolId) {
+  return requestKey(toolId);
+}
+
+export function rememberAskUserRequest(toolId) {
+  var key = requestKey(toolId);
+  var current = requests();
+  if (!current[key]) {
+    var next = Object.assign({}, current);
+    next[key] = { toolId: String(toolId), scope: scopeKey(), answered: false };
+    store.set({ askUserRequests: next });
+  }
+  return key;
+}
+
+export function hasAskUserRequest(toolId) {
+  return !!requests()[requestKey(toolId)];
+}
+
+export function markAskUserRequestAnswered(toolId) {
+  var key = requestKey(toolId);
+  var current = requests();
+  if (!current[key]) return;
+  var next = Object.assign({}, current);
+  next[key] = Object.assign({}, next[key], { answered: true });
+  store.set({ askUserRequests: next });
+}
+
+export function findAskUserCard(root, toolId) {
+  if (!root || !root.querySelectorAll) return null;
+  var key = requestKey(toolId);
+  var cards = root.querySelectorAll(".ask-user-container");
+  for (var i = 0; i < cards.length; i++) {
+    if (cards[i].dataset && cards[i].dataset.askUserRequestKey === key) return cards[i];
+  }
+  return null;
+}
+
+export function saveAskUserState() {
+  return Object.assign({}, requests());
+}
+
+export function restoreAskUserState(saved) {
+  store.set({ askUserRequests: Object.assign({}, saved || {}) });
+}
+
+export function resetAskUserState() {
+  store.set({ askUserRequests: {} });
+}

--- a/lib/public/modules/tools.js
+++ b/lib/public/modules/tools.js
@@ -8,6 +8,7 @@ import { getChatLayout } from './theme.js';
 import { store } from './store.js';
 import { VENDOR_NAMES } from './app-rendering.js';
 import { startThinkingSegment, appendThinkingText, stopThinkingSegment, resetThinkingTurn, clearThinkingState, saveThinkingState, restoreThinkingState, updateThinkingTokenEstimate } from './thinking-lifecycle.js';
+import { findAskUserCard, getAskUserRequestKey, hasAskUserRequest, rememberAskUserRequest, markAskUserRequestAnswered, saveAskUserState, restoreAskUserState, resetAskUserState } from './ask-user-state.js';
 
 var ctx;
 
@@ -227,6 +228,10 @@ function shortPath(p) {
 
 // --- AskUserQuestion ---
 export function renderAskUserQuestion(toolId, input) {
+  var existingCard = findAskUserCard(ctx.messagesEl, toolId);
+  if (existingCard) return existingCard;
+  if (hasAskUserRequest(toolId)) return null;
+
   ctx.finalizeAssistantBlock();
   stopThinking();
   closeToolGroup();
@@ -237,6 +242,9 @@ export function renderAskUserQuestion(toolId, input) {
   var container = document.createElement("div");
   container.className = "ask-user-container";
   container.dataset.toolId = toolId;
+  var requestKey = getAskUserRequestKey(toolId);
+  container.dataset.askUserRequestKey = requestKey;
+  rememberAskUserRequest(toolId);
 
   // Mate DM: wrap in avatar + content layout (same as msg-assistant)
   var mateContentWrap = null;
@@ -372,6 +380,7 @@ export function renderAskUserQuestion(toolId, input) {
   skipBtn.addEventListener("click", function () {
     if (container.classList.contains("answered")) return;
     container.classList.add("answered");
+    markAskUserRequestAnswered(toolId);
     enableMainInput();
     if (ctx.ws && ctx.connected) {
       ctx.ws.send(JSON.stringify({ type: "stop" }));
@@ -415,7 +424,7 @@ export function enableMainInput() {
 }
 
 function submitAskUserAnswer(container, toolId, questions, answers, multiSelections) {
-  if (container.classList.contains("answered")) return;
+  if (container.classList.contains("answered") || container.dataset.askUserSubmitted === "true") return;
 
   var result = {};
   for (var i = 0; i < questions.length; i++) {
@@ -430,6 +439,7 @@ function submitAskUserAnswer(container, toolId, questions, answers, multiSelecti
   if (Object.keys(result).length === 0) return;
 
   container.classList.add("answered");
+  container.dataset.askUserSubmitted = "true";
   enableMainInput();
   if (ctx.stopUrgentBlink) ctx.stopUrgentBlink();
 
@@ -471,9 +481,10 @@ function showAnswerSummary(container, questions, answers) {
 }
 
 export function markAskUserAnswered(toolId, answers) {
-  var container = document.querySelector('.ask-user-container[data-tool-id="' + toolId + '"]');
+  var container = findAskUserCard(ctx.messagesEl, toolId);
   if (container && !container.classList.contains("answered")) {
     container.classList.add("answered");
+    markAskUserRequestAnswered(toolId);
     enableMainInput();
     // Restore answers from history replay
     if (answers && Object.keys(answers).length > 0) {
@@ -2420,6 +2431,7 @@ export function saveToolState() {
     toolGroupCounter: toolGroupCounter,
     toolGroups: toolGroups,
     lastCumulativeCost: _lastCumulativeCost,
+    askUserState: saveAskUserState(),
   };
 }
 
@@ -2435,6 +2447,7 @@ export function restoreToolState(saved) {
   toolGroupCounter = saved.toolGroupCounter;
   toolGroups = saved.toolGroups;
   _lastCumulativeCost = saved.lastCumulativeCost || 0;
+  restoreAskUserState(saved.askUserState);
   if (todoWidgetEl) {
     setupTodoObserver();
   }
@@ -2442,6 +2455,7 @@ export function restoreToolState(saved) {
 
 export function resetToolState() {
   tools = {};
+  resetAskUserState();
   clearThinkingState();
   inPlanMode = false;
   planContent = null;

--- a/lib/sdk-message-processor.js
+++ b/lib/sdk-message-processor.js
@@ -2,6 +2,7 @@ var usersModule = require("./users");
 var yoke = require("./yoke");
 var backgroundTaskTiming = require("./background-task-timing");
 var sessionTitlePolicy = require("./session-title-policy");
+var askUserIdentity = require("./ask-user-request-identity");
 
 var OVERLOAD_RETRY_LIMIT = 3;
 
@@ -379,7 +380,24 @@ function attachMessageProcessor(ctx) {
       if (block && block.type === "tool_use") {
         var input = {};
         try { input = JSON.parse(block.inputJson); } catch (e) {}
-        sendAndRecord(session, { type: "tool_executing", id: block.id, name: block.name, input: input });
+        // Native AskUserQuestion is recorded when canUseTool opens the
+        // request. The later block_stop is the SDK's completion notification
+        // for that same request, not a second question. Keeping both records
+        // made replay render two independently editable cards and allowed the
+        // client to submit the same request twice.
+        var alreadyRecordedAsk = false;
+        if (block.name === "AskUserQuestion" && block.id && Array.isArray(session.history)) {
+          for (var ahi = session.history.length - 1; ahi >= 0; ahi--) {
+            var priorAsk = session.history[ahi];
+            if (askUserIdentity.sameAskUserRequest(priorAsk, block.id, input)) {
+              alreadyRecordedAsk = true;
+              break;
+            }
+          }
+        }
+        if (!alreadyRecordedAsk) {
+          sendAndRecord(session, { type: "tool_executing", id: block.id, name: block.name, input: input });
+        }
 
         // Track active Task tools for sub-agent done detection
         if (block.name === "Task") {

--- a/test/ask-user-rendering.test.js
+++ b/test/ask-user-rendering.test.js
@@ -1,0 +1,127 @@
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var path = require("node:path");
+var pathToFileURL = require("node:url").pathToFileURL;
+
+function FakeElement(tag) {
+  this.tagName = String(tag).toUpperCase();
+  this.children = [];
+  this.parentNode = null;
+  this.dataset = {};
+  this.className = "";
+  this.listeners = {};
+  this.textContent = "";
+  this.value = "";
+  this.disabled = false;
+  var self = this;
+  this.classList = {
+    add: function () { for (var i = 0; i < arguments.length; i++) if (!self.classList.contains(arguments[i])) self.className += (self.className ? " " : "") + arguments[i]; },
+    remove: function (name) { self.className = self.className.split(" ").filter(function (item) { return item && item !== name; }).join(" "); },
+    contains: function (name) { return (" " + self.className + " ").indexOf(" " + name + " ") !== -1; },
+  };
+}
+
+FakeElement.prototype.appendChild = function (child) { child.parentNode = this; this.children.push(child); return child; };
+FakeElement.prototype.insertBefore = function (child, before) { var i = this.children.indexOf(before); if (i < 0) return this.appendChild(child); child.parentNode = this; this.children.splice(i, 0, child); return child; };
+FakeElement.prototype.addEventListener = function (name, fn) { this.listeners[name] = fn; };
+FakeElement.prototype.click = function () { if (this.listeners.click) this.listeners.click({ currentTarget: this }); };
+FakeElement.prototype.querySelectorAll = function (selector) {
+  var result = [];
+  function matches(node) {
+    if (selector === ".ask-user-container") return node.classList.contains("ask-user-container");
+    if (selector === ".ask-user-question") return node.classList.contains("ask-user-question");
+    if (selector === ".ask-user-option") return node.classList.contains("ask-user-option");
+    if (selector === ".ask-user-submit") return node.classList.contains("ask-user-submit");
+    if (selector === ".ask-user-answer-summary") return node.classList.contains("ask-user-answer-summary");
+    if (selector === ".ask-user-other input") return node.tagName === "INPUT" && node.parentNode && node.parentNode.classList.contains("ask-user-other");
+    if (selector === ".option-label") return node.classList.contains("option-label");
+    return false;
+  }
+  function visit(node) { if (matches(node)) result.push(node); for (var i = 0; i < node.children.length; i++) visit(node.children[i]); }
+  visit(this);
+  return result;
+};
+FakeElement.prototype.querySelector = function (selector) {
+  if (selector === ".option-label" && this._innerHTML && !this.querySelectorAll(selector).length) {
+    var label = new FakeElement("div"); label.className = "option-label"; this.appendChild(label);
+  }
+  return this.querySelectorAll(selector)[0] || null;
+};
+Object.defineProperty(FakeElement.prototype, "innerHTML", { get: function () { return this._innerHTML || ""; }, set: function (value) { this._innerHTML = String(value); } });
+
+test("AskUserQuestion rendering is idempotent per session request and submits once", async function () {
+  var originalDocument = global.document;
+  var originalWindow = global.window;
+  var originalLocalStorage = global.localStorage;
+  var originalMarked = global.marked;
+  var originalMermaid = global.mermaid;
+  var originalPurifier = global.DOMPurify;
+  var messages = new FakeElement("div");
+  var secondMessages = new FakeElement("div");
+  var input = new FakeElement("textarea");
+  var sent = [];
+  var context;
+  global.document = {
+    body: new FakeElement("body"),
+    createElement: function (tag) { return new FakeElement(tag); },
+    querySelectorAll: function (selector) { return messages.querySelectorAll(selector).concat(secondMessages.querySelectorAll(selector)); },
+    getElementById: function () { return null; },
+  };
+  global.window = { addEventListener: function () {}, removeEventListener: function () {} };
+  global.localStorage = { getItem: function () { return null; }, setItem: function () {}, removeItem: function () {} };
+  global.marked = { use: function () {}, parse: function (value) { return value; } };
+  global.mermaid = { initialize: function () {} };
+  global.DOMPurify = { sanitize: function (value) { return value; } };
+  try {
+    var storeModule = await import(pathToFileURL(path.join(__dirname, "../lib/public/modules/store.js")).href);
+    storeModule.createStore({ activeSessionId: 101, currentVendor: "claude" });
+    var tools = await import(pathToFileURL(path.join(__dirname, "../lib/public/modules/tools.js")).href);
+    context = {
+      finalizeAssistantBlock: function () {}, stopUrgentBlink: function () {}, setActivity: function () {},
+      addToMessages: function (el) { context.messagesEl.appendChild(el); }, scrollToBottom: function () {},
+      isMateDm: function () { return false; }, inputEl: input, ws: { send: function (value) { sent.push(JSON.parse(value)); } }, connected: true,
+      messagesEl: messages,
+    };
+    tools.initTools(context);
+    tools.resetToolState();
+    var question = { questions: [{ question: "Which outcome?", options: [{ label: "Ship" }, { label: "Wait" }] }] };
+    tools.renderAskUserQuestion("ask-101", question);
+    var first = messages.children[0];
+    var freeform = first.querySelector(".ask-user-other input");
+    freeform.value = "Keep the current plan";
+    freeform.listeners.input();
+    var reordered = { questions: [{ options: [{ label: "Ship" }, { label: "Wait" }], question: "Which outcome?" }] };
+    tools.renderAskUserQuestion("ask-101", reordered);
+    assert.strictEqual(messages.children[0], first);
+    assert.equal(messages.querySelectorAll(".ask-user-container").length, 1);
+    assert.equal(freeform.value, "Keep the current plan");
+    first.querySelector(".ask-user-submit").click();
+    first.querySelector(".ask-user-submit").click();
+    assert.deepEqual(sent, [{ type: "ask_user_response", toolId: "ask-101", answers: { 0: "Keep the current plan" } }]);
+
+    storeModule.store.set({ activeSessionId: 202 });
+    context.messagesEl = secondMessages;
+    tools.renderAskUserQuestion("ask-101", question);
+    var next = secondMessages.children[0];
+    assert.notStrictEqual(next, first);
+    assert.equal(messages.querySelectorAll(".ask-user-container").length, 1);
+    assert.equal(secondMessages.querySelectorAll(".ask-user-container").length, 1);
+    tools.markAskUserAnswered("ask-101", { 0: "Wait" });
+    tools.renderAskUserQuestion("ask-101", question);
+    assert.equal(next.classList.contains("answered"), true);
+    assert.equal(secondMessages.querySelectorAll(".ask-user-container").length, 1);
+
+    storeModule.store.set({ activeSessionId: 303, askUserRequests: {} });
+    context.messagesEl = new FakeElement("div");
+    tools.renderAskUserQuestion("ask-101", question);
+    tools.renderAskUserQuestion("ask-102", question);
+    assert.equal(context.messagesEl.querySelectorAll(".ask-user-container").length, 2);
+  } finally {
+    global.document = originalDocument;
+    global.window = originalWindow;
+    global.localStorage = originalLocalStorage;
+    global.marked = originalMarked;
+    global.mermaid = originalMermaid;
+    global.DOMPurify = originalPurifier;
+  }
+});

--- a/test/sdk-bridge-delivery.test.js
+++ b/test/sdk-bridge-delivery.test.js
@@ -2,6 +2,7 @@ var test = require("node:test");
 var assert = require("node:assert");
 
 var createSDKBridge = require("../lib/sdk-bridge").createSDKBridge;
+var attachAskUser = require("../lib/project-ask-user").attachAskUser;
 
 function createBridge(sessionManager, onProcessingChanged) {
   return createSDKBridge({
@@ -391,6 +392,57 @@ test("adapter errors finish a result-less stream instead of leaving it processin
   assert.strictEqual(recorded[recorded.length - 1].type, "done");
   assert.strictEqual(recorded[recorded.length - 1].code, 1);
   assert.strictEqual(broadcasts, 1);
+});
+
+test("native AskUserQuestion block completion does not record a second question", function() {
+  var recorded = [];
+  var bridge = createBridge({
+    sendAndRecord: function(session, msg) { recorded.push(msg); session.history.push(msg); },
+    sendToSession: function() {},
+    broadcastSessionList: function() {},
+  });
+  var input = { questions: [{ header: "Direction", question: "Which outcome?", options: [{ label: "Ship" }] }] };
+  var session = {
+    localId: 19,
+    vendor: "claude",
+    history: [{ type: "tool_executing", id: "ask-19", name: "AskUserQuestion", input: input }],
+    blocks: {},
+    pendingAskUser: {},
+    pendingPermissions: {},
+    pendingElicitations: {},
+  };
+
+  bridge.processSDKMessage(session, { yokeType: "tool_start", blockId: "blk-19", toolId: "ask-19", toolName: "AskUserQuestion" });
+  bridge.processSDKMessage(session, { yokeType: "tool_input_delta", blockId: "blk-19", partialJson: JSON.stringify(input) });
+  bridge.processSDKMessage(session, { yokeType: "block_stop", blockId: "blk-19" });
+
+  assert.equal(recorded.filter(function(msg) { return msg.type === "tool_executing" && msg.name === "AskUserQuestion"; }).length, 0);
+  assert.equal(recorded.filter(function(msg) { return msg.type === "done"; }).length, 0);
+});
+
+test("native AskUserQuestion recording is idempotent whichever callback arrives first", function() {
+  var input = { questions: [{ question: "Which outcome?", options: [{ label: "Ship" }] }] };
+  function request() {
+    return { id: "ask-order", questions: input.questions };
+  }
+  function respond() {}
+  respond.cancel = function () {};
+
+  function run(order) {
+    var history = [];
+    var session = { localId: 20, history: [], blocks: {}, pendingAskUser: {} };
+    var askUser = attachAskUser({ record: function (boundSession, event) { boundSession.history.push(event); history.push(event); } });
+    var bridge = createBridge({ sendAndRecord: function (boundSession, event) { boundSession.history.push(event); history.push(event); }, sendToSession: function () {}, broadcastSessionList: function () {} });
+    if (order === "native-first") askUser.createHandler(session)(request(), respond);
+    bridge.processSDKMessage(session, { yokeType: "tool_start", blockId: "blk-order", toolId: "ask-order", toolName: "AskUserQuestion" });
+    bridge.processSDKMessage(session, { yokeType: "tool_input_delta", blockId: "blk-order", partialJson: JSON.stringify(input) });
+    bridge.processSDKMessage(session, { yokeType: "block_stop", blockId: "blk-order" });
+    if (order === "block-first") askUser.createHandler(session)(request(), respond);
+    return history.filter(function (event) { return event.type === "tool_executing" && event.name === "AskUserQuestion"; });
+  }
+
+  assert.equal(run("native-first").length, 1);
+  assert.equal(run("block-first").length, 1);
 });
 
 test("Codex writer conflicts surface a recoverable session error", async function() {


### PR DESCRIPTION
Claude's native question callback and SDK block completion could record the same AskUserQuestion twice, producing two independently editable forms.

Deduplicate both recording paths and reuse the client form for the same project/session/pane request. Repeated delivery preserves selections and free text, distinct requests remain separate, and repeated submissions are guarded.

Validation includes executable native/block ordering and client rendering tests, the full integrated test suite, client import checks, and whitespace checks. Client tests use real modules with a fake DOM; no live Claude browser stream was exercised.
