### PR TITLE
feat(notes): add temporary hide with nearest-edge flight

### DIFF
--- a/lib/public/app.js
+++ b/lib/public/app.js
@@ -30,7 +30,7 @@ import { initGitPanel } from './modules/git-panel.js';
 import { initWorkerPaneLock } from './modules/worker-pane-lock.js';
 import { initTerminal, openTerminal, closeTerminal, resetTerminals, handleTermList, handleTermCreated, handleTermOutput, handleTermResized, handleTermExited, handleTermClosed, sendTerminalCommand } from './modules/terminal.js';
 import { initContextSources, updateTerminalList, updateBrowserTabList, handleContextSourcesState, getActiveSources, hasActiveSources } from './modules/context-sources.js';
-import { initStickyNotes, handleNotesList, handleNoteCreated, handleNoteUpdated, handleNoteDeleted, hideNotes, showNotes, isNotesVisible, createNote, setBrowserRefresh } from './modules/sticky-notes.js';
+import { initStickyNotes, handleNotesList, handleNoteCreated, handleNoteUpdated, handleNoteDeleted, hideNotes, showNotes, isNotesVisible, createNote, setBrowserRefresh, toggleNotesTemporaryVisibility } from './modules/sticky-notes.js';
 import { initNotesBrowser, openNotesBrowser, closeNotesBrowser, isNotesBrowserOpen, renderNotesBrowser, registerExclusiveClosers } from './modules/sticky-notes-browser.js';
 import { initTheme, getThemeColor, getComputedVar, onThemeChange, getCurrentTheme, getChatLayout } from './modules/theme.js';
 import { initTools, resetToolState, saveToolState, restoreToolState, renderAskUserQuestion, markAskUserAnswered, renderPermissionRequest, markPermissionResolved, markPermissionCancelled, renderElicitationRequest, markElicitationResolved, renderPlanBanner, renderPlanCard, handleTodoWrite, handleTaskCreate, handleTaskUpdate, startThinking, appendThinking, stopThinking, resetThinkingGroup, createToolItem, updateToolExecuting, updateToolResult, markAllToolsDone, addTurnMeta, resetTurnMetaCost, enableMainInput, getTools, getPlanContent, setPlanContent, isPlanFilePath, getTodoTools, updateSubagentActivity, addSubagentToolEntry, markSubagentDone, updateSubagentProgress, initSubagentStop, closeToolGroup, removeToolFromGroup } from './modules/tools.js';
@@ -269,6 +269,7 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
     splitPanes: null,
     splitGroups: [],
     splitDelegations: {},
+    notesTemporarilyHidden: false,
     dmMode: false,
     historyFrom: 0,
     loadingMore: false,
@@ -1130,6 +1131,13 @@ import { initDebate, handleDebatePreparing, handleDebateStarted, handleDebateRes
       if (isNotesBrowserOpen()) closeNotesBrowser();
       showNotes();
       createNote();
+    });
+  }
+
+  var stickyNotesToggleButtons = document.querySelectorAll("#sticky-notes-toggle-btn");
+  for (var stickyToggleIndex = 0; stickyToggleIndex < stickyNotesToggleButtons.length; stickyToggleIndex++) {
+    stickyNotesToggleButtons[stickyToggleIndex].addEventListener("click", function () {
+      toggleNotesTemporaryVisibility();
     });
   }
 

--- a/lib/public/css/mates.css
+++ b/lib/public/css/mates.css
@@ -2790,7 +2790,6 @@ body.mate-dm-active .activity-inline:not(.mention-activity-bar):not(.mate-pre-ac
   body.mate-dm-active .title-bar-content #todo-sticky,
   body.mate-dm-active .title-bar-content #ralph-sticky,
   body.mate-dm-active .dm-header-bar,
-  body.mate-dm-active .title-bar-content .status #sticky-notes-toggle-btn,
   body.mate-dm-active .title-bar-content .status #terminal-toggle-btn {
     display: none !important;
   }

--- a/lib/public/css/sticky-notes.css
+++ b/lib/public/css/sticky-notes.css
@@ -13,6 +13,16 @@
 
 #sticky-notes-container.hidden { display: none; }
 
+.sticky-note.sticky-note-flight-away {
+  pointer-events: none;
+  transform: var(--sticky-note-flight);
+  transition: transform var(--sticky-note-flight-duration, 240ms) cubic-bezier(0.55, 0, 1, 0.45);
+}
+
+.sticky-note:not(.sticky-note-flight-away) {
+  transition: transform var(--sticky-note-flight-duration, 320ms) cubic-bezier(0.22, 1.25, 0.36, 1), box-shadow 0.15s;
+}
+
 /* --- Toggle button (in title bar, matches terminal-toggle-btn) --- */
 #sticky-notes-toggle-btn {
   display: flex;
@@ -827,11 +837,16 @@
   50% { box-shadow: 0 0 0 6px rgba(var(--accent-rgb, 99, 102, 241), 0); }
 }
 
-/* --- Mobile: hide entirely --- */
+/* --- Mobile browser sizing --- */
 @media (max-width: 768px) {
-  #sticky-notes-container,
-  #sticky-notes-toggle-btn {
-    display: none !important;
+  /* The shared title-bar control remains the sole hide/show affordance on
+     mobile; the canvas itself must stay mountable and viewport-bounded. */
+  #sticky-notes-toggle-btn { display: flex; }
+
+  .sticky-note {
+    min-width: min(160px, calc(100% - 16px));
+    max-width: calc(100% - 16px);
+    max-height: calc(100% - 16px);
   }
 
   .notes-browser-grid {
@@ -840,4 +855,9 @@
   }
 
   .notes-browser-topbar { padding: 10px 12px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sticky-note.sticky-note-flight-away,
+  .sticky-note:not(.sticky-note-flight-away) { transition-duration: 0ms; }
 }

--- a/lib/public/index.html
+++ b/lib/public/index.html
@@ -427,6 +427,7 @@
           </button>
           <button id="debate-pdf-btn" class="hidden" title="Export debate as PDF"><i data-lucide="download"></i></button>
           <button id="find-in-session-btn" title="Search in session (Ctrl+F)"><i data-lucide="search"></i></button>
+          <button type="button" id="sticky-notes-toggle-btn" aria-label="Hide sticky notes" aria-pressed="false" title="Hide sticky notes"><i data-lucide="eye-off"></i></button>
           <button id="terminal-toggle-btn" title="Terminal"><i data-lucide="square-terminal"></i><span id="terminal-count" class="hidden"></span></button>
         </div>
       </div>

--- a/lib/public/modules/sticky-notes-browser.js
+++ b/lib/public/modules/sticky-notes-browser.js
@@ -303,7 +303,7 @@ export function closeNotesBrowser() {
   var sidebarBtn = document.getElementById("sticky-notes-sidebar-btn");
   if (sidebarBtn) sidebarBtn.classList.remove("active");
   // The canvas comes back so the open notes are reachable again.
-  showNotes();
+  showNotes(false);
 }
 
 export function isNotesBrowserOpen() {

--- a/lib/public/modules/sticky-notes.js
+++ b/lib/public/modules/sticky-notes.js
@@ -11,9 +11,11 @@ import { enhanceClayLogLinks } from './clay-log-links.js';
 import { isClosedNote, send, clampPos, clearNoteTimers, syncTitle } from './sticky-notes-shared.js';
 import { renderNote, closeColorPicker } from './sticky-notes-card.js';
 import { closeFormatToolbar, isFormatToolbarOpen } from './sticky-notes-editor.js';
+import { store } from './store.js';
 
 var notes = new Map();  // id -> { data, el }
 var notesVisible = false;
+var notesResizeObserver = null;
 
 // The canvas shows open notes only. Closed notes leave the canvas and live in
 // the browser's Closed tab until they are reopened.
@@ -35,6 +37,93 @@ export function setBrowserRefresh(fn) {
 
 function refreshBrowser() {
   if (browserRefresh) browserRefresh();
+}
+
+function prefersReducedMotion() {
+  return window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function setFlightAccessibility(el, hidden) {
+  el.inert = hidden;
+  el.setAttribute("aria-hidden", hidden ? "true" : "false");
+}
+
+function nearestEdgeTransform(el, container) {
+  // offsetLeft/Top and offsetWidth/Height are layout geometry, unaffected by
+  // an in-flight transform. Never derive the next vector from a translated
+  // boundingClientRect or repeated hide/show cycles will accumulate distance.
+  var left = el.offsetLeft;
+  var top = el.offsetTop;
+  var width = el.offsetWidth;
+  var height = el.offsetHeight;
+  var containerWidth = container.clientWidth;
+  var containerHeight = container.clientHeight;
+  var edges = [
+    { name: "left", distance: left, transform: "translateX(" + -(left + width + 20) + "px)" },
+    { name: "right", distance: containerWidth - left - width, transform: "translateX(" + (containerWidth - left + 20) + "px)" },
+    { name: "top", distance: top, transform: "translateY(" + -(top + height + 20) + "px)" },
+    { name: "bottom", distance: containerHeight - top - height, transform: "translateY(" + (containerHeight - top + 20) + "px)" },
+  ];
+  edges.sort(function (a, b) { return a.distance - b.distance; });
+  return edges[0];
+}
+
+function animateNote(el, hidden, immediate) {
+  if (!el || el.classList.contains("hidden")) return;
+  var container = document.getElementById("sticky-notes-container");
+  if (!container) return;
+  if (hidden) {
+    var edge = nearestEdgeTransform(el, container);
+    el.style.setProperty("--sticky-note-flight", edge.transform);
+    el.style.setProperty("--sticky-note-flight-duration", prefersReducedMotion() || immediate ? "0ms" : "240ms");
+    el.classList.add("sticky-note-flight-away");
+    setFlightAccessibility(el, true);
+    return;
+  }
+  el.style.setProperty("--sticky-note-flight-duration", prefersReducedMotion() || immediate ? "0ms" : "320ms");
+  el.classList.remove("sticky-note-flight-away");
+  setFlightAccessibility(el, false);
+}
+
+function syncFlightState(el, immediate) {
+  if (store.get("notesTemporarilyHidden")) animateNote(el, true, immediate);
+  else animateNote(el, false, immediate);
+}
+
+function recomputeFlightGeometry() {
+  if (!notesVisible) return;
+  reclampAllNotes();
+  if (store.get("notesTemporarilyHidden")) {
+    notes.forEach(function (entry) { if (entry && entry.el) syncFlightState(entry.el, true); });
+  }
+}
+
+function syncFlightControls() {
+  var buttons = document.querySelectorAll("#sticky-notes-toggle-btn");
+  var hidden = !!store.get("notesTemporarilyHidden");
+  var label = hidden ? "Show sticky notes" : "Hide sticky notes";
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].setAttribute("aria-label", label);
+    buttons[i].setAttribute("aria-pressed", hidden ? "true" : "false");
+    buttons[i].title = label;
+    var icon = buttons[i].querySelector("[data-lucide]");
+    if (icon) icon.setAttribute("data-lucide", hidden ? "eye" : "eye-off");
+  }
+  refreshIcons();
+}
+
+export function toggleNotesTemporaryVisibility() {
+  var hidden = !store.get("notesTemporarilyHidden");
+  if (hidden) {
+    closeColorPicker();
+    closeFormatToolbar();
+    var active = document.activeElement;
+    var container = document.getElementById("sticky-notes-container");
+    if (container && active && container.contains(active) && active.blur) active.blur();
+  }
+  store.set({ notesTemporarilyHidden: hidden });
+  notes.forEach(function (entry) { if (entry && entry.el) syncFlightState(entry.el); });
+  syncFlightControls();
 }
 
 // Read-only view of every note the client knows about, for the browser pane.
@@ -67,6 +156,7 @@ function reclampAllNotes() {
     var c = clampPos(curX, curY, noteW, noteH);
     el.style.left = c.x + "px";
     el.style.top = c.y + "px";
+    if (store.get("notesTemporarilyHidden")) syncFlightState(el, true);
   });
 }
 
@@ -86,17 +176,29 @@ export function initStickyNotes() {
       if (notesVisible && notes.size > 0) {
         reclampAllNotes();
       }
+      if (store.get("notesTemporarilyHidden")) notes.forEach(function (entry) { if (entry && entry.el) syncFlightState(entry.el, true); });
     }, 100);
   });
+
+  var canvas = document.getElementById("sticky-notes-container");
+  if (canvas && typeof ResizeObserver === "function") {
+    notesResizeObserver = new ResizeObserver(function () {
+      recomputeFlightGeometry();
+    });
+    notesResizeObserver.observe(canvas);
+  }
 
 }
 
 // --- Visibility ---
 
-export function showNotes() {
+export function showNotes(restoreTemporary) {
   notesVisible = true;
+  if (restoreTemporary !== false) store.set({ notesTemporarilyHidden: false });
   var container = document.getElementById("sticky-notes-container");
   if (container) container.classList.remove("hidden");
+  notes.forEach(function (entry) { if (entry && entry.el) syncFlightState(entry.el); });
+  syncFlightControls();
 }
 
 export function hideNotes() {
@@ -104,6 +206,8 @@ export function hideNotes() {
   var container = document.getElementById("sticky-notes-container");
   if (container) container.classList.add("hidden");
   closeColorPicker();
+  notes.forEach(function (entry) { if (entry && entry.el) syncFlightState(entry.el, true); });
+  syncFlightControls();
 }
 
 export function createNote() {
@@ -158,6 +262,7 @@ export function handleNotesList(msg) {
     var el = renderNote(data);
     notes.set(data.id, { data: data, el: el });
     container.appendChild(el);
+    syncFlightState(el, true);
     created = true;
   }
 
@@ -181,11 +286,14 @@ export function handleNotesList(msg) {
   refreshBrowser();
 
   // Auto-show only when something is actually asking for attention. A board of
-  // nothing but closed notes must not pop the canvas open.
+  // nothing but closed notes must not pop the canvas open. Temporary hiding is
+  // explicit view state and must survive reconnects and list updates.
   if (openCount() > 0 && !notesVisible) {
     notesVisible = true;
     container.classList.remove("hidden");
   }
+  if (created) reclampAllNotes();
+  syncFlightControls();
 }
 
 export function handleNoteCreated(msg) {
@@ -198,15 +306,18 @@ export function handleNoteCreated(msg) {
   var el = renderNote(msg.note);
   notes.set(msg.note.id, { data: msg.note, el: el });
   container.appendChild(el);
+  syncFlightState(el, true);
   updateBadge();
   updateSidebarBadge();
   refreshBrowser();
 
-  // Show container if hidden
-  if (!notesVisible) {
+  // Show container if hidden, unless the user explicitly flew the notes out.
+  if (!notesVisible && !store.get("notesTemporarilyHidden")) {
     notesVisible = true;
     container.classList.remove("hidden");
   }
+  reclampAllNotes();
+  syncFlightControls();
 }
 
 // Patch one existing note element in place from a server payload.
@@ -258,6 +369,7 @@ function patchNote(entry, next) {
 
   if (isClosedNote(next)) el.classList.add("hidden");
   else el.classList.remove("hidden");
+  syncFlightState(el, true);
 
   // The minimize button swaps its icon, which is the only path here that can
   // introduce fresh Lucide markup.
@@ -288,6 +400,7 @@ export function handleNoteUpdated(msg) {
   if (!entry) return;
 
   if (patchNote(entry, msg.note)) refreshIcons();
+  reclampAllNotes();
 
   // A close or reopen arrives as an ordinary update, so the canvas count and
   // the browser both follow from the same message.


### PR DESCRIPTION
A new title-bar toggle temporarily clears the floating sticky notes from the conversation. Each note accelerates through its nearest canvas edge in 240 ms; toggling again brings it back with a 320 ms settling motion. Notes stay mounted and retain their positions and open/closed status.

Temporary visibility lives in the client store and survives incoming note updates, reconnect lists, and opening/closing the notes browser. Hidden notes are inert, editor popovers close on hiding, and reduced-motion users get an immediate transition. Layout-based flight vectors and canvas resize observation handle repeated toggles, resizing, and the shared split canvas.

The floating canvas and toggle are now available on mobile, including Mate views, with note dimensions bounded to the canvas.

Validation:
- 61 focused note tests passed on Node 22 on this PR branch.
- All 186 client module imports resolve; syntax and diff checks passed.
- Driver browser fixture exercised all four directions, exact restoration, rapid toggles, new/list updates while hidden, mobile layout, reduced motion, canvas resizing/reparenting, and preservation through browser show/hide.
- Toggling emitted no note writes in the fixture. Physical-device and live-server end-to-end testing were not performed.
